### PR TITLE
feat: reintroduce coffee form link from profile

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -144,6 +144,7 @@ const AppContent = (): React.JSX.Element => {
         <UserProfile
           onEdit={handleEditProfilePress}
           onPreferences={() => setCurrentScreen('edit-preferences')}
+          onForm={() => setCurrentScreen('preferences')}
         />
       </SafeAreaView>
     );

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -36,10 +36,12 @@ interface Stat {
 const UserProfile = ({
                        onEdit,
                        onPreferences,
+                       onForm,
                        onBack
                      }: {
   onEdit: () => void;
   onPreferences: () => void;
+  onForm?: () => void;
   onBack?: () => void;
 }) => {
   const [profile, setProfile] = useState<ProfileData | null>(null);
@@ -320,6 +322,18 @@ const UserProfile = ({
                 Upraviť preferencie
               </Text>
             </TouchableOpacity>
+            {onForm && (
+                <TouchableOpacity
+                    style={[styles.actionButton, styles.secondaryActionButton]}
+                    onPress={onForm}
+                    activeOpacity={0.8}
+                >
+                  <View style={styles.actionIcon}>
+                    <Text style={styles.actionEmoji}>📝</Text>
+                  </View>
+                  <Text style={styles.actionButtonText}>Formulár preferencií</Text>
+                </TouchableOpacity>
+            )}
             {onBack && (
                 <TouchableOpacity style={styles.backButton} onPress={onBack}>
                   <Text style={styles.backButtonText}>←</Text>


### PR DESCRIPTION
## Summary
- allow users to open coffee preference form directly from profile
- wire up navigation handler for the new form action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f49a8cc7c832a852fc71caf0cf8de