### PR TITLE
feat: add offline support and retryable OCR calls

### DIFF
--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -51,6 +51,40 @@ export const scannerStyles = (isDarkMode: boolean = false) => {
       paddingBottom: 20,
     },
 
+    connectionBanner: {
+      padding: 6,
+      alignItems: 'center',
+    },
+    bannerOnline: {
+      backgroundColor: colors.success,
+    },
+    bannerOffline: {
+      backgroundColor: colors.danger,
+    },
+    bannerText: {
+      color: colors.textLight,
+      fontWeight: '600',
+    },
+    offlineModalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    offlineModalContent: {
+      backgroundColor: colors.surface,
+      padding: 20,
+      borderRadius: 10,
+      width: '80%',
+      alignItems: 'center',
+    },
+    offlineModalText: {
+      fontSize: 16,
+      color: colors.textPrimary,
+      textAlign: 'center',
+      marginBottom: 20,
+    },
+
     // Elegant Header
     header: {
       paddingTop: Platform.OS === 'ios' ? 50 : 30,

--- a/src/services/offlineCache.ts
+++ b/src/services/offlineCache.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const LAST_KEY = 'ocr:last';
+
+export const saveOCRResult = async (id: string, payload: any) => {
+  try {
+    await AsyncStorage.setItem(`ocr:${id}`, JSON.stringify(payload));
+    await AsyncStorage.setItem(LAST_KEY, id);
+  } catch (error) {
+    console.error('Error saving OCR result:', error);
+  }
+};
+
+export const loadOCRResult = async (id?: string) => {
+  try {
+    let key = id;
+    if (!key) {
+      key = await AsyncStorage.getItem(LAST_KEY) || undefined;
+      if (!key) return null;
+    }
+    const data = await AsyncStorage.getItem(`ocr:${key}`);
+    return data ? JSON.parse(data) : null;
+  } catch (error) {
+    console.error('Error loading OCR result:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add NetInfo connectivity checks with retryable fetches for OCR/AI calls
- cache OCR results locally for offline reuse
- show connection banner and offline modal with last-result fallback

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b68f8b30832a8d54dc3fcf11451f