### PR TITLE
feat: let users customize AI coffee preferences

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import ProfessionalOCRScanner from './src/components/ProfessionalOCRScanner';
 import UserProfile from './src/components/UserProfile';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
+import EditPreferences from './src/components/EditPreferences';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
 
@@ -25,6 +26,7 @@ type ScreenName =
   | 'profile'
   | 'edit-profile'
   | 'preferences'
+  | 'edit-preferences'
   | 'brew'
   | 'discover'
   | 'recipes'
@@ -141,7 +143,7 @@ const AppContent = (): React.JSX.Element => {
         </View>
         <UserProfile
           onEdit={handleEditProfilePress}
-          onPreferences={() => setCurrentScreen('preferences')}
+          onPreferences={() => setCurrentScreen('edit-preferences')}
         />
       </SafeAreaView>
     );
@@ -159,6 +161,14 @@ const AppContent = (): React.JSX.Element => {
     return (
       <SafeAreaView style={backgroundStyle}>
         <CoffeePreferenceForm onBack={() => setCurrentScreen('profile')} />
+      </SafeAreaView>
+    );
+  }
+
+  if (currentScreen === 'edit-preferences') {
+    return (
+      <SafeAreaView style={backgroundStyle}>
+        <EditPreferences onBack={() => setCurrentScreen('profile')} />
       </SafeAreaView>
     );
   }

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.get('/api/profile', async (req, res) => {
     const uid = decoded.uid;
 
     const result = await db.query(
-        'SELECT id, email, name, coffee_preferences, experience_level, ai_recommendation FROM user_profiles WHERE id = $1',
+        'SELECT id, email, name, coffee_preferences, experience_level, ai_recommendation, manual_input FROM user_profiles WHERE id = $1',
         [uid]
     );
 
@@ -82,6 +82,7 @@ app.put('/api/profile', async (req, res) => {
       coffee_preferences,
       experience_level,
       ai_recommendation,
+      manual_input,
     } = req.body;
 
     console.log('🧩 Extrahované polia:');
@@ -91,6 +92,7 @@ app.put('/api/profile', async (req, res) => {
     console.log('experience_level:', experience_level);
     console.log('coffee_preferences:', coffee_preferences);
     console.log('ai_recommendation:', ai_recommendation);
+    console.log('manual_input:', manual_input);
 
     const safe = (val) => typeof val !== 'undefined' ? val : null;
 
@@ -103,8 +105,9 @@ app.put('/api/profile', async (req, res) => {
                                coffee_preferences = $4,
                                experience_level = $5,
                                ai_recommendation = $6,
+                               manual_input = $7,
                                updated_at = now()
-        WHERE id = $7
+        WHERE id = $8
       `,
       [
         safe(name),
@@ -113,6 +116,7 @@ app.put('/api/profile', async (req, res) => {
         coffee_preferences,
         experience_level,
         ai_recommendation,
+        manual_input,
         uid
       ]
     );
@@ -124,6 +128,8 @@ app.put('/api/profile', async (req, res) => {
 ${JSON.stringify(coffee_preferences, null, 2)}
 --- AI ---
 ${ai_recommendation}
+--- Manual ---
+${manual_input}
 --- Meta ---
 name: ${name}, bio: ${bio}, avatar_url: ${avatar_url}
 `;

--- a/src/components/EditPreferences.tsx
+++ b/src/components/EditPreferences.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from 'react';
+import { Text, TextInput, StyleSheet, TouchableOpacity, Alert, ActivityIndicator, ScrollView, useColorScheme } from 'react-native';
+import auth from '@react-native-firebase/auth';
+import { getColors, Colors } from '../theme/colors';
+
+const OPENAI_API_KEY = "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";
+
+interface ProfileData {
+  coffee_preferences?: any;
+  experience_level?: string;
+  ai_recommendation?: string;
+  manual_input?: string;
+}
+
+const EditPreferences = ({ onBack }: { onBack: () => void }) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const colors = getColors(isDarkMode);
+  const styles = createStyles(colors);
+
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [manualText, setManualText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const user = auth().currentUser;
+        const token = await user?.getIdToken();
+        const res = await fetch('http://10.0.2.2:3001/api/profile', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error('Nepodarilo sa načítať profil');
+        const data = await res.json();
+        setProfile(data);
+        setManualText(data.manual_input || data.ai_recommendation || '');
+      } catch (err) {
+        Alert.alert('Chyba', 'Nepodarilo sa načítať profil');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, []);
+
+  const generateAI = async (manual: string) => {
+    try {
+      const prompt = `Odpovede používateľa z formulára: ${JSON.stringify(profile?.coffee_preferences)}. Dodatočné poznámky: ${manual}. Vytvor personalizované odporúčanie na kávu.`;
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o',
+          messages: [
+            {
+              role: 'system',
+              content: 'Si skúsený barista a coffee expert. Vytváraš personalizované odporúčania pre milovníkov kávy.'
+            },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.4,
+        }),
+      });
+      const data = await response.json();
+      return data?.choices?.[0]?.message?.content?.trim() || 'Nepodarilo sa získať odporúčanie.';
+    } catch (err) {
+      console.error('AI error:', err);
+      return 'Nastala chyba pri generovaní odporúčania.';
+    }
+  };
+
+  const handleSave = async () => {
+    if (!profile) return;
+    setSaving(true);
+    try {
+      const aiRecommendation = await generateAI(manualText);
+      const user = auth().currentUser;
+      const token = await user?.getIdToken();
+      const res = await fetch('http://10.0.2.2:3001/api/profile', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ai_recommendation: aiRecommendation,
+          manual_input: manualText,
+        }),
+      });
+      if (!res.ok) throw new Error('Uloženie zlyhalo');
+      Alert.alert('✅ Uložené', 'Preferencie boli aktualizované');
+      onBack();
+    } catch (err) {
+      Alert.alert('Chyba', 'Uloženie zlyhalo');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <ActivityIndicator style={{ marginTop: 40 }} size="large" color={colors.primary} />;
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Upraviť preferencie</Text>
+      <Text style={styles.label}>Tvoje poznámky</Text>
+      <TextInput
+        value={manualText}
+        onChangeText={setManualText}
+        style={[styles.input, styles.multiline]}
+        multiline
+        numberOfLines={6}
+        placeholder="Doplň alebo uprav svoje preferencie"
+        placeholderTextColor={colors.textSecondary}
+      />
+      <TouchableOpacity style={styles.saveButton} onPress={handleSave} disabled={saving}>
+        <Text style={styles.saveButtonText}>{saving ? 'Ukladám...' : 'Uložiť'}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.backButton} onPress={onBack}>
+        <Text style={styles.backButtonText}>← Späť</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const createStyles = (colors: Colors) =>
+  StyleSheet.create({
+    container: {
+      padding: 30,
+      backgroundColor: colors.background,
+      flexGrow: 1,
+    },
+    title: {
+      fontSize: 26,
+      fontWeight: 'bold',
+      marginBottom: 20,
+      color: colors.text,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.text,
+      marginBottom: 10,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 12,
+      padding: 10,
+      backgroundColor: colors.cardBackground,
+      color: colors.text,
+    },
+    multiline: {
+      height: 160,
+      textAlignVertical: 'top',
+      marginBottom: 20,
+    },
+    saveButton: {
+      backgroundColor: colors.secondary,
+      padding: 15,
+      borderRadius: 20,
+      alignItems: 'center',
+    },
+    saveButtonText: {
+      color: '#fff',
+      fontWeight: 'bold',
+    },
+    backButton: {
+      marginTop: 20,
+      alignItems: 'center',
+    },
+    backButtonText: {
+      color: colors.primary,
+      fontSize: 16,
+    },
+  });
+
+export default EditPreferences;
+

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -24,6 +24,7 @@ interface ProfileData {
   coffee_preferences?: any;
   experience_level?: string;
   ai_recommendation?: string;
+  manual_input?: string;
 }
 
 interface Stat {


### PR DESCRIPTION
## Summary
- add EditPreferences screen for manual coffee preference notes
- update navigation to include new edit-preferences flow
- store manual preference text on server alongside AI recommendation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689effc8756c832a8983dbb98ed4bddb