### PR TITLE
feat: add scan FAB above bottom nav

### DIFF
--- a/__mocks__/firebaseAuth.ts
+++ b/__mocks__/firebaseAuth.ts
@@ -1,0 +1,12 @@
+const auth = () => ({
+  currentUser: {
+    getIdToken: async () => '',
+  },
+  onAuthStateChanged: (callback: any) => {
+    callback(null);
+    return () => {};
+  },
+  signOut: async () => {},
+});
+
+export default auth;

--- a/__mocks__/googleSignin.ts
+++ b/__mocks__/googleSignin.ts
@@ -1,0 +1,6 @@
+export const GoogleSignin = {
+  configure: () => {},
+  hasPlayServices: async () => true,
+  signIn: async () => ({}),
+  getTokens: async () => ({ idToken: '' }),
+};

--- a/__mocks__/react-native-paper.tsx
+++ b/__mocks__/react-native-paper.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View } from 'react-native';
+
+interface FABProps {
+  icon: string;
+  onPress?: () => void;
+  style?: any;
+  color?: string;
+}
+
+export const FAB: React.FC<FABProps> = () => <View />;
+
+export default { FAB };

--- a/firebase-auth.d.ts
+++ b/firebase-auth.d.ts
@@ -1,0 +1,3 @@
+declare module '@react-native-firebase/auth' {
+  export default function auth(): any;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '^react-native-paper$': '<rootDir>/__mocks__/react-native-paper.tsx',
+    '^@react-native-firebase/auth$': '<rootDir>/__mocks__/firebaseAuth.ts',
+    '^@react-native-google-signin/google-signin$': '<rootDir>/__mocks__/googleSignin.ts',
+  },
 };

--- a/react-native-paper.d.ts
+++ b/react-native-paper.d.ts
@@ -1,0 +1,13 @@
+declare module 'react-native-paper' {
+  import * as React from 'react';
+  import { StyleProp, ViewStyle } from 'react-native';
+
+  export interface FABProps {
+    icon: string;
+    onPress?: () => void;
+    style?: StyleProp<ViewStyle>;
+    color?: string;
+  }
+
+  export const FAB: React.FC<FABProps>;
+}

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -17,6 +17,7 @@ import {
   toggleFavorite,
   getDailyTip
 } from '../services/homePagesService.ts';
+import { FAB } from 'react-native-paper';
 
 // const { width } = Dimensions.get('window');
 
@@ -369,6 +370,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
           )}
         </View>
       </ScrollView>
+
+      <FAB icon="camera" style={styles.fab} onPress={onScanPress} />
 
       {/* Bottom Navigation */}
       <View style={styles.bottomNav}>

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -361,6 +361,18 @@ export const homeStyles = (isDarkMode: boolean) => {
       color: colors.textSecondary,
     },
 
+    fab: {
+      position: 'absolute',
+      right: 20,
+      bottom: 80,
+      backgroundColor: colors.primary,
+      shadowColor: colors.shadow,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.3,
+      shadowRadius: 4,
+      elevation: 5,
+    },
+
     // Bottom Navigation
     bottomNav: {
       position: 'absolute',


### PR DESCRIPTION
## Summary
- add camera FAB above bottom navigation for quick scanning
- style FAB with primary color, shadow, and bottom-right positioning
- configure Jest mocks for external modules

## Testing
- `npm test` *(fails: Cannot find module 'react-native-vision-camera' from 'src/components/ProfessionalOCRScanner.tsx')*
- `npm run lint` *(fails: CoffeePreferenceForm.tsx - 'width' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689b7153be88832ab971fa161e4c21bd