### PR TITLE
feat: track coffee purchase after tasting scan

### DIFF
--- a/db/create_ocr_logs_table.sql
+++ b/db/create_ocr_logs_table.sql
@@ -8,6 +8,7 @@ create table if not exists ocr_logs (
     brand text,
     match_percentage integer,
     is_recommended boolean,
+    is_purchased boolean default false,
     rating numeric,
     created_at timestamptz default now()
 );

--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -585,6 +585,17 @@ export const scannerStyles = (isDarkMode: boolean = false) => {
       lineHeight: 18,
     },
 
+    purchaseContainer: {
+      marginTop: 12,
+    },
+
+    purchaseLabel: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      marginBottom: 8,
+    },
+
     // Action Buttons
     actionButtons: {
       flexDirection: 'row',

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -34,6 +34,7 @@ interface OCRHistory {
   rating?: number;
   match_percentage?: number;
   is_recommended?: boolean;
+  is_purchased?: boolean;
 }
 
 /**
@@ -53,7 +54,7 @@ const getAuthToken = async (): Promise<string | null> => {
 /**
  * Extrahuje názov kávy z textu
  */
-const extractCoffeeName = (text: string): string => {
+export const extractCoffeeName = (text: string): string => {
   if (!text) return 'Neznáma káva';
 
   // Hľadaj známe značky
@@ -361,11 +362,33 @@ export const fetchOCRHistory = async (limit: number = 10): Promise<OCRHistory[]>
       rating: item.rating,
       match_percentage: item.match_percentage,
       is_recommended: item.is_recommended,
+      is_purchased: item.is_purchased,
     }));
   } catch (error) {
     console.error('Error fetching OCR history:', error);
     return [];
   }
+};
+
+/**
+ * Označí, že používateľ kúpil danú kávu
+ */
+export const markCoffeePurchased = async (
+  ocrLogId: string,
+  coffeeName: string,
+  brand?: string
+): Promise<void> => {
+  const token = await getAuthToken();
+  if (!token) throw new Error('Nie si prihlásený');
+
+  await loggedFetch(`${API_URL}/api/ocr/purchase`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ ocr_log_id: ocrLogId, coffee_name: coffeeName, brand }),
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary
- ask user after tasting scan if they bought the coffee
- record purchases in coffees table and flag OCR logs
- expose purchase info in history and client services

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57ce2f56c832a85accc77c567cb02