### PR TITLE
feat: add daily tip support with history

### DIFF
--- a/__tests__/DailyTipCard.test.tsx
+++ b/__tests__/DailyTipCard.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { Text } from 'react-native';
+import DailyTipCard from '../src/components/DailyTipCard';
+import Share from 'react-native/Libraries/Share/Share';
+
+const store: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+jest.mock('react-native/Libraries/Share/Share', () => ({
+  share: jest.fn(),
+}));
+
+beforeEach(() => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  (AsyncStorage.getItem as jest.Mock).mockClear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  Object.keys(store).forEach((k) => delete store[k]);
+  (Share.share as jest.Mock).mockClear();
+});
+
+describe('DailyTipCard', () => {
+  const tip = { id: 1, text: 'Tip text', date: '2024-01-01' };
+
+  it('saves tip to storage', async () => {
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<DailyTipCard tip={tip} />);
+    });
+    const saveBtn = instance.root.findByProps({ children: 'Ulož' });
+    await ReactTestRenderer.act(async () => {
+      await saveBtn.props.onPress();
+    });
+    const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'SavedTips',
+      JSON.stringify([tip])
+    );
+  });
+
+  it('shares tip text', async () => {
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<DailyTipCard tip={tip} />);
+    });
+    const shareBtn = instance.root.findByProps({ children: 'Zdieľaj' });
+    shareBtn.props.onPress();
+    expect(Share.share).toHaveBeenCalledWith({ message: tip.text });
+  });
+
+  it('uses stored tip when offline', async () => {
+    const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+    await AsyncStorage.setItem('lastTip', JSON.stringify(tip));
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<DailyTipCard />);
+    });
+    const texts = instance.root.findAllByType(Text);
+    const hasTip = texts.some((t) => t.props.children === tip.text);
+    expect(hasTip).toBe(true);
+  });
+});

--- a/__tests__/contentServices.test.ts
+++ b/__tests__/contentServices.test.ts
@@ -1,0 +1,32 @@
+import { fetchDailyTip, Tip } from '../src/services/contentServices';
+
+jest.useFakeTimers();
+
+const store: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+describe('fetchDailyTip', () => {
+  it('returns same tip within a day and different on next day', async () => {
+    jest.setSystemTime(new Date('2024-01-01'));
+    const tip1 = await fetchDailyTip();
+    const tipStored: Tip = JSON.parse(store['lastTip']);
+    expect(tipStored.id).toBe(tip1.id);
+
+    const tip2 = await fetchDailyTip();
+    expect(tip2.id).toBe(tip1.id);
+
+    jest.setSystemTime(new Date('2024-01-02'));
+    const tip3 = await fetchDailyTip();
+    expect(tip3.id).not.toBe(tip1.id);
+  });
+});

--- a/content/dailyTips.json
+++ b/content/dailyTips.json
@@ -1,4 +1,16 @@
 [
-  "Clean your equipment before brewing for best taste.",
-  "Use fresh water for a crisper brew."
+  {
+    "id": 1,
+    "text": "Clean your equipment before brewing for best taste.",
+    "date": "2024-01-01"
+  },
+  {
+    "id": 2,
+    "text": "Use fresh water for a crisper brew.",
+    "date": "2024-01-02"
+  },
+  {
+    "id": 3,
+    "text": "Store coffee beans in an airtight container."
+  }
 ]

--- a/src/components/DailyTipCard.tsx
+++ b/src/components/DailyTipCard.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, Share } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Tip } from '../services/contentServices';
+
+interface Props {
+  tip?: Tip;
+}
+
+const SAVED_TIPS_KEY = 'SavedTips';
+
+const DailyTipCard: React.FC<Props> = ({ tip }) => {
+  const [currentTip, setCurrentTip] = useState<Tip | null>(tip ?? null);
+
+  useEffect(() => {
+    if (tip) {
+      setCurrentTip(tip);
+    } else {
+      AsyncStorage.getItem('lastTip').then((stored) => {
+        if (stored) {
+          setCurrentTip(JSON.parse(stored));
+        }
+      });
+    }
+  }, [tip]);
+
+  const saveTip = async () => {
+    if (!currentTip) return;
+    const raw = await AsyncStorage.getItem(SAVED_TIPS_KEY);
+    const arr: Tip[] = raw ? JSON.parse(raw) : [];
+    if (!arr.find((t) => t.id === currentTip.id && t.date === currentTip.date)) {
+      arr.push(currentTip);
+      await AsyncStorage.setItem(SAVED_TIPS_KEY, JSON.stringify(arr));
+    }
+  };
+
+  const shareTip = () => {
+    if (!currentTip) return;
+    Share.share({ message: currentTip.text });
+  };
+
+  if (!currentTip) return null;
+
+  return (
+    <View style={{ padding: 16, backgroundColor: '#fff', borderRadius: 8 }}>
+      <Text>{currentTip.text}</Text>
+      <View style={{ flexDirection: 'row', marginTop: 8 }}>
+        <TouchableOpacity onPress={saveTip} style={{ marginRight: 16 }}>
+          <Text>Ulož</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={shareTip}>
+          <Text>Zdieľaj</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default DailyTipCard;

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -10,6 +10,9 @@ import {
 } from 'react-native';
 import { homeStyles } from './styles/HomeScreen.styles.ts';
 import { fetchCoffees } from '../services/homePagesService.ts';
+import DailyTipCard from './DailyTipCard';
+import { fetchDailyTip, Tip } from '../services/contentServices';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 
 interface CoffeeItem {
@@ -56,6 +59,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   ]);
 
   const [recommendedCoffees, setRecommendedCoffees] = useState<CoffeeItem[]>([]);
+  const [dailyTip, setDailyTip] = useState<Tip | null>(null);
   const styles = homeStyles();
 
   const loadCoffees = useCallback(async () => {
@@ -71,6 +75,19 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   useEffect(() => {
     loadCoffees();
   }, [loadCoffees]);
+
+  useEffect(() => {
+    const loadTip = async () => {
+      try {
+        const tip = await fetchDailyTip();
+        setDailyTip(tip);
+      } catch (e) {
+        const stored = await AsyncStorage.getItem('lastTip');
+        if (stored) setDailyTip(JSON.parse(stored));
+      }
+    };
+    loadTip();
+  }, []);
 
   const getGreeting = () => {
     const hour = new Date().getHours();
@@ -205,6 +222,12 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
             <Text style={styles.statusText}>{getTimeBasedMessage()}</Text>
           </View>
         </View>
+
+        {dailyTip && (
+          <View style={{ marginVertical: 16 }}>
+            <DailyTipCard tip={dailyTip} />
+          </View>
+        )}
 
         {/* Weather & Coffee Widget */}
         <View style={styles.weatherWidget}>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,1 @@
+export { default } from '../components/HomeScreen';

--- a/src/screens/SavedTipsScreen.tsx
+++ b/src/screens/SavedTipsScreen.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Tip } from '../services/contentServices';
+
+const SAVED_TIPS_KEY = 'SavedTips';
+
+const SavedTipsScreen: React.FC = () => {
+  const [tips, setTips] = useState<Tip[]>([]);
+
+  const loadTips = async () => {
+    const raw = await AsyncStorage.getItem(SAVED_TIPS_KEY);
+    setTips(raw ? JSON.parse(raw) : []);
+  };
+
+  useEffect(() => {
+    loadTips();
+  }, []);
+
+  const removeTip = async (id: number, date: string) => {
+    const updated = tips.filter((t) => !(t.id === id && t.date === date));
+    setTips(updated);
+    await AsyncStorage.setItem(SAVED_TIPS_KEY, JSON.stringify(updated));
+  };
+
+  const renderItem = ({ item }: { item: Tip }) => (
+    <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#ccc' }}>
+      <Text style={{ fontWeight: 'bold' }}>{item.date}</Text>
+      <Text>{item.text}</Text>
+      <TouchableOpacity onPress={() => removeTip(item.id, item.date)}>
+        <Text style={{ color: 'red' }}>Odstrániť</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList data={tips} keyExtractor={(item) => `${item.id}-${item.date}`} renderItem={renderItem} />
+    </View>
+  );
+};
+
+export default SavedTipsScreen;

--- a/src/services/contentServices.ts
+++ b/src/services/contentServices.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+const tips = require('../../content/dailyTips.json');
+
+export interface Tip {
+  id: number;
+  text: string;
+  date: string;
+}
+
+const LAST_TIP_KEY = 'lastTip';
+
+export const fetchDailyTip = async (): Promise<Tip> => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  try {
+    const stored = await AsyncStorage.getItem(LAST_TIP_KEY);
+    if (stored) {
+      const parsed: Tip = JSON.parse(stored);
+      if (parsed.date === today) {
+        return parsed;
+      }
+    }
+  } catch (error) {
+    console.error('Error reading last tip:', error);
+  }
+
+  const list: Tip[] = tips as Tip[];
+  const matched = list.find((t) => t.date === today);
+  const index = new Date(today).getDate() % list.length;
+  const chosen = matched || list[index];
+  const tip: Tip = { ...chosen, date: today };
+
+  try {
+    await AsyncStorage.setItem(LAST_TIP_KEY, JSON.stringify(tip));
+  } catch (error) {
+    console.error('Error saving last tip:', error);
+  }
+
+  return tip;
+};


### PR DESCRIPTION
## Summary
- structure dailyTips.json for unique tips with optional dates
- fetch daily tip and cache per day in AsyncStorage
- display and save/share tip in new DailyTipCard, integrate into HomeScreen
- add SavedTipsScreen for viewing and removing saved tips

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c69d40ced4832ab929d12250dcfd24