### PR TITLE
Add coffee list screen and refresh recommendations

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import AuthScreen from './src/components/AuthVisual.tsx';
 import HomeScreen from './src/components/HomeScreen';
 import CoffeeTasteScanner from './src/components/CoffeeTasteScanner.tsx';
 import CoffeeReceipeScanner from './src/components/CoffeeReceipeScanner.tsx';
+import AllCoffeesScreen from './src/components/AllCoffeesScreen';
 import UserProfile from './src/components/UserProfile';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
@@ -61,7 +62,7 @@ const AppContent = (): React.JSX.Element => {
   };
 
   const handleDiscoverPress = () => {
-    Alert.alert('Objaviť', 'Sekcia objavovania nových káv bude čoskoro!');
+    setCurrentScreen('discover');
   };
 
   const handleRecipesPress = () => {
@@ -236,6 +237,18 @@ const AppContent = (): React.JSX.Element => {
         statusBarBackground={colors.primary}
       >
         <EditPreferences onBack={() => setCurrentScreen('profile')} />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'discover') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
+        <AllCoffeesScreen onBack={handleBackPress} />
       </ResponsiveWrapper>
     );
   }

--- a/src/components/AllCoffeesScreen.tsx
+++ b/src/components/AllCoffeesScreen.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  RefreshControl,
+} from 'react-native';
+import { homeStyles } from './styles/HomeScreen.styles.ts';
+import { fetchCoffees } from '../services/homePagesService.ts';
+
+interface CoffeeItem {
+  id: string;
+  name: string;
+  origin?: string;
+  rating?: number;
+  match?: number;
+}
+
+interface AllCoffeesScreenProps {
+  onBack: () => void;
+}
+
+const AllCoffeesScreen: React.FC<AllCoffeesScreenProps> = ({ onBack }) => {
+  const styles = homeStyles();
+  const [coffees, setCoffees] = useState<CoffeeItem[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadCoffees = useCallback(async () => {
+    try {
+      const data = await fetchCoffees();
+      setCoffees(data);
+    } catch (err) {
+      console.error('Error loading coffees:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCoffees();
+  }, [loadCoffees]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadCoffees();
+    setRefreshing(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.appHeader}>
+        <TouchableOpacity onPress={onBack} style={styles.logoSection}>
+          <Text style={{ color: 'white', fontSize: 18 }}>←</Text>
+        </TouchableOpacity>
+        <Text style={[styles.appTitle, { flex: 1, textAlign: 'center' }]}>Moje kávy</Text>
+        <View style={{ width: 32 }} />
+      </View>
+      <ScrollView
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        contentContainerStyle={{ padding: 16 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {coffees.map((coffee) => (
+          <View
+            key={coffee.id}
+            style={[styles.coffeeCard, { marginRight: 0, marginBottom: 16 }]}
+          >
+            <View style={styles.coffeeImage}>
+              <Text style={styles.coffeeEmoji}>☕</Text>
+            </View>
+            <Text style={styles.coffeeName}>{coffee.name}</Text>
+            {coffee.origin && <Text style={styles.coffeeOrigin}>{coffee.origin}</Text>}
+            {(coffee.match !== undefined || coffee.rating !== undefined) && (
+              <View style={styles.coffeeMatch}>
+                {coffee.match !== undefined && (
+                  <Text style={styles.matchScore}>{coffee.match}% zhoda</Text>
+                )}
+                {coffee.rating !== undefined && (
+                  <Text style={styles.coffeeRating}>⭐ {coffee.rating}</Text>
+                )}
+              </View>
+            )}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default AllCoffeesScreen;

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,5 +1,5 @@
 // HomeScreen.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -53,17 +53,18 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   const [recommendedCoffees, setRecommendedCoffees] = useState<CoffeeItem[]>([]);
   const styles = homeStyles();
 
-  useEffect(() => {
-    const loadCoffees = async () => {
-      try {
-        const coffees = await fetchCoffees();
-        setRecommendedCoffees(coffees);
-      } catch (err) {
-        console.error('Error loading coffees:', err);
-      }
-    };
-    loadCoffees();
+  const loadCoffees = useCallback(async () => {
+    try {
+      const coffees = await fetchCoffees();
+      setRecommendedCoffees(coffees);
+    } catch (err) {
+      console.error('Error loading coffees:', err);
+    }
   }, []);
+
+  useEffect(() => {
+    loadCoffees();
+  }, [loadCoffees]);
 
   const getGreeting = () => {
     const hour = new Date().getHours();
@@ -98,8 +99,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
 
   const onRefresh = async () => {
     setRefreshing(true);
-    // Simulate data refresh
-    await new Promise(resolve => setTimeout(resolve, 1500));
+    await loadCoffees();
     setRefreshing(false);
   };
 


### PR DESCRIPTION
## Summary
- Refactor HomeScreen coffee loading so pull-to-refresh fetches latest coffees
- Add AllCoffeesScreen to list all stored coffees with swipe-to-refresh
- Wire HomeScreen "Všetky" button and navigation to new AllCoffeesScreen

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install jest` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c442888960832a9373ddd09dd2b663