### PR TITLE
feat: add offline OCR caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-native-permissions": "^5.4.1",
     "react-native-vector-icons": "^10.3.0",
     "react-native-vision-camera": "^4.7.1",
-    "@react-native-async-storage/async-storage": "^1.23.1"
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-community/netinfo": "^11.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- check network availability in OCR service
- fallback to cached results when offline and store new scans locally
- add NetInfo dependency

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5adae4b0c832aac54a419569d3e56