### PR TITLE
feat: add brew log tracking

### DIFF
--- a/src/components/BrewHistoryScreen.tsx
+++ b/src/components/BrewHistoryScreen.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, TextInput, Alert } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { BrewLog, BrewDevice } from '../types/BrewLog';
+import { getBrewLogs } from '../services/brewLogService';
+
+const BrewHistoryScreen: React.FC = () => {
+  const [logs, setLogs] = useState<BrewLog[]>([]);
+  const [deviceFilter, setDeviceFilter] = useState<string>('all');
+  const [dateFilter, setDateFilter] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await getBrewLogs();
+      setLogs(data);
+    };
+    load();
+  }, []);
+
+  const filtered = logs.filter((log) => {
+    const byDevice = deviceFilter === 'all' || log.brewDevice === deviceFilter;
+    const byDate = dateFilter === '' || log.date.startsWith(dateFilter);
+    return byDevice && byDate;
+  });
+
+  const renderItem = ({ item }: { item: BrewLog }) => (
+    <TouchableOpacity
+      style={styles.item}
+      onPress={() => Alert.alert('Detail záznamu', JSON.stringify(item, null, 2))}
+    >
+      <Text style={styles.itemTitle}>
+        {new Date(item.date).toLocaleDateString()} - {item.brewDevice}
+      </Text>
+      <Text>{`T:${item.waterTemp}°C D:${item.coffeeDose}g V:${item.waterVolume}ml`}</Text>
+      {item.notes ? <Text style={styles.notes}>{item.notes}</Text> : null}
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.filters}>
+        <Picker
+          selectedValue={deviceFilter}
+          style={styles.devicePicker}
+          onValueChange={(v) => setDeviceFilter(String(v))}
+        >
+          <Picker.Item label="Všetky" value="all" />
+          {Object.values(BrewDevice).map((d) => (
+            <Picker.Item key={d} label={d} value={d} />
+          ))}
+        </Picker>
+        <TextInput
+          style={styles.dateInput}
+          placeholder="YYYY-MM-DD"
+          value={dateFilter}
+          onChangeText={setDateFilter}
+        />
+      </View>
+      <FlatList data={filtered} keyExtractor={(item) => item.id} renderItem={renderItem} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  filters: { flexDirection: 'row', marginBottom: 12 },
+  devicePicker: { flex: 1 },
+  dateInput: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginLeft: 8, flex: 1 },
+  item: { padding: 12, borderBottomWidth: 1, borderColor: '#eee' },
+  itemTitle: { fontWeight: 'bold' },
+  notes: { fontStyle: 'italic' },
+});
+
+export default BrewHistoryScreen;

--- a/src/components/BrewLogForm.tsx
+++ b/src/components/BrewLogForm.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { BrewLog, BrewDevice } from '../types/BrewLog';
+import { saveBrewLog } from '../services/brewLogService';
+
+interface Props {
+  recipeId?: string;
+  initialDevice?: BrewDevice;
+}
+
+const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice }) => {
+  const [waterTemp, setWaterTemp] = useState('');
+  const [coffeeDose, setCoffeeDose] = useState('');
+  const [ratio, setRatio] = useState('');
+  const [grindSize, setGrindSize] = useState('medium');
+  const [brewDevice, setBrewDevice] = useState<BrewDevice>(initialDevice || BrewDevice.V60);
+  const [brewTime, setBrewTime] = useState('');
+  const [notes, setNotes] = useState('');
+  const [errors, setErrors] = useState<{ waterTemp?: string; coffeeDose?: string; ratio?: string }>({});
+
+  const validate = () => {
+    const err: { waterTemp?: string; coffeeDose?: string; ratio?: string } = {};
+    const t = parseFloat(waterTemp);
+    if (isNaN(t) || t < 60 || t > 100) err.waterTemp = 'Teplota musí byť 60–100°C';
+    const d = parseFloat(coffeeDose);
+    if (isNaN(d) || d <= 0) err.coffeeDose = 'Dávka musí byť >0';
+    if (!/^\d+$/.test(ratio) || parseInt(ratio, 10) <= 0) err.ratio = 'Pomer musí byť 1:x';
+    setErrors(err);
+    return Object.keys(err).length === 0;
+  };
+
+  const handleSave = async () => {
+    if (!validate()) return;
+    const ratioNum = parseInt(ratio, 10);
+    const doseNum = parseFloat(coffeeDose);
+    const log: BrewLog = {
+      id: Date.now().toString(),
+      recipeId,
+      date: new Date().toISOString(),
+      waterTemp: parseFloat(waterTemp),
+      grindSize,
+      coffeeDose: doseNum,
+      waterVolume: doseNum * ratioNum,
+      brewTime,
+      notes,
+      brewDevice,
+    };
+    await saveBrewLog(log);
+    setWaterTemp('');
+    setCoffeeDose('');
+    setRatio('');
+    setBrewTime('');
+    setNotes('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Teplota vody (°C)</Text>
+      <TextInput
+        style={styles.input}
+        value={waterTemp}
+        onChangeText={setWaterTemp}
+        keyboardType="numeric"
+      />
+      {errors.waterTemp ? <Text style={styles.error}>{errors.waterTemp}</Text> : null}
+
+      <Text>Dávka kávy (g)</Text>
+      <TextInput
+        style={styles.input}
+        value={coffeeDose}
+        onChangeText={setCoffeeDose}
+        keyboardType="numeric"
+      />
+      {errors.coffeeDose ? <Text style={styles.error}>{errors.coffeeDose}</Text> : null}
+
+      <Text>Pomer (1:x)</Text>
+      <TextInput
+        style={styles.input}
+        value={ratio}
+        onChangeText={setRatio}
+        keyboardType="numeric"
+      />
+      {errors.ratio ? <Text style={styles.error}>{errors.ratio}</Text> : null}
+
+      <Text>Hrubosť mletia</Text>
+      <Picker selectedValue={grindSize} onValueChange={(v) => setGrindSize(String(v))}>
+        <Picker.Item label="Jemná" value="fine" />
+        <Picker.Item label="Stredná" value="medium" />
+        <Picker.Item label="Hrubá" value="coarse" />
+      </Picker>
+
+      <Text>Zariadenie</Text>
+      <Picker selectedValue={brewDevice} onValueChange={(v) => setBrewDevice(v as BrewDevice)}>
+        {Object.values(BrewDevice).map((device) => (
+          <Picker.Item key={device} label={device} value={device} />
+        ))}
+      </Picker>
+
+      <Text>Čas extrakcie</Text>
+      <TextInput
+        style={styles.input}
+        value={brewTime}
+        onChangeText={setBrewTime}
+        placeholder="mm:ss"
+      />
+
+      <Text>Poznámky</Text>
+      <TextInput
+        style={[styles.input, styles.notes]}
+        value={notes}
+        onChangeText={setNotes}
+        multiline
+      />
+
+      <Button title="Uložiť" onPress={handleSave} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 4,
+  },
+  notes: { height: 80, textAlignVertical: 'top' },
+  error: { color: 'red', marginBottom: 8 },
+});
+
+export default BrewLogForm;

--- a/src/components/RecipeStepsScreen.tsx
+++ b/src/components/RecipeStepsScreen.tsx
@@ -13,12 +13,15 @@ import Timer from './Timer';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { colors, spacing, unifiedStyles } from '../theme/unifiedStyles';
 
+import { useNavigation } from '@react-navigation/native';
 interface RecipeStepsScreenProps {
   recipe: string;
+  recipeId?: string;
   onBack: () => void;
 }
 
-const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, onBack }) => {
+const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, recipeId, onBack }) => {
+  const navigation = useNavigation<any>();
   const { colors: themeColors } = useTheme();
   const { colors, typography, spacing, componentStyles } = unifiedStyles;
   const steps = useMemo(() => formatRecipeSteps(recipe), [recipe]);
@@ -127,7 +130,7 @@ const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, onBack })
           ]}
           onPress={() => {
             if (currentStep === steps.length - 1) {
-              onBack();
+              navigation.navigate('BrewLog', { recipeId });
             } else {
               setCurrentStep(currentStep + 1);
             }

--- a/src/services/brewLogService.ts
+++ b/src/services/brewLogService.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BrewLog } from '../types/BrewLog';
+import { Platform, ToastAndroid, Alert } from 'react-native';
+
+const STORAGE_KEY = 'brewLogs';
+
+export const saveBrewLog = async (log: BrewLog): Promise<void> => {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  const logs: BrewLog[] = raw ? JSON.parse(raw) : [];
+  logs.push(log);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+  if (Platform.OS === 'android') {
+    ToastAndroid.show('Záznam uložený', ToastAndroid.SHORT);
+  } else {
+    Alert.alert('Záznam uložený');
+  }
+};
+
+export const getBrewLogs = async (recipeId?: string): Promise<BrewLog[]> => {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  let logs: BrewLog[] = raw ? JSON.parse(raw) : [];
+  if (recipeId) {
+    logs = logs.filter((l) => l.recipeId === recipeId);
+  }
+  return logs;
+};

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,0 +1,29 @@
+import { getBrewLogs } from './brewLogService';
+import { BrewLog } from '../types/BrewLog';
+
+export const exportBrewLogsToCSV = async (recipeId?: string): Promise<string> => {
+  const logs: BrewLog[] = await getBrewLogs(recipeId);
+  const headers = [
+    'date',
+    'brewDevice',
+    'waterTemp',
+    'grindSize',
+    'coffeeDose',
+    'waterVolume',
+    'brewTime',
+    'notes',
+  ];
+  const rows = logs.map((log) =>
+    [
+      log.date,
+      log.brewDevice,
+      log.waterTemp,
+      log.grindSize,
+      log.coffeeDose,
+      log.waterVolume,
+      log.brewTime,
+      log.notes?.replace(/\n/g, ' '),
+    ].join(',')
+  );
+  return [headers.join(','), ...rows].join('\n');
+};

--- a/src/types/BrewLog.ts
+++ b/src/types/BrewLog.ts
@@ -1,0 +1,23 @@
+export enum BrewDevice {
+  V60 = 'V60',
+  Aeropress = 'Aeropress',
+  Espresso = 'Espresso',
+  FrenchPress = 'FrenchPress',
+  Chemex = 'Chemex',
+  Other = 'Other',
+}
+
+export interface BrewLog {
+  id: string;
+  recipeId?: string;
+  date: string;
+  waterTemp: number;
+  grindSize: string;
+  coffeeDose: number;
+  waterVolume: number;
+  brewTime: string;
+  notes: string;
+  brewDevice: BrewDevice;
+}
+
+export type BrewLogs = BrewLog[];


### PR DESCRIPTION
## Summary
- add BrewLog data types and service for AsyncStorage persistence
- add BrewLogForm and history UI with validation and filtering
- navigate to BrewLog from recipe steps and export logs to CSV

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b84cbe54832ab08e1403e1157ab9