### PR TITLE
feat: confirm purchase and load coffees

### DIFF
--- a/src/components/CoffeeTasteScanner.tsx
+++ b/src/components/CoffeeTasteScanner.tsx
@@ -65,6 +65,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
   const [ocrHistory, setOcrHistory] = useState<OCRHistory[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [userRating, setUserRating] = useState<number>(0);
+  const [purchaseSelection, setPurchaseSelection] = useState<boolean | null>(null);
   const [purchased, setPurchased] = useState<boolean | null>(null);
 
   const camera = useRef<Camera>(null);
@@ -161,6 +162,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
       if (result) {
         setScanResult(result);
         setEditedText(result.corrected);
+        setPurchaseSelection(null);
         setPurchased(null);
 
         // Načítaj aktualizovanú históriu
@@ -232,6 +234,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
     });
     setEditedText(item.corrected_text);
     setUserRating(item.rating || 0);
+    setPurchaseSelection(null);
     setPurchased(item.is_purchased ?? null);
 
     // Scroll to top to show loaded result
@@ -288,9 +291,14 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
     }
   };
 
-  const handlePurchaseAnswer = async (answer: boolean) => {
-    setPurchased(answer);
-    if (answer && scanResult?.scanId) {
+  const handlePurchaseSelect = (answer: boolean) => {
+    setPurchaseSelection(answer);
+  };
+
+  const submitPurchaseAnswer = async () => {
+    if (purchaseSelection === null) return;
+    setPurchased(purchaseSelection);
+    if (purchaseSelection && scanResult?.scanId) {
       try {
         const name = extractCoffeeName(editedText || scanResult.corrected);
         await markCoffeePurchased(scanResult.scanId, name);
@@ -318,6 +326,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
     setScanResult(null);
     setEditedText('');
     setUserRating(0);
+    setPurchaseSelection(null);
     setPurchased(null);
   };
 
@@ -517,18 +526,36 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
                 <Text style={styles.purchaseLabel}>Kúpil si túto kávu?</Text>
                 <View style={styles.actionButtons}>
                   <TouchableOpacity
-                    style={styles.button}
-                    onPress={() => handlePurchaseAnswer(true)}
+                    style={[
+                      styles.button,
+                      purchaseSelection === true && styles.buttonSelected,
+                    ]}
+                    onPress={() => handlePurchaseSelect(true)}
                   >
                     <Text style={styles.buttonText}>Áno</Text>
                   </TouchableOpacity>
                   <TouchableOpacity
-                    style={[styles.button, styles.buttonSecondary]}
-                    onPress={() => handlePurchaseAnswer(false)}
+                    style={[
+                      styles.button,
+                      styles.buttonSecondary,
+                      purchaseSelection === false && styles.buttonSelected,
+                    ]}
+                    onPress={() => handlePurchaseSelect(false)}
                   >
                     <Text style={[styles.buttonText, styles.buttonTextSecondary]}>Nie</Text>
                   </TouchableOpacity>
                 </View>
+                <TouchableOpacity
+                  style={[
+                    styles.button,
+                    styles.submitButton,
+                    purchaseSelection === null && styles.buttonDisabled,
+                  ]}
+                  onPress={submitPurchaseAnswer}
+                  disabled={purchaseSelection === null}
+                >
+                  <Text style={styles.buttonText}>Odoslať</Text>
+                </TouchableOpacity>
               </View>
             )}
 

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,5 +1,5 @@
 // HomeScreen.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -9,13 +9,14 @@ import {
   Alert,
 } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles.ts';
+import { fetchCoffees } from '../services/homePagesService.ts';
 
 interface CoffeeItem {
   id: string;
   name: string;
-  origin: string;
-  rating: number;
-  match: number;
+  origin?: string;
+  rating?: number;
+  match?: number;
   hasCheckmark?: boolean;
 }
 
@@ -49,7 +50,20 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
     'Arabica',
   ]);
 
+  const [recommendedCoffees, setRecommendedCoffees] = useState<CoffeeItem[]>([]);
   const styles = homeStyles();
+
+  useEffect(() => {
+    const loadCoffees = async () => {
+      try {
+        const coffees = await fetchCoffees();
+        setRecommendedCoffees(coffees);
+      } catch (err) {
+        console.error('Error loading coffees:', err);
+      }
+    };
+    loadCoffees();
+  }, []);
 
   const getGreeting = () => {
     const hour = new Date().getHours();
@@ -72,12 +86,6 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
     if (temp > 20) return { name: 'Cold Brew', icon: '🧊' };
     return { name: 'Cappuccino', icon: '☕' };
   };
-
-  const recommendedCoffees: CoffeeItem[] = [
-    { id: '1', name: 'Ethiopia Yirgacheffe', origin: 'Single Origin', rating: 4.8, match: 94, hasCheckmark: true },
-    { id: '2', name: 'Colombia Supremo', origin: 'Premium Blend', rating: 4.6, match: 87, hasCheckmark: true },
-    { id: '3', name: 'Brazil Santos', origin: 'Medium Roast', rating: 4.5, match: 82, hasCheckmark: false },
-  ];
 
   const tasteTags = [
     'Stredná intenzita',
@@ -104,9 +112,16 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const handleCoffeeCardPress = (coffee: CoffeeItem) => {
+    const details = [
+      coffee.origin,
+      coffee.rating !== undefined ? `⭐ ${coffee.rating}` : null,
+      coffee.match !== undefined ? `${coffee.match}% zhoda s tvojím profilom` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
     Alert.alert(
       coffee.name,
-      `${coffee.origin}\n⭐ ${coffee.rating}\n${coffee.match}% zhoda s tvojím profilom`,
+      details,
       [
         { text: 'Zatvoriť', style: 'cancel' },
         { text: 'Pripraviť', onPress: onBrewPress },
@@ -313,11 +328,19 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                   <Text style={styles.coffeeEmoji}>☕</Text>
                 </View>
                 <Text style={styles.coffeeName}>{coffee.name}</Text>
-                <Text style={styles.coffeeOrigin}>{coffee.origin}</Text>
-                <View style={styles.coffeeMatch}>
-                  <Text style={styles.matchScore}>{coffee.match}% zhoda</Text>
-                  <Text style={styles.coffeeRating}>⭐ {coffee.rating}</Text>
-                </View>
+                {coffee.origin && (
+                  <Text style={styles.coffeeOrigin}>{coffee.origin}</Text>
+                )}
+                {(coffee.match !== undefined || coffee.rating !== undefined) && (
+                  <View style={styles.coffeeMatch}>
+                    {coffee.match !== undefined && (
+                      <Text style={styles.matchScore}>{coffee.match}% zhoda</Text>
+                    )}
+                    {coffee.rating !== undefined && (
+                      <Text style={styles.coffeeRating}>⭐ {coffee.rating}</Text>
+                    )}
+                  </View>
+                )}
               </TouchableOpacity>
             ))}
           </ScrollView>

--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -617,6 +617,19 @@ export const scannerStyles = (isDarkMode: boolean = false) => {
       borderColor: colors.border,
     },
 
+    buttonSelected: {
+      borderWidth: 2,
+      borderColor: colors.accent,
+    },
+
+    submitButton: {
+      marginTop: 10,
+    },
+
+    buttonDisabled: {
+      opacity: 0.5,
+    },
+
     buttonText: {
       fontSize: 14,
       fontWeight: '600',

--- a/src/services/homePagesService.ts
+++ b/src/services/homePagesService.ts
@@ -22,10 +22,10 @@ interface UserStats {
 interface CoffeeData {
   id: string;
   name: string;
-  rating: number;
-  match: number;
-  timestamp: Date;
-  isRecommended: boolean;
+  rating?: number;
+  match?: number;
+  timestamp?: Date;
+  isRecommended?: boolean;
   brand?: string;
   origin?: string;
   roastLevel?: string;
@@ -173,6 +173,40 @@ export const fetchUserStats = async (): Promise<UserStats> => {
 //     return getMockRecommendations();
 //   }
 // };
+
+/**
+ * Načíta všetky kávy z databázy
+ */
+export const fetchCoffees = async (): Promise<CoffeeData[]> => {
+  try {
+    const token = await getAuthToken();
+    if (!token) return [];
+
+    const response = await loggedFetch(`${API_URL}/coffees`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = await response.json();
+    return data.map((item: any) => ({
+      id: item.id?.toString() || '',
+      name: item.name,
+      origin: item.brand || item.origin,
+      rating: item.rating,
+      match: item.match,
+    }));
+  } catch (error) {
+    console.error('Error fetching coffees:', error);
+    return [];
+  }
+};
 
 /**
  * Načíta históriu skenovaní


### PR DESCRIPTION
## Summary
- require explicit confirmation to mark a scanned coffee as purchased
- pull recommended coffees from the backend instead of a hardcoded list

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b605154eb8832a818421e75e324203