### PR TITLE
feat: add brew device selection and filtering

### DIFF
--- a/db/create_brew_recipes_table.sql
+++ b/db/create_brew_recipes_table.sql
@@ -5,6 +5,7 @@ create table if not exists brew_recipes (
     method text not null,
     taste text,
     recipe text not null,
+    brew_device text,
     created_at timestamptz default now()
 );
 
@@ -25,3 +26,4 @@ begin
 end $$;
 
 create index if not exists brew_recipes_user_id_idx on brew_recipes(user_id);
+alter table brew_recipes add column if not exists brew_device text;

--- a/src/components/AIChatScreen.tsx
+++ b/src/components/AIChatScreen.tsx
@@ -7,9 +7,11 @@ import {
   ScrollView,
   StyleSheet,
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 import { useTheme } from '../theme/ThemeProvider';
 import { CONFIG } from '../config/config';
+import { BrewDevice, BREW_DEVICES } from '../types/Recipe';
 
 interface AIChatScreenProps {
   onBack: () => void;
@@ -37,6 +39,7 @@ const AIChatScreen: React.FC<AIChatScreenProps> = ({
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [brewDevice, setBrewDevice] = useState<BrewDevice>(BREW_DEVICES[0]);
 
   const sendMessage = async () => {
     if (!input.trim()) return;
@@ -57,12 +60,12 @@ const AIChatScreen: React.FC<AIChatScreenProps> = ({
           messages: [
             {
               role: 'system',
-              content:
-                'Si priateľský odborník na kávu. Zisťuj preferencie používateľa a odporúčaj kávu, mlynčeky a kávovary.',
+              content: `Si priateľský odborník na kávu. Zisťuj preferencie používateľa a odporúčaj kávu, mlynčeky a kávovary. Generuj recept pre zariadenie ${brewDevice}.`,
             },
             ...newMessages.map((m) => ({ role: m.role, content: m.content })),
           ],
           temperature: 0.4,
+          brewDevice,
         }),
       });
       const data = await response.json();
@@ -91,6 +94,15 @@ const AIChatScreen: React.FC<AIChatScreenProps> = ({
         <Text style={styles.headerTitle}>AI odporúčania</Text>
         <View style={{ width: 32 }} />
       </View>
+      <Picker
+        selectedValue={brewDevice}
+        onValueChange={(v) => setBrewDevice(v as BrewDevice)}
+        style={styles.devicePicker}
+      >
+        {BREW_DEVICES.map((d) => (
+          <Picker.Item key={d} label={d} value={d} />
+        ))}
+      </Picker>
       <ScrollView
         contentContainerStyle={{ padding: 16, paddingBottom: BOTTOM_NAV_HEIGHT }}
         showsVerticalScrollIndicator={false}
@@ -197,6 +209,9 @@ const createStyles = (colors: any) =>
       borderTopWidth: 1,
       borderColor: '#ccc',
       backgroundColor: colors.background,
+    },
+    devicePicker: {
+      marginHorizontal: 16,
     },
     input: {
       flex: 1,

--- a/src/components/BrewHistoryScreen.tsx
+++ b/src/components/BrewHistoryScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet, TextInput, Alert } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
-import { BrewLog, BrewDevice } from '../types/BrewLog';
+import { BrewLog } from '../types/BrewLog';
+import { BREW_DEVICES } from '../types/Recipe';
 import { getBrewLogs } from '../services/brewLogService';
 
 const BrewHistoryScreen: React.FC = () => {
@@ -45,7 +46,7 @@ const BrewHistoryScreen: React.FC = () => {
           onValueChange={(v) => setDeviceFilter(String(v))}
         >
           <Picker.Item label="Všetky" value="all" />
-          {Object.values(BrewDevice).map((d) => (
+          {BREW_DEVICES.map((d) => (
             <Picker.Item key={d} label={d} value={d} />
           ))}
         </Picker>

--- a/src/components/BrewLogForm.tsx
+++ b/src/components/BrewLogForm.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
-import { BrewLog, BrewDevice } from '../types/BrewLog';
+import { BrewLog } from '../types/BrewLog';
+import { BrewDevice, BREW_DEVICES } from '../types/Recipe';
 import { saveBrewLog } from '../services/brewLogService';
 
 interface Props {
@@ -14,7 +15,7 @@ const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice }) => {
   const [coffeeDose, setCoffeeDose] = useState('');
   const [ratio, setRatio] = useState('');
   const [grindSize, setGrindSize] = useState('medium');
-  const [brewDevice, setBrewDevice] = useState<BrewDevice>(initialDevice || BrewDevice.V60);
+  const [brewDevice, setBrewDevice] = useState<BrewDevice>(initialDevice || BREW_DEVICES[0]);
   const [brewTime, setBrewTime] = useState('');
   const [notes, setNotes] = useState('');
   const [errors, setErrors] = useState<{ waterTemp?: string; coffeeDose?: string; ratio?: string }>({});
@@ -92,7 +93,7 @@ const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice }) => {
 
       <Text>Zariadenie</Text>
       <Picker selectedValue={brewDevice} onValueChange={(v) => setBrewDevice(v as BrewDevice)}>
-        {Object.values(BrewDevice).map((device) => (
+        {BREW_DEVICES.map((device) => (
           <Picker.Item key={device} label={device} value={device} />
         ))}
       </Picker>

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { Recipe, BrewDevice, BREW_DEVICES } from '../types/Recipe';
+import { createRecipe } from '../services/recipeServices';
+
+const RecipeForm: React.FC = () => {
+  const [title, setTitle] = useState('');
+  const [instructions, setInstructions] = useState('');
+  const [brewDevice, setBrewDevice] = useState<BrewDevice>(BREW_DEVICES[0]);
+  const [error, setError] = useState('');
+
+  const handleSave = async () => {
+    if (!brewDevice) {
+      setError('Vyberte zariadenie');
+      return;
+    }
+    const recipe: Recipe = {
+      id: '',
+      title,
+      instructions,
+      brewDevice,
+    };
+    await createRecipe(recipe);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Názov</Text>
+      <TextInput style={styles.input} value={title} onChangeText={setTitle} />
+      <Text>Postup</Text>
+      <TextInput
+        style={[styles.input, styles.textArea]}
+        value={instructions}
+        onChangeText={setInstructions}
+        multiline
+      />
+      <Text>Zariadenie</Text>
+      <Picker selectedValue={brewDevice} onValueChange={(v) => setBrewDevice(v as BrewDevice)}>
+        {BREW_DEVICES.map((d) => (
+          <Picker.Item key={d} label={d} value={d} />
+        ))}
+      </Picker>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Button title="Uložiť" onPress={handleSave} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 8 },
+  textArea: { height: 80, textAlignVertical: 'top' },
+  error: { color: 'red' },
+});
+
+export default RecipeForm;

--- a/src/components/RecipeStepsScreen.tsx
+++ b/src/components/RecipeStepsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../theme/ThemeProvider';
 import { formatRecipeSteps } from './utils/AITextFormatter';
+import { BrewDevice } from '../types/Recipe';
 import Timer from './Timer';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { colors, spacing, unifiedStyles } from '../theme/unifiedStyles';
@@ -18,7 +19,7 @@ import { useNavigation } from '@react-navigation/native';
 interface RecipeStepsScreenProps {
   recipe: string;
   recipeId?: string;
-  brewDevice?: string;
+  brewDevice?: BrewDevice;
   onBack: () => void;
 }
 

--- a/src/components/SavedRecipesScreen.tsx
+++ b/src/components/SavedRecipesScreen.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { homeStyles } from './styles/HomeScreen.styles';
 import { fetchRecipeHistory, RecipeHistory } from '../services/recipeServices';
+import { BrewDevice, BREW_DEVICES } from '../types/Recipe';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 interface SavedRecipesScreenProps {
@@ -24,6 +26,10 @@ const SavedRecipesScreen: React.FC<SavedRecipesScreenProps> = ({
   const styles = homeStyles();
   const [recipes, setRecipes] = useState<RecipeHistory[]>([]);
   const [refreshing, setRefreshing] = useState(false);
+  const [deviceFilter, setDeviceFilter] = useState<'All' | BrewDevice>('All');
+  const filteredRecipes = recipes.filter(
+    (r) => r.brewDevice === deviceFilter || deviceFilter === 'All'
+  );
 
   const loadRecipes = useCallback(async () => {
     try {
@@ -58,12 +64,22 @@ const SavedRecipesScreen: React.FC<SavedRecipesScreenProps> = ({
         contentContainerStyle={{ padding: 16, paddingBottom: BOTTOM_NAV_HEIGHT }}
         showsVerticalScrollIndicator={false}
       >
-        {recipes.length === 0 ? (
+        <Picker
+          selectedValue={deviceFilter}
+          onValueChange={(v) => setDeviceFilter(v as any)}
+          style={{ marginBottom: 16 }}
+        >
+          <Picker.Item label="All" value="All" />
+          {BREW_DEVICES.map((d) => (
+            <Picker.Item key={d} label={d} value={d} />
+          ))}
+        </Picker>
+        {filteredRecipes.length === 0 ? (
           <Text style={{ textAlign: 'center', color: '#666', marginTop: 20 }}>
             Žiadne uložené recepty
           </Text>
         ) : (
-          recipes.map((item) => (
+          filteredRecipes.map((item) => (
             <View
               key={item.id}
               style={[styles.coffeeCard, { width: '100%', marginRight: 0, marginBottom: 16 }]}

--- a/src/screens/AIChatScreen.tsx
+++ b/src/screens/AIChatScreen.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/AIChatScreen';

--- a/src/screens/CommunityRecipesScreen.tsx
+++ b/src/screens/CommunityRecipesScreen.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { Recipe, BrewDevice, BREW_DEVICES } from '../types/Recipe';
+import { fetchRecipes } from '../services/recipeServices';
+
+const CommunityRecipesScreen: React.FC = () => {
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [device, setDevice] = useState<'All' | BrewDevice>('All');
+
+  useEffect(() => {
+    fetchRecipes().then(setRecipes);
+  }, []);
+
+  const filtered = recipes.filter(
+    (r) => r.brewDevice === device || device === 'All'
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Picker selectedValue={device} onValueChange={(v) => setDevice(v as any)}>
+        <Picker.Item label="All" value="All" />
+        {BREW_DEVICES.map((d) => (
+          <Picker.Item key={d} label={d} value={d} />
+        ))}
+      </Picker>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#eee' }}>
+            <Text style={{ fontWeight: 'bold' }}>{item.title}</Text>
+            <Text>{item.brewDevice}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+};
+
+export default CommunityRecipesScreen;

--- a/src/screens/SavedRecipesScreen.tsx
+++ b/src/screens/SavedRecipesScreen.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/SavedRecipesScreen';

--- a/src/services/recipeServices.ts
+++ b/src/services/recipeServices.ts
@@ -1,5 +1,6 @@
 import auth from '@react-native-firebase/auth';
 import { API_URL } from './api';
+import { Recipe, BrewDevice } from '../types/Recipe';
 
 const loggedFetch = async (url: string, options: RequestInit) => {
   console.log('📤 [FE->BE]', url, options);
@@ -24,6 +25,7 @@ export interface RecipeHistory {
   method: string;
   taste: string;
   recipe: string;
+  brewDevice?: BrewDevice;
   created_at: string;
 }
 
@@ -84,6 +86,62 @@ export const fetchRecipeHistory = async (
     return data as RecipeHistory[];
   } catch (error) {
     console.error('Error fetching recipe history:', error);
+    return [];
+  }
+};
+
+export const createRecipe = async (recipe: Recipe): Promise<Recipe | null> => {
+  try {
+    const token = await getAuthToken();
+    if (!token) return null;
+
+    const res = await loggedFetch(`${API_URL}/recipes`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(recipe),
+    });
+
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    return { ...data, brewDevice: data.brewDevice as BrewDevice } as Recipe;
+  } catch (error) {
+    console.error('Error creating recipe:', error);
+    return null;
+  }
+};
+
+const mapRecipes = (arr: any[]): Recipe[] =>
+  arr.map((r) => ({ ...r, brewDevice: r.brewDevice as BrewDevice }));
+
+export const fetchRecipes = async (): Promise<Recipe[]> => {
+  try {
+    const res = await loggedFetch(`${API_URL}/recipes`, { method: 'GET' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return mapRecipes(data);
+  } catch (error) {
+    console.error('Error fetching recipes:', error);
+    return [];
+  }
+};
+
+export const fetchUserRecipes = async (): Promise<Recipe[]> => {
+  try {
+    const token = await getAuthToken();
+    if (!token) return [];
+    const res = await loggedFetch(`${API_URL}/users/me/recipes`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return mapRecipes(data);
+  } catch (error) {
+    console.error('Error fetching user recipes:', error);
     return [];
   }
 };

--- a/src/types/BrewLog.ts
+++ b/src/types/BrewLog.ts
@@ -1,11 +1,4 @@
-export enum BrewDevice {
-  V60 = 'V60',
-  Aeropress = 'Aeropress',
-  Espresso = 'Espresso',
-  FrenchPress = 'FrenchPress',
-  Chemex = 'Chemex',
-  Other = 'Other',
-}
+import { BrewDevice } from './Recipe';
 
 export interface BrewLog {
   id: string;

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -1,0 +1,10 @@
+export type BrewDevice = 'V60' | 'Aeropress' | 'Espresso' | 'FrenchPress' | 'ColdBrew';
+
+export const BREW_DEVICES: BrewDevice[] = ['V60', 'Aeropress', 'Espresso', 'FrenchPress', 'ColdBrew'];
+
+export interface Recipe {
+  id: string;
+  title: string;
+  instructions: string;
+  brewDevice: BrewDevice;
+}


### PR DESCRIPTION
## Summary
- define reusable `BrewDevice` type and include in `Recipe` model
- add device pickers to recipe/brew log forms and recipe screens
- pass brew device to services and AI prompts; add DB column

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ba00f90832a9675b5d620d41053