### PR TITLE
fix: skip logging undefined request bodies

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,10 +25,12 @@ app.use(cors());
 
 // Global request logger to capture communication from frontend
 app.use((req, _res, next) => {
-  console.log(
-    `➡️  [${new Date().toISOString()}] ${req.method} ${req.originalUrl}`,
-    req.body
-  );
+  const base = `➡️  [${new Date().toISOString()}] ${req.method} ${req.originalUrl}`;
+  if (req.body && Object.keys(req.body).length > 0) {
+    console.log(base, req.body);
+  } else {
+    console.log(base);
+  }
   next();
 });
 


### PR DESCRIPTION
## Summary
- avoid printing `undefined` in request logs

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b272b444832a86038f7b74e069d7