### PR TITLE
chore: drop process.env fallback from config

### DIFF
--- a/src/components/CoffeePreferenceForm.tsx
+++ b/src/components/CoffeePreferenceForm.tsx
@@ -14,8 +14,9 @@ import {
 import auth from '@react-native-firebase/auth';
 import { getColors } from '../theme/colors';
 import AIResponseDisplay from './AIResponseDisplay';
+import { CONFIG } from '../config/config';
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_API_KEY = CONFIG.OPENAI_API_KEY;
 
 /**
  * Wrapper pre fetch s logovaním komunikácie FE ↔ BE.
@@ -416,6 +417,11 @@ const CoffeePreferenceForm = ({ onBack }: { onBack: () => void }) => {
    * Zavolá OpenAI a vygeneruje odporúčanie podľa preferencií.
    */
   const generateAIRecommendation = async (prefs: any, level: string): Promise<string> => {
+    if (!OPENAI_API_KEY) {
+      console.error('Chýba OpenAI API key. Odporúčanie sa nevygeneruje.');
+      return 'Nastala chyba pri generovaní odporúčania.';
+    }
+
     const prompt = `
 Ako profesionálny barista vytvor personalizované odporúčanie pre používateľa.
 Úroveň skúseností: ${level}

--- a/src/components/EditPreferences.tsx
+++ b/src/components/EditPreferences.tsx
@@ -16,8 +16,9 @@ import auth from '@react-native-firebase/auth';
 import { getColors, Colors } from '../theme/colors';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
 import { AIResponseDisplay } from './AIResponseDisplay';
+import { CONFIG } from '../config/config';
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_API_KEY = CONFIG.OPENAI_API_KEY;
 
 /**
  * Jednoduchý wrapper pre fetch s logovaním komunikácie FE ↔ BE.
@@ -78,6 +79,11 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
    * Vygeneruje nové AI odporúčanie podľa zadaných poznámok.
    */
   const generateAI = async (additionalNotes: string) => {
+    if (!OPENAI_API_KEY) {
+      console.error('Chýba OpenAI API key. Odporúčanie sa nevygeneruje.');
+      return 'Nastala chyba pri generovaní odporúčania.';
+    }
+
     try {
       let prompt = `Používateľ má tieto preferencie kávy: ${JSON.stringify(profile?.coffee_preferences)}.`;
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,7 +11,3 @@ export const CONFIG = {
   // AZURE_API_KEY: 'your-azure-key',
 };
 
-// Alternative: Use environment variables (recommended for production)
-// export const CONFIG = {
-//   OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
-// };

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1,9 +1,9 @@
 // services/ocrService.ts
 import auth from '@react-native-firebase/auth';
+import { CONFIG } from '../config/config';
 
 const API_URL = 'http://10.0.2.2:3001';
-const OPENAI_API_KEY =
-  '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';
+const OPENAI_API_KEY = CONFIG.OPENAI_API_KEY;
 
 /**
  * Wrapper okolo fetchu pre logovanie požiadaviek a odpovedí.
@@ -80,7 +80,7 @@ const extractCoffeeName = (text: string): string => {
  */
 const fixTextWithAI = async (ocrText: string): Promise<string> => {
   const prompt = `
-Toto je text získaný OCR rozpoznávaním z etikety kávy. 
+Toto je text získaný OCR rozpoznávaním z etikety kávy.
 Oprav všetky chyby, ktoré mohli vzniknúť zlým rozpoznaním znakov.
 Zachovaj pôvodný význam a štruktúru, ale oprav OCR chyby.
 Vráť iba opravený text.
@@ -88,6 +88,11 @@ Vráť iba opravený text.
 OCR text:
 ${ocrText}
   `;
+
+  if (!OPENAI_API_KEY) {
+    console.error('Chýba OpenAI API key. Text sa neodošle na opravu.');
+    return ocrText;
+  }
 
   try {
     console.log('📤 [OpenAI] OCR prompt:', prompt);
@@ -133,6 +138,11 @@ const suggestBrewingMethods = async (coffeeText: string): Promise<string[]> => {
     `Odpovedz len zoznamom metód oddelených novým riadkom. Popis: "${coffeeText}"`;
 
   const fallback = ['Espresso', 'French press', 'V60', 'Cold brew'];
+
+  if (!OPENAI_API_KEY) {
+    console.error('Chýba OpenAI API key. Vráti sa predvolený zoznam metód.');
+    return fallback;
+  }
 
   try {
     console.log('📤 [OpenAI] Brewing prompt:', prompt);
@@ -189,6 +199,11 @@ export const getBrewRecipe = async (
   taste: string
 ): Promise<string> => {
   const prompt = `Priprav detailný recept na kávu pomocou metódy ${method}. Používateľ preferuje ${taste} chuť. Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.`;
+
+  if (!OPENAI_API_KEY) {
+    console.error('Chýba OpenAI API key. Recept sa nevygeneruje.');
+    return '';
+  }
 
   try {
     console.log('📤 [OpenAI] Recipe prompt:', prompt);


### PR DESCRIPTION
## Summary
- remove leftover process.env fallback from config so only CONFIG is used outside server

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b22c05cb64832aa9d3e3795edac4bf