### PR TITLE
Add badge progress tracking and profile UI

### DIFF
--- a/src/components/CoffeeTasteScanner.tsx
+++ b/src/components/CoffeeTasteScanner.tsx
@@ -33,6 +33,7 @@ import {
   markCoffeePurchased,
   extractCoffeeName
 } from '../services/ocrServices.ts';
+import { incrementProgress } from '../services/profileServices';
 import { saveOCRResult, loadOCRResult } from '../services/offlineCache';
 
 interface OCRHistory {
@@ -183,6 +184,13 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
         setPurchaseSelection(null);
         setPurchased(null);
         await saveOCRResult(result.scanId || 'last', result);
+
+        // Update user progress for successful scan
+        try {
+          await incrementProgress('scan');
+        } catch (e) {
+          console.error('Failed to update progress', e);
+        }
 
         // Načítaj aktualizovanú históriu
         await loadHistory();

--- a/src/components/RecipeStepsScreen.tsx
+++ b/src/components/RecipeStepsScreen.tsx
@@ -12,15 +12,17 @@ import { formatRecipeSteps } from './utils/AITextFormatter';
 import Timer from './Timer';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { colors, spacing, unifiedStyles } from '../theme/unifiedStyles';
+import { incrementProgress } from '../services/profileServices';
 
 import { useNavigation } from '@react-navigation/native';
 interface RecipeStepsScreenProps {
   recipe: string;
   recipeId?: string;
+  brewDevice?: string;
   onBack: () => void;
 }
 
-const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, recipeId, onBack }) => {
+const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, recipeId, brewDevice, onBack }) => {
   const navigation = useNavigation<any>();
   const { colors: themeColors } = useTheme();
   const { colors, typography, spacing, componentStyles } = unifiedStyles;
@@ -128,8 +130,13 @@ const RecipeStepsScreen: React.FC<RecipeStepsScreenProps> = ({ recipe, recipeId,
             styles.navButtonPrimary,
             currentStep === steps.length - 1 && styles.navButtonComplete,
           ]}
-          onPress={() => {
+          onPress={async () => {
             if (currentStep === steps.length - 1) {
+              try {
+                await incrementProgress('recipe', brewDevice || 'generic');
+              } catch (e) {
+                console.error('Failed to update progress', e);
+              }
               navigation.navigate('BrewLog', { recipeId });
             } else {
               setCurrentStep(currentStep + 1);

--- a/src/data/badges.ts
+++ b/src/data/badges.ts
@@ -1,0 +1,49 @@
+export interface Badge {
+  id: string;
+  title: string;
+  description: string;
+  icon: string; // placeholder string or path to icon
+  criteria: {
+    type: 'scan' | 'recipe';
+    count: number;
+    device?: string;
+  };
+}
+
+export const badges: Badge[] = [
+  {
+    id: 'scan_10',
+    title: 'Skener Nováčik',
+    description: 'Vykonaj 10 skenov kávy',
+    icon: '🔍',
+    criteria: { type: 'scan', count: 10 },
+  },
+  {
+    id: 'scan_50',
+    title: 'Skener Expert',
+    description: 'Vykonaj 50 skenov kávy',
+    icon: '🔎',
+    criteria: { type: 'scan', count: 50 },
+  },
+  {
+    id: 'recipe_espresso_5',
+    title: 'Espresso Učeň',
+    description: 'Dokonči 5 espresso receptov',
+    icon: '☕',
+    criteria: { type: 'recipe', device: 'espresso', count: 5 },
+  },
+  {
+    id: 'recipe_pourover_10',
+    title: 'Pour Over Majster',
+    description: 'Dokonči 10 pour-over receptov',
+    icon: '🫖',
+    criteria: { type: 'recipe', device: 'pourover', count: 10 },
+  },
+  {
+    id: 'all_rounder',
+    title: 'Všestranný Barista',
+    description: 'Dosiahni 20 skenov a 20 receptov',
+    icon: '🏆',
+    criteria: { type: 'scan', count: 20 }, // additional check in code for recipes
+  },
+];

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { View, Text, FlatList, StyleSheet, Modal, Animated } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { badges, Badge } from '../data/badges';
+import { getUserProgress, UserProgress } from '../services/profileServices';
+
+const ProfileScreen: React.FC = () => {
+  const [progress, setProgress] = useState<UserProgress | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [newBadge, setNewBadge] = useState<Badge | null>(null);
+  const scaleAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const load = async () => {
+      const p = await getUserProgress();
+      setProgress(p);
+      if (p.lastBadge) {
+        const badge = badges.find((b) => b.id === p.lastBadge) || null;
+        setNewBadge(badge);
+        setModalVisible(true);
+        Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true }).start();
+        p.lastBadge = undefined;
+        await AsyncStorage.setItem('userProgress', JSON.stringify(p));
+      }
+    };
+    load();
+  }, [scaleAnim]);
+
+  const unlocked = progress?.badges || [];
+
+  const renderBadge = ({ item }: { item: Badge }) => {
+    const isUnlocked = unlocked.includes(item.id);
+    return (
+      <View style={[styles.badge, { opacity: isUnlocked ? 1 : 0.3 }]}> 
+        <Text style={styles.badgeIcon}>{item.icon}</Text>
+        <Text style={styles.badgeText}>{item.title}</Text>
+      </View>
+    );
+  };
+
+  const levelPercent = progress ? ((progress.level - 1) / 9) * 100 : 0;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.levelText}>Úroveň {progress?.level || 1}/10</Text>
+      <View style={styles.progressBar}>
+        <View style={[styles.progressFill, { width: `${levelPercent}%` }]} />
+      </View>
+
+      <FlatList
+        data={badges}
+        renderItem={renderBadge}
+        keyExtractor={(item) => item.id}
+        numColumns={3}
+        contentContainerStyle={styles.badgeGrid}
+      />
+
+      <Modal visible={modalVisible} transparent animationType="fade">
+        <View style={styles.modalBackdrop}>
+          <Animated.View style={[styles.modalContent, { transform: [{ scale: scaleAnim }] }]}> 
+            <Text style={styles.modalEmoji}>🎉</Text>
+            <Text style={styles.modalText}>Gratulujeme!</Text>
+            {newBadge && <Text style={styles.modalBadgeTitle}>{newBadge.title}</Text>}
+          </Animated.View>
+        </View>
+      </Modal>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  levelText: { fontSize: 18, marginBottom: 10, textAlign: 'center' },
+  progressBar: { height: 10, backgroundColor: '#eee', borderRadius: 5, overflow: 'hidden', marginBottom: 20 },
+  progressFill: { height: '100%', backgroundColor: '#6B4423' },
+  badgeGrid: { alignItems: 'center' },
+  badge: { width: '30%', margin: '1.5%', alignItems: 'center' },
+  badgeIcon: { fontSize: 32 },
+  badgeText: { fontSize: 12, textAlign: 'center', marginTop: 4 },
+  modalBackdrop: { flex:1, backgroundColor:'rgba(0,0,0,0.5)', justifyContent:'center', alignItems:'center' },
+  modalContent: { backgroundColor:'#fff', padding:30, borderRadius:10, alignItems:'center' },
+  modalEmoji: { fontSize:48, marginBottom:10 },
+  modalText: { fontSize:20, fontWeight:'bold', marginBottom:10 },
+  modalBadgeTitle: { fontSize:16 },
+});
+
+export default ProfileScreen;

--- a/src/services/apiBadges.ts
+++ b/src/services/apiBadges.ts
@@ -1,0 +1,14 @@
+import { API_URL } from './api';
+
+export async function getBadgesFromApi() {
+  const res = await fetch(`${API_URL}/badges`);
+  return res.json();
+}
+
+export async function saveBadgesToApi(badges: string[], level: number) {
+  await fetch(`${API_URL}/badges`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ badges, level }),
+  });
+}

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,4 @@
+export async function scheduleLocalNotification(title: string, body: string) {
+  // Placeholder implementation; real notifications will use native APIs
+  console.log(`Notification scheduled: ${title} - ${body}`);
+}

--- a/src/services/profileServices.ts
+++ b/src/services/profileServices.ts
@@ -1,0 +1,87 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { badges, Badge } from '../data/badges';
+import { scheduleLocalNotification } from './notificationService';
+
+const STORAGE_KEY = 'userProgress';
+
+export interface UserProgress {
+  level: number;
+  scan: number;
+  recipes: Record<string, number>;
+  badges: string[];
+  lastBadge?: string;
+}
+
+const defaultProgress: UserProgress = {
+  level: 1,
+  scan: 0,
+  recipes: {},
+  badges: [],
+};
+
+export async function getUserProgress(): Promise<UserProgress> {
+  const raw = await AsyncStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    return JSON.parse(raw);
+  }
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(defaultProgress));
+  return { ...defaultProgress };
+}
+
+async function saveProgress(progress: UserProgress) {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+}
+
+export async function incrementProgress(eventType: 'scan' | 'recipe', brewDevice?: string): Promise<Badge[]> {
+  const progress = await getUserProgress();
+
+  if (eventType === 'scan') {
+    progress.scan += 1;
+  } else if (eventType === 'recipe' && brewDevice) {
+    progress.recipes[brewDevice] = (progress.recipes[brewDevice] || 0) + 1;
+  }
+
+  const totalEvents = progress.scan + Object.values(progress.recipes).reduce((a, b) => a + b, 0);
+  progress.level = Math.min(10, Math.floor(totalEvents / 10) + 1);
+
+  const newlyUnlocked: Badge[] = [];
+
+  badges.forEach((badge) => {
+    if (!progress.badges.includes(badge.id)) {
+      if (badge.criteria.type === 'scan') {
+        if (progress.scan >= badge.criteria.count) {
+          if (badge.id === 'all_rounder') {
+            const totalRecipes = Object.values(progress.recipes).reduce((a, b) => a + b, 0);
+            if (totalRecipes >= 20) {
+              progress.badges.push(badge.id);
+              newlyUnlocked.push(badge);
+            }
+          } else {
+            progress.badges.push(badge.id);
+            newlyUnlocked.push(badge);
+          }
+        }
+      } else if (badge.criteria.type === 'recipe') {
+        const deviceCount = progress.recipes[badge.criteria.device || ''] || 0;
+        if (deviceCount >= badge.criteria.count) {
+          progress.badges.push(badge.id);
+          newlyUnlocked.push(badge);
+        }
+      }
+    }
+  });
+
+  if (newlyUnlocked.length > 0) {
+    const first = newlyUnlocked[0];
+    progress.lastBadge = first.id;
+    await scheduleLocalNotification('Nový odznak', first.title);
+  }
+
+  await saveProgress(progress);
+  return newlyUnlocked;
+}
+
+export async function getUnlockedBadges(): Promise<Badge[]> {
+  const progress = await getUserProgress();
+  return badges.filter((b) => progress.badges.includes(b.id));
+}


### PR DESCRIPTION
## Summary
- Define badge metadata and criteria
- Track user progress and unlocked badges with AsyncStorage
- Show progress and badges on new profile screen and update on scans/recipes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68c690c44414832aa8f9e7dfe68a9817