### PR TITLE
feat: add onboarding flow with AsyncStorage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import AuthScreen from './src/components/AuthVisual.tsx';
 import HomeScreen from './src/components/HomeScreen';
 import CoffeeTasteScanner from './src/components/CoffeeTasteScanner.tsx';
@@ -18,6 +19,7 @@ import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
 import EditPreferences from './src/components/EditPreferences';
 import RecipeStepsScreen from './src/components/RecipeStepsScreen';
+import OnboardingScreen from './src/components/OnboardingScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
 import ResponsiveWrapper from './src/components/ResponsiveWrapper';
@@ -41,6 +43,8 @@ const AppContent = (): React.JSX.Element => {
   const [currentScreen, setCurrentScreen] = useState<ScreenName>('home');
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [generatedRecipe, setGeneratedRecipe] = useState('');
+  const [isOnboardingComplete, setIsOnboardingComplete] = useState(false);
+  const [checkingOnboarding, setCheckingOnboarding] = useState(true);
   const { isDark, colors } = useTheme();
 
   useEffect(() => {
@@ -48,6 +52,15 @@ const AppContent = (): React.JSX.Element => {
       setIsAuthenticated(!!user);
     });
     return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    const checkOnboarding = async () => {
+      const value = await AsyncStorage.getItem('onboardingComplete');
+      setIsOnboardingComplete(value === 'true');
+      setCheckingOnboarding(false);
+    };
+    checkOnboarding();
   }, []);
 
   const handleScannerPress = () => {
@@ -91,6 +104,22 @@ const AppContent = (): React.JSX.Element => {
         statusBarBackground={colors.background}
       >
         <AuthScreen />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (checkingOnboarding) {
+    return null;
+  }
+
+  if (!isOnboardingComplete) {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <OnboardingScreen onFinish={() => setIsOnboardingComplete(true)} />
       </ResponsiveWrapper>
     );
   }

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -29,6 +29,14 @@ jest.mock(
   { virtual: true },
 );
 
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
 jest.mock('../src/components/CoffeeTasteScanner.tsx', () => 'View');
 
 import App from '../App';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-native-linear-gradient": "^2.8.3",
     "react-native-permissions": "^5.4.1",
     "react-native-vector-icons": "^10.3.0",
-    "react-native-vision-camera": "^4.7.1"
+    "react-native-vision-camera": "^4.7.1",
+    "@react-native-async-storage/async-storage": "^1.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTheme } from '../theme/ThemeProvider';
+
+interface OnboardingScreenProps {
+  onFinish: () => void;
+}
+
+const pages = [
+  {
+    title: 'Vitajte v BrewMate',
+    text: 'Objavte recepty a odporúčania pre vašu dokonalú kávu.',
+  },
+  {
+    title: 'Skenovanie',
+    text: 'Použite fotoaparát na skenovanie kávy a receptov.',
+  },
+  {
+    title: 'Povolenia',
+    text: 'Aplikácia potrebuje prístup k fotoaparátu na skenovanie a k úložisku pre uloženie vašich preferencií.',
+  },
+];
+
+const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onFinish }) => {
+  const [page, setPage] = useState(0);
+  const { colors } = useTheme();
+
+  const handleNext = async () => {
+    if (page < pages.length - 1) {
+      setPage(page + 1);
+    } else {
+      await AsyncStorage.setItem('onboardingComplete', 'true');
+      onFinish();
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <Text style={[styles.title, { color: colors.text }]}>{pages[page].title}</Text>
+      <Text style={[styles.text, { color: colors.textSecondary }]}>{pages[page].text}</Text>
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor: colors.primary }]}
+        onPress={handleNext}
+      >
+        <Text style={[styles.buttonText, { color: colors.cardBackground }]}> 
+          {page === pages.length - 1 ? 'Dokončiť' : 'Ďalej'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  text: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 40,
+  },
+  button: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+
+export default OnboardingScreen;
+


### PR DESCRIPTION
## Summary
- add onboarding screen with short tutorial and permission info
- persist onboarding completion to AsyncStorage
- show onboarding before home screen until completed

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a89fa8f0832a8d282250cf606956