### PR TITLE
fix: prevent bottom nav from hiding content

### DIFF
--- a/src/components/AllCoffeesScreen.tsx
+++ b/src/components/AllCoffeesScreen.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles.ts';
 import { fetchCoffees } from '../services/homePagesService.ts';
-import BottomNav from './BottomNav';
+import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 interface CoffeeItem {
   id: string;
@@ -76,7 +76,7 @@ const AllCoffeesScreen: React.FC<AllCoffeesScreenProps> = ({
       </View>
       <ScrollView
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        contentContainerStyle={{ padding: 16 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: BOTTOM_NAV_HEIGHT }}
         showsVerticalScrollIndicator={false}
       >
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
 import { useTheme } from '../theme/ThemeProvider';
-import { bottomNavStyles } from './styles/BottomNav.styles';
+import { bottomNavStyles, BOTTOM_NAV_HEIGHT } from './styles/BottomNav.styles';
 
 export type NavItem = 'home' | 'discover' | 'recipes' | 'favorites' | 'profile';
 
@@ -52,3 +52,6 @@ const BottomNav: React.FC<BottomNavProps> = ({
 };
 
 export default BottomNav;
+
+// Re-export height constant for convenience when offsetting screen content
+export { BOTTOM_NAV_HEIGHT };

--- a/src/components/CoffeePreferenceForm.tsx
+++ b/src/components/CoffeePreferenceForm.tsx
@@ -15,6 +15,7 @@ import auth from '@react-native-firebase/auth';
 import { getColors } from '../theme/colors';
 import AIResponseDisplay from './AIResponseDisplay';
 import { CONFIG } from '../config/config';
+import { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 const OPENAI_API_KEY = CONFIG.OPENAI_API_KEY;
 
@@ -796,7 +797,7 @@ const createStyles = (isDarkMode: boolean) => {
       fontWeight: '600',
     },
     bottomPadding: {
-      height: 20,
+      height: BOTTOM_NAV_HEIGHT,
     },
     modalContainer: {
       flex: 1,

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles.ts';
 import { fetchCoffees } from '../services/homePagesService.ts';
-import BottomNav from './BottomNav';
+import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 interface CoffeeItem {
   id: string;
@@ -189,6 +189,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
+        contentContainerStyle={{ paddingBottom: BOTTOM_NAV_HEIGHT }}
         showsVerticalScrollIndicator={false}
       >
         {/* Hero Welcome Card */}

--- a/src/components/SavedRecipesScreen.tsx
+++ b/src/components/SavedRecipesScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles';
 import { fetchRecipeHistory, RecipeHistory } from '../services/recipeServices';
-import BottomNav from './BottomNav';
+import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 interface SavedRecipesScreenProps {
   onBack: () => void;
@@ -55,7 +55,7 @@ const SavedRecipesScreen: React.FC<SavedRecipesScreenProps> = ({
       </View>
       <ScrollView
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        contentContainerStyle={{ padding: 16 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: BOTTOM_NAV_HEIGHT }}
         showsVerticalScrollIndicator={false}
       >
         {recipes.length === 0 ? (

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -17,7 +17,7 @@ import auth from '@react-native-firebase/auth';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { unifiedStyles } from '../theme/unifiedStyles';
-import BottomNav from './BottomNav';
+import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 const { width } = Dimensions.get('window');
 const { colors, typography, spacing, componentStyles } = unifiedStyles;
@@ -433,7 +433,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingBottom: getSafeAreaBottom() + scale(20),
+    paddingBottom: getSafeAreaBottom() + BOTTOM_NAV_HEIGHT + scale(20),
   },
   centerContainer: {
     flex: 1,

--- a/src/components/styles/BottomNav.styles.ts
+++ b/src/components/styles/BottomNav.styles.ts
@@ -1,25 +1,31 @@
 import { StyleSheet, Platform } from 'react-native';
 import { Colors } from '../../theme/colors';
 
-export const bottomNavStyles = (colors: Colors) => StyleSheet.create({
-  bottomNav: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: colors.cardBackground,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-    paddingVertical: 12,
-    paddingBottom: Platform.OS === 'ios' ? 28 : 12,
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: -4 },
-    shadowOpacity: 0.08,
-    shadowRadius: 20,
-    elevation: 10,
-  },
+// Estimated height of the bottom navigation bar used to offset scrollable
+// content so it isn't hidden behind the menu.
+export const BOTTOM_NAV_HEIGHT = Platform.OS === 'ios' ? 88 : 64;
+
+export const bottomNavStyles = (colors: Colors) =>
+  StyleSheet.create({
+    bottomNav: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: BOTTOM_NAV_HEIGHT,
+      backgroundColor: colors.cardBackground,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      paddingVertical: 12,
+      paddingBottom: Platform.OS === 'ios' ? 28 : 12,
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: -4 },
+      shadowOpacity: 0.08,
+      shadowRadius: 20,
+      elevation: 10,
+    },
   navItem: {
     alignItems: 'center',
     paddingVertical: 8,


### PR DESCRIPTION
## Summary
- add `BOTTOM_NAV_HEIGHT` constant for bottom navigation
- pad scrollable screens so content stays above bottom menu

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - @react-native-clipboard/clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_68c54764689c832aa756dcc24b79034e