### PR TITLE
Add safe area wrapper to prevent top overlap

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,6 @@
 // App.tsx
 import React, { useState, useEffect } from 'react';
 import {
-  SafeAreaView,
-  StatusBar,
   StyleSheet,
   Text,
   View,
@@ -19,6 +17,7 @@ import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
 import EditPreferences from './src/components/EditPreferences';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
+import ResponsiveWrapper from './src/components/ResponsiveWrapper';
 
 type ScreenName =
   | 'home'
@@ -43,11 +42,6 @@ const AppContent = (): React.JSX.Element => {
     });
     return unsubscribe;
   }, []);
-
-  const backgroundStyle = {
-    backgroundColor: colors.background,
-    flex: 1,
-  };
 
   const handleScannerPress = () => {
     setCurrentScreen('scanner');
@@ -113,12 +107,24 @@ const AppContent = (): React.JSX.Element => {
   };
 
   if (!isAuthenticated) {
-    return <AuthScreen />;
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <AuthScreen />
+      </ResponsiveWrapper>
+    );
   }
 
   if (currentScreen === 'scanner') {
     return (
-      <SafeAreaView style={backgroundStyle}>
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
         <View style={styles.header}>
           <TouchableOpacity
             style={[styles.backButton, { backgroundColor: colors.primary }]}
@@ -127,13 +133,17 @@ const AppContent = (): React.JSX.Element => {
           </TouchableOpacity>
         </View>
         <ProfessionalOCRScanner />
-      </SafeAreaView>
+      </ResponsiveWrapper>
     );
   }
 
   if (currentScreen === 'profile') {
     return (
-      <SafeAreaView style={backgroundStyle}>
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
         <View style={styles.header}>
           <TouchableOpacity
             style={[styles.backButton, { backgroundColor: colors.primary }]}
@@ -146,40 +156,52 @@ const AppContent = (): React.JSX.Element => {
           onPreferences={() => setCurrentScreen('edit-preferences')}
           onForm={() => setCurrentScreen('preferences')}
         />
-      </SafeAreaView>
+      </ResponsiveWrapper>
     );
   }
 
   if (currentScreen === 'edit-profile') {
     return (
-      <SafeAreaView style={backgroundStyle}>
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
         <EditUserProfile onBack={() => setCurrentScreen('profile')} />
-      </SafeAreaView>
+      </ResponsiveWrapper>
     );
   }
 
   if (currentScreen === 'preferences') {
     return (
-      <SafeAreaView style={backgroundStyle}>
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
         <CoffeePreferenceForm onBack={() => setCurrentScreen('profile')} />
-      </SafeAreaView>
+      </ResponsiveWrapper>
     );
   }
 
   if (currentScreen === 'edit-preferences') {
     return (
-      <SafeAreaView style={backgroundStyle}>
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
         <EditPreferences onBack={() => setCurrentScreen('profile')} />
-      </SafeAreaView>
+      </ResponsiveWrapper>
     );
   }
 
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar
-        barStyle={isDark ? 'light-content' : 'dark-content'}
-        backgroundColor={colors.background}
-      />
+    <ResponsiveWrapper
+      backgroundColor={colors.background}
+      statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+      statusBarBackground={colors.background}
+    >
       <HomeScreen
         onScanPress={handleScannerPress}
         onBrewPress={handleBrewPress}
@@ -189,7 +211,7 @@ const AppContent = (): React.JSX.Element => {
         onFavoritesPress={handleFavoritesPress}
         onLogout={handleLogout}
       />
-    </SafeAreaView>
+    </ResponsiveWrapper>
   );
 };
 

--- a/src/components/CoffeePreferenceForm.tsx
+++ b/src/components/CoffeePreferenceForm.tsx
@@ -9,7 +9,6 @@ import {
   ScrollView,
   Alert,
   useColorScheme,
-  SafeAreaView,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import { getColors } from '../theme/colors';
@@ -552,7 +551,7 @@ Píš jednoducho, zrozumiteľne a priateľsky v slovenčine.
   };
 
   return (
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         {/* Header */}
         <View style={styles.header}>
           <TouchableOpacity onPress={onBack} style={styles.closeButton}>
@@ -579,7 +578,7 @@ Píš jednoducho, zrozumiteľne a priateľsky v slovenčine.
 
           <View style={styles.bottomPadding} />
         </ScrollView>
-      </SafeAreaView>
+      </View>
   );
 };
 

--- a/src/components/EditPreferences.tsx
+++ b/src/components/EditPreferences.tsx
@@ -9,16 +9,13 @@ import {
   ScrollView,
   useColorScheme,
   View,
-  SafeAreaView,
   KeyboardAvoidingView,
   Platform,
-  Dimensions,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import { getColors, Colors } from '../theme/colors';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
 
-const { width } = Dimensions.get('window');
 const OPENAI_API_KEY = "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";
 
 interface ProfileData {
@@ -217,7 +214,7 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
 
   if (loading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         <View style={styles.header}>
           <View style={styles.headerPlaceholder} />
           <Text style={styles.headerTitle}>Upraviť preferencie</Text>
@@ -226,12 +223,12 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
         <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.headerButton} onPress={onBack}>
@@ -314,7 +311,7 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/components/EditUserProfile.tsx
+++ b/src/components/EditUserProfile.tsx
@@ -8,17 +8,14 @@ import {
   ActivityIndicator,
   ScrollView,
   useColorScheme,
-  SafeAreaView,
   View,
   KeyboardAvoidingView,
   Platform,
-  Dimensions,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import { getColors, Colors } from '../theme/colors';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
 
-const { width } = Dimensions.get('window');
 
 const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -83,7 +80,7 @@ const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
 
   if (loading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         <View style={styles.header}>
           <View style={styles.headerPlaceholder} />
           <Text style={styles.headerTitle}>Upraviť profil</Text>
@@ -92,12 +89,12 @@ const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
         <View style={styles.centerContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.headerButton} onPress={onBack}>
@@ -182,7 +179,7 @@ const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -5,14 +5,10 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  SafeAreaView,
   RefreshControl,
-  Dimensions,
   Alert,
 } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles.ts';
-
-const { width } = Dimensions.get('window');
 
 interface CoffeeItem {
   id: string;
@@ -44,8 +40,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                                                }) => {
   const [refreshing, setRefreshing] = useState(false);
   const [activeNavItem, setActiveNavItem] = useState('home');
-  const [caffeineAmount, setCaffeineAmount] = useState(195);
-  const [coffeesToday, setCoffeesToday] = useState(3);
+  const [caffeineAmount, _setCaffeineAmount] = useState(195);
+  const [coffeesToday, _setCoffeesToday] = useState(3);
   const [activeTasteTags, setActiveTasteTags] = useState([
     'Stredná intenzita',
     'Čokoládové tóny',
@@ -130,7 +126,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   // @ts-ignore
   // @ts-ignore
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       {/* Status Bar */}
       <View style={styles.statusBar}>
         <Text style={styles.statusTime}>9:41</Text>
@@ -366,7 +362,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
           <Text style={[styles.navLabel, activeNavItem === 'profile' && styles.navActive]}>Profil</Text>
         </TouchableOpacity>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/components/ResponsiveWrapper.tsx
+++ b/src/components/ResponsiveWrapper.tsx
@@ -41,6 +41,7 @@ const ResponsiveWrapper: React.FC<ResponsiveWrapperProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    paddingTop: getSafeAreaTop(),
   },
   content: {
     flex: 1,

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -7,17 +7,16 @@ import {
   Alert,
   TouchableOpacity,
   ScrollView,
-  SafeAreaView,
   RefreshControl,
   Dimensions,
-  StatusBar,
   KeyboardAvoidingView,
-  StyleSheet, Platform,
+  StyleSheet,
+  Platform,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
 
-const { width, height } = Dimensions.get('window');
+const { width } = Dimensions.get('window');
 
 interface ProfileData {
   email: string;
@@ -342,9 +341,7 @@ const UserProfile = ({
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar barStyle="light-content" backgroundColor="#6B4423" />
-
+    <View style={styles.container}>
       {/* Header */}
       <View style={styles.header}>
         {onBack && (
@@ -363,7 +360,7 @@ const UserProfile = ({
       >
         {loading ? <LoadingView /> : !profile ? <ErrorView /> : <ProfileContent />}
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -1,7 +1,5 @@
 // HomeScreen.styles.ts
-import { StyleSheet, Dimensions, Platform } from 'react-native';
-
-const { width, height } = Dimensions.get('window');
+import { StyleSheet, Platform } from 'react-native';
 
 const colors = {
   primary: '#6B4423',

--- a/src/components/styles/UserProfile.styles.ts
+++ b/src/components/styles/UserProfile.styles.ts
@@ -1,7 +1,5 @@
 // UserProfile.styles.ts
-import { StyleSheet, Dimensions, Platform } from 'react-native';
-
-const { width, height } = Dimensions.get('window');
+import { StyleSheet, Platform } from 'react-native';
 
 const colors = {
     primary: '#6B4423',

--- a/src/components/utils/safeArea.ts
+++ b/src/components/utils/safeArea.ts
@@ -1,7 +1,7 @@
 // utils/safeArea.ts
 import { Platform, Dimensions, StatusBar } from 'react-native';
 
-const { height: screenHeight, width: screenWidth } = Dimensions.get('window');
+const { height: screenHeight } = Dimensions.get('window');
 
 // Pomocné funkcie pre bezpečné zóny (bez externých dependencies)
 export const getSafeAreaTop = () => {


### PR DESCRIPTION
## Summary
- add paddingTop from safe area utilities to ResponsiveWrapper
- wrap all screens with ResponsiveWrapper and remove nested SafeAreaView components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f733561e4832aacf8eb714ab5ae9d