### PR TITLE
Swap discover and favorites screens and add AI chat

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   View,
   TouchableOpacity,
-  Alert,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import AuthScreen from './src/components/AuthVisual.tsx';
@@ -13,6 +12,7 @@ import HomeScreen from './src/components/HomeScreen';
 import CoffeeTasteScanner from './src/components/CoffeeTasteScanner.tsx';
 import CoffeeReceipeScanner from './src/components/CoffeeReceipeScanner.tsx';
 import AllCoffeesScreen from './src/components/AllCoffeesScreen';
+import AIChatScreen from './src/components/AIChatScreen';
 import UserProfile from './src/components/UserProfile';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
@@ -72,7 +72,7 @@ const AppContent = (): React.JSX.Element => {
   };
 
   const handleFavoritesPress = () => {
-    Alert.alert('Obľúbené', 'Vaše obľúbené kávy budú čoskoro dostupné!');
+    setCurrentScreen('favorites');
   };
 
   const handleBackPress = () => {
@@ -284,7 +284,7 @@ const AppContent = (): React.JSX.Element => {
     );
   }
 
-  if (currentScreen === 'discover') {
+  if (currentScreen === 'favorites') {
     return (
       <ResponsiveWrapper
         backgroundColor={colors.background}
@@ -292,6 +292,25 @@ const AppContent = (): React.JSX.Element => {
         statusBarBackground={colors.primary}
       >
         <AllCoffeesScreen
+          onBack={handleBackPress}
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'discover') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
+        <AIChatScreen
           onBack={handleBackPress}
           onHomePress={handleBackPress}
           onDiscoverPress={handleDiscoverPress}

--- a/src/components/AIChatScreen.tsx
+++ b/src/components/AIChatScreen.tsx
@@ -1,0 +1,223 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
+import { useTheme } from '../theme/ThemeProvider';
+import { CONFIG } from '../config/config';
+
+interface AIChatScreenProps {
+  onBack: () => void;
+  onHomePress: () => void;
+  onDiscoverPress: () => void;
+  onRecipesPress: () => void;
+  onFavoritesPress: () => void;
+  onProfilePress: () => void;
+}
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const AIChatScreen: React.FC<AIChatScreenProps> = ({
+  onBack,
+  onHomePress,
+  onDiscoverPress,
+  onRecipesPress,
+  onFavoritesPress,
+  onProfilePress,
+}) => {
+  const { colors } = useTheme();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const newMessages = [...messages, { role: 'user', content: input }];
+    setMessages(newMessages);
+    setInput('');
+
+    try {
+      setLoading(true);
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${CONFIG.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Si priateľský odborník na kávu. Zisťuj preferencie používateľa a odporúčaj kávu, mlynčeky a kávovary.',
+            },
+            ...newMessages.map((m) => ({ role: m.role, content: m.content })),
+          ],
+          temperature: 0.4,
+        }),
+      });
+      const data = await response.json();
+      const reply = data?.choices?.[0]?.message?.content?.trim();
+      if (reply) {
+        setMessages((msgs) => [...msgs, { role: 'assistant', content: reply }]);
+      }
+    } catch (err) {
+      setMessages((msgs) => [
+        ...msgs,
+        { role: 'assistant', content: 'Nastala chyba pri komunikácii s AI.' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const styles = createStyles(colors);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backText}>←</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>AI odporúčania</Text>
+        <View style={{ width: 32 }} />
+      </View>
+      <ScrollView
+        contentContainerStyle={{ padding: 16, paddingBottom: BOTTOM_NAV_HEIGHT }}
+        showsVerticalScrollIndicator={false}
+      >
+        {messages.map((msg, idx) => (
+          <View
+            key={idx}
+            style={[
+              styles.message,
+              msg.role === 'user' ? styles.userMessage : styles.aiMessage,
+            ]}
+          >
+            <Text
+              style={[
+                styles.messageText,
+                msg.role === 'user' ? styles.userText : styles.aiText,
+              ]}
+            >
+              {msg.content}
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          value={input}
+          onChangeText={setInput}
+          placeholder="Napíš otázku o káve..."
+          placeholderTextColor="#999"
+        />
+        <TouchableOpacity
+          onPress={sendMessage}
+          disabled={loading}
+          style={styles.sendButton}
+        >
+          <Text style={styles.sendText}>{loading ? '...' : 'Poslať'}</Text>
+        </TouchableOpacity>
+      </View>
+      <BottomNav
+        active="discover"
+        onHomePress={onHomePress}
+        onDiscoverPress={onDiscoverPress}
+        onRecipesPress={onRecipesPress}
+        onFavoritesPress={onFavoritesPress}
+        onProfilePress={onProfilePress}
+      />
+    </View>
+  );
+};
+
+const createStyles = (colors: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 16,
+      backgroundColor: colors.primary,
+    },
+    backButton: {
+      padding: 4,
+    },
+    backText: {
+      color: 'white',
+      fontSize: 18,
+    },
+    headerTitle: {
+      flex: 1,
+      textAlign: 'center',
+      color: 'white',
+      fontSize: 18,
+      fontWeight: 'bold',
+    },
+    message: {
+      marginBottom: 12,
+      padding: 10,
+      borderRadius: 8,
+      maxWidth: '80%',
+    },
+    userMessage: {
+      alignSelf: 'flex-end',
+      backgroundColor: colors.primary,
+    },
+    aiMessage: {
+      alignSelf: 'flex-start',
+      backgroundColor: '#e0e0e0',
+    },
+    messageText: {
+      fontSize: 16,
+    },
+    userText: {
+      color: 'white',
+    },
+    aiText: {
+      color: '#000',
+    },
+    inputRow: {
+      flexDirection: 'row',
+      padding: 16,
+      borderTopWidth: 1,
+      borderColor: '#ccc',
+      backgroundColor: colors.background,
+    },
+    input: {
+      flex: 1,
+      borderWidth: 1,
+      borderColor: '#ccc',
+      borderRadius: 8,
+      paddingHorizontal: 8,
+      paddingVertical: 6,
+    },
+    sendButton: {
+      marginLeft: 8,
+      backgroundColor: colors.primary,
+      paddingHorizontal: 16,
+      justifyContent: 'center',
+      borderRadius: 8,
+      opacity: 1,
+    },
+    sendText: {
+      color: '#fff',
+      fontWeight: 'bold',
+    },
+  });
+
+export default AIChatScreen;

--- a/src/components/AllCoffeesScreen.tsx
+++ b/src/components/AllCoffeesScreen.tsx
@@ -156,7 +156,7 @@ const AllCoffeesScreen: React.FC<AllCoffeesScreenProps> = ({
 
       </ScrollView>
       <BottomNav
-        active="discover"
+        active="favorites"
         onHomePress={onHomePress}
         onDiscoverPress={onDiscoverPress}
         onRecipesPress={onRecipesPress}


### PR DESCRIPTION
## Summary
- Show coffee list under Favorites tab and move Discover to new AI chat
- Implement AIChatScreen to converse with OpenAI for coffee gear tips
- Update AllCoffeesScreen bottom nav highlighting to match Favorites

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d826b60832a9b156eb3a4ed3c39