### PR TITLE
feat: add recent scan carousel

### DIFF
--- a/src/components/CoffeeTasteScanner.tsx
+++ b/src/components/CoffeeTasteScanner.tsx
@@ -35,6 +35,7 @@ import {
 } from '../services/ocrServices.ts';
 import { incrementProgress } from '../services/profileServices';
 import { saveOCRResult, loadOCRResult } from '../services/offlineCache';
+import { addRecentScan } from '../services/coffeeServices.ts';
 
 interface OCRHistory {
   id: string;
@@ -191,6 +192,14 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = () => {
         } catch (e) {
           console.error('Failed to update progress', e);
         }
+
+        // Ulož do zoznamu posledných skenov
+        const name = extractCoffeeName(result.corrected || result.original);
+        await addRecentScan({
+          id: result.scanId || Date.now().toString(),
+          name,
+          imageUrl: `data:image/jpeg;base64,${base64image}`,
+        });
 
         // Načítaj aktualizovanú históriu
         await loadHistory();

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -14,6 +14,8 @@ import DailyTipCard from './DailyTipCard';
 import { fetchDailyTip, Tip } from '../services/contentServices';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
+import RecentScansCarousel from './RecentScansCarousel';
+import { fetchRecentScans, RecentScan } from '../services/coffeeServices.ts';
 
 interface CoffeeItem {
   id: string;
@@ -60,6 +62,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
 
   const [recommendedCoffees, setRecommendedCoffees] = useState<CoffeeItem[]>([]);
   const [dailyTip, setDailyTip] = useState<Tip | null>(null);
+  const [recentScans, setRecentScans] = useState<RecentScan[]>([]);
   const styles = homeStyles();
 
   const loadCoffees = useCallback(async () => {
@@ -87,6 +90,18 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
       }
     };
     loadTip();
+  }, []);
+
+  useEffect(() => {
+    const loadScans = async () => {
+      try {
+        const scans = await fetchRecentScans(10);
+        setRecentScans(scans);
+      } catch (err) {
+        console.error('Error loading recent scans:', err);
+      }
+    };
+    loadScans();
   }, []);
 
   const getGreeting = () => {
@@ -131,6 +146,12 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
   const onRefresh = async () => {
     setRefreshing(true);
     await loadCoffees();
+    try {
+      const scans = await fetchRecentScans(10);
+      setRecentScans(scans);
+    } catch (err) {
+      console.error('Error refreshing scans:', err);
+    }
     setRefreshing(false);
   };
 
@@ -315,6 +336,15 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
             ))}
           </View>
         </View>
+
+        {recentScans.length > 0 && (
+          <View style={styles.recentScans}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Naposledy naskenované</Text>
+            </View>
+            <RecentScansCarousel scans={recentScans} />
+          </View>
+        )}
 
         {/* Recommendations */}
         <View style={styles.recommendations}>

--- a/src/components/RecentScansCarousel.tsx
+++ b/src/components/RecentScansCarousel.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, Image, FlatList, TouchableOpacity, Dimensions, Platform } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { RecentScan } from '../services/coffeeServices';
+
+interface Props {
+  scans: RecentScan[];
+}
+
+const ITEM_WIDTH = 120;
+
+const RecentScansCarousel: React.FC<Props> = ({ scans }) => {
+  const navigation = useNavigation<any>();
+
+  const renderItem = ({ item }: { item: RecentScan }) => (
+    <TouchableOpacity
+      style={{ width: ITEM_WIDTH, marginRight: 12 }}
+      onPress={() => navigation.navigate('CoffeeDetail', { id: item.id })}
+    >
+      {item.imageUrl ? (
+        <Image
+          source={{ uri: item.imageUrl }}
+          style={{ width: ITEM_WIDTH, height: ITEM_WIDTH, borderRadius: 8 }}
+        />
+      ) : (
+        <View
+          style={{
+            width: ITEM_WIDTH,
+            height: ITEM_WIDTH,
+            borderRadius: 8,
+            backgroundColor: '#eee',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Text>☕</Text>
+        </View>
+      )}
+      <Text style={{ marginTop: 4, textAlign: 'center' }}>{item.name}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <FlatList
+      horizontal
+      data={scans}
+      keyExtractor={item => item.id}
+      renderItem={renderItem}
+      showsHorizontalScrollIndicator={false}
+      snapToInterval={ITEM_WIDTH + 12}
+      decelerationRate="fast"
+    />
+  );
+};
+
+export default RecentScansCarousel;

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -407,6 +407,10 @@ export const homeStyles = () => {
       marginHorizontal: 16,
       marginBottom: 100,
     },
+    recentScans: {
+      marginHorizontal: 16,
+      marginBottom: 24,
+    },
     sectionHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/src/services/coffeeServices.ts
+++ b/src/services/coffeeServices.ts
@@ -1,0 +1,71 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
+import auth from '@react-native-firebase/auth';
+import { API_URL } from './api';
+
+export interface RecentScan {
+  id: string;
+  name: string;
+  imageUrl?: string;
+}
+
+const STORAGE_KEY = 'recentScans';
+
+/**
+ * Uloží nový scan do lokálneho úložiska.
+ */
+export const addRecentScan = async (scan: RecentScan): Promise<void> => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    const scans: RecentScan[] = raw ? JSON.parse(raw) : [];
+    const updated = [scan, ...scans.filter(s => s.id !== scan.id)].slice(0, 20);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (err) {
+    console.error('Failed to store recent scan', err);
+  }
+};
+
+/**
+ * Načíta posledné skeny. Najprv sa pokúsi načítať z cache,
+ * následne osvieži dáta z API. Pri offline stave vráti len cache.
+ */
+export const fetchRecentScans = async (limit: number): Promise<RecentScan[]> => {
+  try {
+    const cachedRaw = await AsyncStorage.getItem(STORAGE_KEY);
+    let cached: RecentScan[] = cachedRaw ? JSON.parse(cachedRaw) : [];
+
+    // Ak je zariadenie offline, vráť len cache
+    const state = await NetInfo.fetch();
+    if (!state.isConnected) {
+      return cached.slice(0, limit);
+    }
+
+    const user = auth().currentUser;
+    const token = await user?.getIdToken();
+    if (!token) {
+      return cached.slice(0, limit);
+    }
+
+    const res = await fetch(`${API_URL}/coffees/recent?limit=${limit}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      cached = data;
+    }
+
+    return cached.slice(0, limit);
+  } catch (err) {
+    console.error('Failed to fetch recent scans', err);
+    const fallback = await AsyncStorage.getItem(STORAGE_KEY);
+    return fallback ? JSON.parse(fallback).slice(0, limit) : [];
+  }
+};
+
+export default { fetchRecentScans, addRecentScan };


### PR DESCRIPTION
## Summary
- cache recent coffee scans with AsyncStorage and API fallback
- show recent scans carousel on home screen
- record new scans after OCR processing

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e7d5cfc832a9e5dbb2d7767a1ba