### PR TITLE
feat: add interactive recipe steps screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import UserProfile from './src/components/UserProfile';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
 import EditPreferences from './src/components/EditPreferences';
+import RecipeStepsScreen from './src/components/RecipeStepsScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
 import ResponsiveWrapper from './src/components/ResponsiveWrapper';
@@ -30,11 +31,13 @@ type ScreenName =
   | 'brew'
   | 'discover'
   | 'recipes'
+  | 'recipe-steps'
   | 'favorites';
 
 const AppContent = (): React.JSX.Element => {
   const [currentScreen, setCurrentScreen] = useState<ScreenName>('home');
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [generatedRecipe, setGeneratedRecipe] = useState('');
   const { isDark, colors } = useTheme();
 
   useEffect(() => {
@@ -153,7 +156,27 @@ const AppContent = (): React.JSX.Element => {
             <Text style={styles.backButtonText}>← Späť</Text>
           </TouchableOpacity>
         </View>
-        <BrewScanner />
+        <BrewScanner
+          onRecipeGenerated={(recipe) => {
+            setGeneratedRecipe(recipe);
+            setCurrentScreen('recipe-steps');
+          }}
+        />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'recipe-steps') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <RecipeStepsScreen
+          recipe={generatedRecipe}
+          onBack={() => setCurrentScreen('brew')}
+        />
       </ResponsiveWrapper>
     );
   }

--- a/__tests__/RecipeStepsScreen.test.tsx
+++ b/__tests__/RecipeStepsScreen.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import RecipeStepsScreen from '../src/components/RecipeStepsScreen';
+import { ThemeProvider } from '../src/theme/ThemeProvider';
+
+test('renders recipe steps', () => {
+  ReactTestRenderer.create(
+    <ThemeProvider>
+      <RecipeStepsScreen recipe={'Krok 1\nKrok 2'} onBack={() => {}} />
+    </ThemeProvider>,
+  );
+});

--- a/src/components/BrewScanner.tsx
+++ b/src/components/BrewScanner.tsx
@@ -54,9 +54,10 @@ interface ScanResult {
 
 interface BrewScannerProps {
   onBack?: () => void;
+  onRecipeGenerated?: (recipe: string) => void;
 }
 
-const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
+const BrewScanner: React.FC<BrewScannerProps> = ({ onBack, onRecipeGenerated }) => {
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [editedText, setEditedText] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
@@ -67,7 +68,6 @@ const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
   const [userRating, setUserRating] = useState<number>(0);
   const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
   const [tastePreference, setTastePreference] = useState('');
-  const [brewRecipe, setBrewRecipe] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
 
   const camera = useRef<Camera>(null);
@@ -238,7 +238,6 @@ const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
   const handleMethodPress = (method: string) => {
     setSelectedMethod(method);
     setTastePreference('');
-    setBrewRecipe('');
   };
 
   const generateRecipe = async () => {
@@ -246,7 +245,9 @@ const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
     try {
       setIsGenerating(true);
       const recipe = await getBrewRecipe(selectedMethod, tastePreference);
-      setBrewRecipe(recipe);
+      if (onRecipeGenerated) {
+        onRecipeGenerated(recipe);
+      }
     } catch (error) {
       console.error('Error generating recipe:', error);
       Alert.alert('Chyba', 'Nepodarilo sa získať recept');
@@ -276,7 +277,6 @@ const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
     setUserRating(0);
     setSelectedMethod(null);
     setTastePreference('');
-    setBrewRecipe('');
   };
 
   if (!device) {
@@ -471,13 +471,6 @@ const BrewScanner: React.FC<BrewScannerProps> = ({ onBack }) => {
                     {isGenerating ? 'Generujem...' : 'Vyhodnotiť recept'}
                   </Text>
                 </TouchableOpacity>
-              </View>
-            )}
-
-            {brewRecipe !== '' && (
-              <View style={styles.recipeCard}>
-                <Text style={styles.recipeResultTitle}>☕ Recept</Text>
-                <Text style={styles.recipeResultText}>{brewRecipe}</Text>
               </View>
             )}
 

--- a/src/components/RecipeStepsScreen.tsx
+++ b/src/components/RecipeStepsScreen.tsx
@@ -1,0 +1,75 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '../theme/ThemeProvider';
+import { recipeStepsStyles } from './styles/RecipeSteps.styles';
+
+interface RecipeStepsScreenProps {
+  recipe: string;
+  onBack: () => void;
+}
+
+const stepIcons = ['🫘', '⚖️', '🔥', '⏱️', '☕'];
+
+const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, onBack }) => {
+  const { colors } = useTheme();
+  const styles = useMemo(() => recipeStepsStyles(colors), [colors]);
+  const steps = useMemo(() => recipe.split(/\n+/).filter((s) => s.trim().length > 0), [recipe]);
+  const [index, setIndex] = useState(0);
+
+  const handleNext = () => {
+    if (index < steps.length - 1) setIndex(index + 1);
+  };
+
+  const handlePrev = () => {
+    if (index > 0) setIndex(index - 1);
+  };
+
+  if (steps.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity style={styles.backButton} onPress={onBack}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.content}>
+          <Text style={styles.stepText}>Recept nie je k dispozícii</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={onBack}>
+          <Text style={styles.backButtonText}>← Späť</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.content}>
+        <Text style={styles.stepCounter}>{`Krok ${index + 1} / ${steps.length}`}</Text>
+        <Text style={styles.stepIcon}>{stepIcons[index % stepIcons.length]}</Text>
+        <Text style={styles.stepText}>{steps[index]}</Text>
+      </View>
+      <View style={styles.nav}>
+        <TouchableOpacity
+          style={[styles.navButton, index === 0 && styles.navButtonDisabled]}
+          onPress={handlePrev}
+          disabled={index === 0}>
+          <Text style={styles.navButtonText}>Predchádzajúci</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.navButton,
+            index === steps.length - 1 && styles.navButtonDisabled,
+          ]}
+          onPress={handleNext}
+          disabled={index === steps.length - 1}>
+          <Text style={styles.navButtonText}>Ďalší</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default RecipeStepsScreen;

--- a/src/components/styles/RecipeSteps.styles.ts
+++ b/src/components/styles/RecipeSteps.styles.ts
@@ -1,0 +1,67 @@
+import { StyleSheet } from 'react-native';
+import { scale } from '../../theme/responsive';
+import { Colors } from '../../theme/colors';
+
+export const recipeStepsStyles = (colors: Colors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      padding: scale(20),
+    },
+    backButton: {
+      paddingHorizontal: scale(15),
+      paddingVertical: scale(8),
+      borderRadius: scale(15),
+      backgroundColor: colors.primary,
+    },
+    backButtonText: {
+      color: '#fff',
+      fontWeight: 'bold',
+      fontSize: scale(14),
+    },
+    content: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: scale(20),
+    },
+    stepCounter: {
+      fontSize: scale(18),
+      color: colors.text,
+      marginBottom: scale(10),
+    },
+    stepIcon: {
+      fontSize: scale(64),
+      marginBottom: scale(20),
+    },
+    stepText: {
+      fontSize: scale(16),
+      color: colors.text,
+      textAlign: 'center',
+    },
+    nav: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      padding: scale(20),
+    },
+    navButton: {
+      flex: 1,
+      paddingVertical: scale(12),
+      marginHorizontal: scale(5),
+      borderRadius: scale(12),
+      alignItems: 'center',
+      backgroundColor: colors.primary,
+    },
+    navButtonDisabled: {
+      opacity: 0.5,
+    },
+    navButtonText: {
+      color: '#fff',
+      fontSize: scale(14),
+      fontWeight: 'bold',
+    },
+  });


### PR DESCRIPTION
## Summary
- add RecipeStepsScreen for step-by-step brewing guide
- open recipe steps from BrewScanner after generation
- include basic unit test for RecipeStepsScreen

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7c432130832a981510f932668852