### PR TITLE
feat: add quick scan widgets

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,5 +29,15 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+      <receiver
+        android:name=".QuickScanWidgetProvider"
+        android:exported="false">
+        <intent-filter>
+          <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+        </intent-filter>
+        <meta-data
+          android:name="android.appwidget.provider"
+          android:resource="@xml/quickscan_widget_info" />
+      </receiver>
     </application>
 </manifest>

--- a/android/app/src/main/java/com/brewmatenew/QuickScanWidgetProvider.kt
+++ b/android/app/src/main/java/com/brewmatenew/QuickScanWidgetProvider.kt
@@ -1,0 +1,28 @@
+package com.brewmatenew
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+
+class QuickScanWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (appWidgetId in appWidgetIds) {
+            val views = RemoteViews(context.packageName, R.layout.widget_quickscan)
+
+            val prefs = context.getSharedPreferences("BrewMateWidget", Context.MODE_PRIVATE)
+            val tip = prefs.getString("dailyTip", "") ?: ""
+            views.setTextViewText(R.id.txt_tip, tip)
+
+            val intent = Intent(context, MainActivity::class.java).apply {
+                putExtra("route", "Scanner")
+            }
+            val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+            views.setOnClickPendingIntent(R.id.btn_scan, pendingIntent)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+}

--- a/android/app/src/main/res/layout/widget_quickscan.xml
+++ b/android/app/src/main/res/layout/widget_quickscan.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/btn_scan"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Scan" />
+
+    <TextView
+        android:id="@+id/txt_tip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Tip"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/android/app/src/main/res/xml/quickscan_widget_info.xml
+++ b/android/app/src/main/res/xml/quickscan_widget_info.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="120dp"
+    android:minHeight="60dp"
+    android:updatePeriodMillis="86400000"
+    android:initialLayout="@layout/widget_quickscan"
+    android:widgetCategory="home_screen" />

--- a/app.json
+++ b/app.json
@@ -1,4 +1,10 @@
 {
   "name": "BrewMateNew",
-  "displayName": "BrewMateNew"
+  "displayName": "BrewMateNew",
+  "expo": {
+    "widgets": {
+      "name": "BrewMateWidget",
+      "description": "Quick scan widget showing daily tips"
+    }
+  }
 }

--- a/content/dailyTips.json
+++ b/content/dailyTips.json
@@ -1,0 +1,4 @@
+[
+  "Clean your equipment before brewing for best taste.",
+  "Use fresh water for a crisper brew."
+]

--- a/ios/BrewMateWidget/Info.plist
+++ b/ios/BrewMateWidget/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).BrewMateWidget</string>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>WKAppBundleIdentifier</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/ios/BrewMateWidget/Widget.swift
+++ b/ios/BrewMateWidget/Widget.swift
@@ -1,0 +1,55 @@
+import WidgetKit
+import SwiftUI
+
+struct DailyTipEntry: TimelineEntry {
+    let date: Date
+    let tip: String
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> DailyTipEntry {
+        DailyTipEntry(date: Date(), tip: "Loading tip...")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (DailyTipEntry) -> ()) {
+        fetchDailyTip { tip in
+            completion(DailyTipEntry(date: Date(), tip: tip))
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<DailyTipEntry>) -> ()) {
+        fetchDailyTip { tip in
+            let entry = DailyTipEntry(date: Date(), tip: tip)
+            let next = Calendar.current.startOfDay(for: Date().addingTimeInterval(86400))
+            completion(Timeline(entries: [entry], policy: .after(next)))
+        }
+    }
+}
+
+func fetchDailyTip(completion: @escaping (String) -> Void) {
+    let tip = UserDefaults.standard.string(forKey: "dailyTip") ?? "Enjoy your brew!"
+    completion(tip)
+}
+
+struct WidgetEntryView: View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Link("Scan", destination: URL(string: "brewMate://scan")!)
+            Text(entry.tip).font(.caption)
+        }
+        .padding()
+    }
+}
+
+@main
+struct BrewMateWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "BrewMateWidget", provider: Provider()) { entry in
+            WidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("BrewMate Quick Scan")
+        .description("Quick access to scan and daily tips.")
+    }
+}

--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import tips from '../../content/dailyTips.json';
+
+const TIP_KEY = 'dailyTip';
+
+export async function fetchDailyTip(): Promise<string> {
+  const today = new Date().toDateString();
+  try {
+    const cachedRaw = await AsyncStorage.getItem(TIP_KEY);
+    if (cachedRaw) {
+      const cached = JSON.parse(cachedRaw);
+      if (cached.date === today && cached.tip) {
+        return cached.tip;
+      }
+    }
+  } catch (e) {
+    // ignore parsing errors
+  }
+
+  let tip = tips[Math.floor(Math.random() * tips.length)];
+  // TODO: Optionally fetch from remote API here
+
+  try {
+    await AsyncStorage.setItem(TIP_KEY, JSON.stringify({ date: today, tip }));
+  } catch (e) {
+    // ignore write errors
+  }
+  scheduleNextUpdate();
+  return tip;
+}
+
+function scheduleNextUpdate() {
+  const now = new Date();
+  const midnight = new Date(now);
+  midnight.setHours(24, 0, 0, 0);
+  const timeout = midnight.getTime() - now.getTime();
+  setTimeout(fetchDailyTip, timeout);
+}
+
+export default fetchDailyTip;


### PR DESCRIPTION
## Summary
- add QuickScan Android widget with provider, layout, and manifest entry
- implement iOS BrewMateWidget timeline with daily tip and scan link
- create shared daily tip utility and sample tips data
- register widget metadata in app config

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b93ab2c8832a8523593d2a9963c1