### PR TITLE
feat: add inventory reminders and calendar integration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,7 @@ import { scale } from './src/theme/responsive';
 import ResponsiveWrapper from './src/components/ResponsiveWrapper';
 import SavedRecipesScreen from './src/components/SavedRecipesScreen';
 import BottomNav from './src/components/BottomNav';
+import { scheduleLowStockCheck } from './src/utils/reminders';
 
 type ScreenName =
   | 'home'
@@ -61,6 +62,20 @@ const AppContent = (): React.JSX.Element => {
       setCheckingOnboarding(false);
     };
     checkOnboarding();
+  }, []);
+
+  useEffect(() => {
+    scheduleLowStockCheck();
+    const now = new Date();
+    const next = new Date();
+    next.setHours(9, 0, 0, 0);
+    let timeout = next.getTime() - now.getTime();
+    if (timeout < 0) timeout += 24 * 60 * 60 * 1000;
+    const timer = setTimeout(() => {
+      scheduleLowStockCheck();
+      setInterval(scheduleLowStockCheck, 24 * 60 * 60 * 1000);
+    }, timeout);
+    return () => clearTimeout(timer);
   }, []);
 
   const handleScannerPress = () => {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "react-native-permissions": "^5.4.1",
     "react-native-vector-icons": "^10.3.0",
     "react-native-vision-camera": "^4.7.1",
-    "@react-native-async-storage/async-storage": "^1.23.1"
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "react-native-push-notification": "^8.1.1",
+    "@react-native-community/push-notification-ios": "^1.11.0",
+    "react-native-add-calendar-event": "^4.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/screens/InventoryScreen.tsx
+++ b/src/screens/InventoryScreen.tsx
@@ -1,0 +1,119 @@
+import React, {useEffect, useState} from 'react';
+import {View, Text, Button, TextInput, FlatList} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import PushNotification from 'react-native-push-notification';
+import AddCalendarEvent from 'react-native-add-calendar-event';
+import {InventoryItem} from '../types/InventoryItem';
+import {scheduleReminder} from '../utils/reminders';
+
+const InventoryScreen = (): React.JSX.Element => {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [reminders, setReminders] = useState<any[]>([]);
+  const [form, setForm] = useState({
+    coffeeName: '',
+    gramsLeft: '',
+    dailyUsage: '',
+    reminderDate: '',
+  });
+
+  const loadItems = async () => {
+    const data = await AsyncStorage.getItem('inventory');
+    if (data) setItems(JSON.parse(data));
+  };
+
+  const loadReminders = () => {
+    PushNotification.getScheduledLocalNotifications((n) => setReminders(n));
+  };
+
+  useEffect(() => {
+    loadItems();
+    loadReminders();
+  }, []);
+
+  const saveItems = async (newItems: InventoryItem[]) => {
+    setItems(newItems);
+    await AsyncStorage.setItem('inventory', JSON.stringify(newItems));
+  };
+
+  const addItem = async () => {
+    const newItem: InventoryItem = {
+      id: Date.now().toString(),
+      coffeeName: form.coffeeName,
+      gramsLeft: parseFloat(form.gramsLeft),
+      dailyUsage: parseFloat(form.dailyUsage),
+      reminderDate: form.reminderDate || undefined,
+    };
+    const updated = [...items, newItem];
+    await saveItems(updated);
+    if (form.reminderDate) {
+      scheduleReminder(new Date(form.reminderDate), `${form.coffeeName} reminder`);
+      loadReminders();
+    }
+    setForm({coffeeName: '', gramsLeft: '', dailyUsage: '', reminderDate: ''});
+  };
+
+  const cancelReminder = (id: string) => {
+    PushNotification.cancelLocalNotification(id);
+    loadReminders();
+  };
+
+  const addToCalendar = (item: InventoryItem) => {
+    AddCalendarEvent.presentEventCreatingDialog({
+      title: item.coffeeName,
+      startDate: item.reminderDate || new Date().toISOString(),
+    });
+  };
+
+  return (
+    <View>
+      <FlatList
+        data={items}
+        keyExtractor={(i) => i.id}
+        renderItem={({item}) => (
+          <View>
+            <Text>
+              {item.coffeeName} - {item.gramsLeft}g
+            </Text>
+            <Button
+              title="Pridať brew session do kalendára"
+              onPress={() => addToCalendar(item)}
+            />
+          </View>
+        )}
+      />
+      <Text>Pridať položku</Text>
+      <TextInput
+        placeholder="coffeeName"
+        value={form.coffeeName}
+        onChangeText={(t) => setForm({...form, coffeeName: t})}
+      />
+      <TextInput
+        placeholder="gramsLeft"
+        keyboardType="numeric"
+        value={form.gramsLeft}
+        onChangeText={(t) => setForm({...form, gramsLeft: t})}
+      />
+      <TextInput
+        placeholder="dailyUsage"
+        keyboardType="numeric"
+        value={form.dailyUsage}
+        onChangeText={(t) => setForm({...form, dailyUsage: t})}
+      />
+      <TextInput
+        placeholder="reminderDate"
+        value={form.reminderDate}
+        onChangeText={(t) => setForm({...form, reminderDate: t})}
+      />
+      <Button title="Uložiť" onPress={addItem} />
+      <Text>Aktívne pripomienky</Text>
+      {reminders.map((r) => (
+        <View key={r.id}>
+          <Text>{r.message}</Text>
+          <Button title="Zrušiť" onPress={() => cancelReminder(r.id)} />
+        </View>
+      ))}
+    </View>
+  );
+};
+
+export default InventoryScreen;

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,0 +1,42 @@
+import { Platform } from 'react-native';
+import PushNotification, {Importance} from 'react-native-push-notification';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+
+class NotificationService {
+  constructor() {
+    this.configure();
+  }
+
+  configure() {
+    PushNotification.configure({
+      onRegister: () => {},
+      onNotification: (notification) => {
+        if (Platform.OS === 'ios') {
+          notification.finish(PushNotificationIOS.FetchResult.NoData);
+        }
+      },
+      requestPermissions: Platform.OS === 'ios'
+    });
+
+    PushNotification.createChannel(
+      {
+        channelId: 'default-channel',
+        channelName: 'General Notifications',
+        importance: Importance.HIGH,
+      },
+      () => {}
+    );
+  }
+
+  requestPermissions() {
+    if (Platform.OS === 'ios') {
+      PushNotificationIOS.requestPermissions();
+    }
+  }
+
+  cancelLocalNotification(id: string) {
+    PushNotification.cancelLocalNotification(id);
+  }
+}
+
+export default new NotificationService();

--- a/src/types/InventoryItem.ts
+++ b/src/types/InventoryItem.ts
@@ -1,0 +1,7 @@
+export interface InventoryItem {
+  id: string;
+  coffeeName: string;
+  gramsLeft: number;
+  dailyUsage: number;
+  reminderDate?: string;
+}

--- a/src/utils/reminders.ts
+++ b/src/utils/reminders.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import PushNotification from 'react-native-push-notification';
+import { InventoryItem } from '../types/InventoryItem';
+
+export const scheduleReminder = (date: Date, message: string): string => {
+  const id = Date.now().toString();
+  PushNotification.localNotificationSchedule({
+    channelId: 'default-channel',
+    message,
+    date,
+    allowWhileIdle: true,
+    id,
+  });
+  return id;
+};
+
+export const scheduleLowStockCheck = async (): Promise<void> => {
+  const data = await AsyncStorage.getItem('inventory');
+  if (!data) return;
+  const items: InventoryItem[] = JSON.parse(data);
+  const now = new Date();
+  items.forEach((item) => {
+    if (item.dailyUsage > 0) {
+      const daysLeft = item.gramsLeft / item.dailyUsage;
+      const depletion = new Date(now.getTime() + daysLeft * 86400000);
+      const reminderDate = new Date(depletion.getTime() - 3 * 86400000);
+      if (reminderDate > now) {
+        scheduleReminder(reminderDate, `${item.coffeeName} is running low`);
+      }
+    }
+  });
+};
+


### PR DESCRIPTION
## Summary
- add push notification and calendar dependencies
- implement NotificationService and reminder utilities
- create inventory management screen with calendar and reminder support
- schedule low stock checks at app startup and daily at 9:00

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@react-native-async-storage%2fasync-storage)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69a4785a4832a84a4f656ee4a39a2