### PR TITLE
Wrap string children in ResponsiveWrapper

### DIFF
--- a/src/components/ResponsiveWrapper.tsx
+++ b/src/components/ResponsiveWrapper.tsx
@@ -5,6 +5,7 @@ import {
   StatusBar,
   Platform,
   View,
+  Text,
   StyleSheet,
 } from 'react-native';
 import { getSafeAreaTop, getSafeAreaBottom } from './utils/safeArea.ts';
@@ -31,7 +32,11 @@ const ResponsiveWrapper: React.FC<ResponsiveWrapperProps> = ({
       />
       <SafeAreaView style={[styles.container, { backgroundColor }]}>
         <View style={styles.content}>
-          {children}
+          {React.Children.map(children, child =>
+            typeof child === 'string' || typeof child === 'number'
+              ? <Text>{child}</Text>
+              : child
+          )}
         </View>
       </SafeAreaView>
     </>


### PR DESCRIPTION
## Summary
- Ensure ResponsiveWrapper wraps string and number children with a Text component to prevent React Native warnings

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1735e400c832a9607f4295cabc19a