### PR TITLE
Add recipe history support

### DIFF
--- a/db/create_brew_recipes_table.sql
+++ b/db/create_brew_recipes_table.sql
@@ -1,0 +1,10 @@
+create table if not exists brew_recipes (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid references auth.users(id) on delete cascade,
+    method text not null,
+    taste text,
+    recipe text not null,
+    created_at timestamptz default now()
+);
+
+create index if not exists brew_recipes_user_id_idx on brew_recipes(user_id);

--- a/src/services/recipeServices.ts
+++ b/src/services/recipeServices.ts
@@ -1,0 +1,82 @@
+import auth from '@react-native-firebase/auth';
+
+const API_URL = 'http://10.0.2.2:3001/api';
+
+const loggedFetch = async (url: string, options: RequestInit) => {
+  console.log('📤 [FE->BE]', url, options);
+  const res = await fetch(url, options);
+  console.log('📥 [BE->FE]', url, res.status);
+  return res;
+};
+
+const getAuthToken = async (): Promise<string | null> => {
+  try {
+    const user = auth().currentUser;
+    if (!user) return null;
+    return await user.getIdToken();
+  } catch (error) {
+    console.error('Error getting auth token:', error);
+    return null;
+  }
+};
+
+export interface RecipeHistory {
+  id: string;
+  method: string;
+  taste: string;
+  recipe: string;
+  created_at: string;
+}
+
+export const saveRecipe = async (
+  method: string,
+  taste: string,
+  recipe: string
+): Promise<boolean> => {
+  try {
+    const token = await getAuthToken();
+    if (!token) return false;
+
+    const res = await loggedFetch(`${API_URL}/recipes`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ method, taste, recipe }),
+    });
+
+    return res.ok;
+  } catch (error) {
+    console.error('Error saving recipe:', error);
+    return false;
+  }
+};
+
+export const fetchRecipeHistory = async (
+  limit: number = 10
+): Promise<RecipeHistory[]> => {
+  try {
+    const token = await getAuthToken();
+    if (!token) return [];
+
+    const res = await loggedFetch(`${API_URL}/recipes/history?limit=${limit}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!res.ok) {
+      console.warn('Failed to fetch recipe history');
+      return [];
+    }
+
+    const data = await res.json();
+    return data as RecipeHistory[];
+  } catch (error) {
+    console.error('Error fetching recipe history:', error);
+    return [];
+  }
+};
+


### PR DESCRIPTION
## Summary
- Save generated recipes in new Supabase table and expose POST/GET endpoints
- Add frontend service to persist recipes and fetch recipe history
- Display recipe history in scanner screen and auto-save generated recipes
- Include SQL migration for `brew_recipes` table

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4465b7aac832aa76c7a3641465c95