### PR TITLE
Add screen for saved recipes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import RecipeStepsScreen from './src/components/RecipeStepsScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
 import ResponsiveWrapper from './src/components/ResponsiveWrapper';
+import SavedRecipesScreen from './src/components/SavedRecipesScreen';
 
 type ScreenName =
   | 'home'
@@ -66,7 +67,7 @@ const AppContent = (): React.JSX.Element => {
   };
 
   const handleRecipesPress = () => {
-    Alert.alert('Recepty', 'Vaše obľúbené recepty budú čoskoro dostupné!');
+    setCurrentScreen('recipes');
   };
 
   const handleFavoritesPress = () => {
@@ -237,6 +238,18 @@ const AppContent = (): React.JSX.Element => {
         statusBarBackground={colors.primary}
       >
         <EditPreferences onBack={() => setCurrentScreen('profile')} />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'recipes') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
+        <SavedRecipesScreen onBack={handleBackPress} />
       </ResponsiveWrapper>
     );
   }

--- a/src/components/SavedRecipesScreen.tsx
+++ b/src/components/SavedRecipesScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
+import { homeStyles } from './styles/HomeScreen.styles';
+import { fetchRecipeHistory, RecipeHistory } from '../services/recipeServices';
+
+interface SavedRecipesScreenProps {
+  onBack: () => void;
+}
+
+const SavedRecipesScreen: React.FC<SavedRecipesScreenProps> = ({ onBack }) => {
+  const styles = homeStyles();
+  const [recipes, setRecipes] = useState<RecipeHistory[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadRecipes = useCallback(async () => {
+    try {
+      const data = await fetchRecipeHistory(20);
+      setRecipes(data);
+    } catch (err) {
+      console.error('Error loading recipes:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRecipes();
+  }, [loadRecipes]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadRecipes();
+    setRefreshing(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.appHeader}>
+        <TouchableOpacity onPress={onBack} style={styles.logoSection}>
+          <Text style={{ color: 'white', fontSize: 18 }}>←</Text>
+        </TouchableOpacity>
+        <Text style={[styles.appTitle, { flex: 1, textAlign: 'center' }]}>Recepty</Text>
+        <View style={{ width: 32 }} />
+      </View>
+      <ScrollView
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        contentContainerStyle={{ padding: 16 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {recipes.length === 0 ? (
+          <Text style={{ textAlign: 'center', color: '#666', marginTop: 20 }}>
+            Žiadne uložené recepty
+          </Text>
+        ) : (
+          recipes.map((item) => (
+            <View
+              key={item.id}
+              style={[styles.coffeeCard, { width: '100%', marginRight: 0, marginBottom: 16 }]}
+            >
+              <Text style={styles.coffeeName}>{item.method}</Text>
+              <Text style={styles.coffeeOrigin}>
+                {new Date(item.created_at).toLocaleDateString('sk-SK')}
+              </Text>
+              <Text style={styles.coffeeOrigin}>{item.recipe}</Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default SavedRecipesScreen;
+


### PR DESCRIPTION
## Summary
- add a SavedRecipesScreen component to show previously saved brewing recipes
- connect the bottom navigation's recipe button to open the new screen

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c497e1e148832ab5fe888af4f05f87