### PR TITLE
feat: onboarding flow with language and permissions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -55,14 +55,14 @@ const AppContent = (): React.JSX.Element => {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    const checkOnboarding = async () => {
-      const value = await AsyncStorage.getItem('onboardingComplete');
-      setIsOnboardingComplete(value === 'true');
-      setCheckingOnboarding(false);
-    };
-    checkOnboarding();
-  }, []);
+    useEffect(() => {
+      const checkOnboarding = async () => {
+        const value = await AsyncStorage.getItem('@OnboardingComplete');
+        setIsOnboardingComplete(value === 'true');
+        setCheckingOnboarding(false);
+      };
+      checkOnboarding();
+    }, []);
 
   useEffect(() => {
     scheduleLowStockCheck();
@@ -111,18 +111,6 @@ const AppContent = (): React.JSX.Element => {
     setCurrentScreen('edit-profile');
   };
 
-  if (!isAuthenticated) {
-    return (
-      <ResponsiveWrapper
-        backgroundColor={colors.background}
-        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
-        statusBarBackground={colors.background}
-      >
-        <AuthScreen />
-      </ResponsiveWrapper>
-    );
-  }
-
   if (checkingOnboarding) {
     return null;
   }
@@ -135,6 +123,18 @@ const AppContent = (): React.JSX.Element => {
         statusBarBackground={colors.background}
       >
         <OnboardingScreen onFinish={() => setIsOnboardingComplete(true)} />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <AuthScreen />
       </ResponsiveWrapper>
     );
   }

--- a/src/components/Onboarding/FeaturesScreen.tsx
+++ b/src/components/Onboarding/FeaturesScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useRef, useState } from 'react';
+import { View, Text, FlatList, Dimensions, StyleSheet, Button } from 'react-native';
+import { useTheme } from '../../theme/ThemeProvider';
+
+interface Props {
+  onFinish: () => void;
+}
+
+const features = [
+  { key: 'ocr', title: 'OCR sken', text: 'Skenuj recepty pomocou OCR.' },
+  { key: 'ai', title: 'AI recepty', text: 'Generuj recepty s pomocou AI.' },
+  { key: 'personal', title: 'Personalizácia', text: 'Prispôsob si aplikáciu svojim potrebám.' },
+];
+
+const { width } = Dimensions.get('window');
+
+const FeaturesScreen: React.FC<Props> = ({ onFinish }) => {
+  const { colors } = useTheme();
+  const [index, setIndex] = useState(0);
+  const onViewableItemsChanged = useRef(({ viewableItems }: any) => {
+    if (viewableItems.length > 0 && viewableItems[0].index != null) {
+      setIndex(viewableItems[0].index);
+    }
+  }).current;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <FlatList
+        data={features}
+        horizontal
+        pagingEnabled
+        keyExtractor={(item) => item.key}
+        showsHorizontalScrollIndicator={false}
+        renderItem={({ item }) => (
+          <View style={[styles.card, { width }]}> 
+            <Text style={[styles.title, { color: colors.text }]}>{item.title}</Text>
+            <Text style={[styles.text, { color: colors.textSecondary }]}>{item.text}</Text>
+          </View>
+        )}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={{ viewAreaCoveragePercentThreshold: 50 }}
+      />
+      {index === features.length - 1 && (
+        <Button title="Začať" onPress={onFinish} />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  card: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  text: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});
+
+export default FeaturesScreen;

--- a/src/components/Onboarding/LanguageThemeScreen.tsx
+++ b/src/components/Onboarding/LanguageThemeScreen.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Button, Switch } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Picker } from '@react-native-picker/picker';
+import { useTheme } from '../../theme/ThemeProvider';
+
+interface Props {
+  navigation: any;
+}
+
+const LanguageThemeScreen: React.FC<Props> = ({ navigation }) => {
+  const { isDark, setScheme, colors } = useTheme();
+  const [language, setLanguage] = useState('sk');
+  const [darkMode, setDarkMode] = useState(isDark);
+
+  const handleContinue = async () => {
+    await AsyncStorage.setItem('@AppLang', language);
+    setScheme(darkMode ? 'dark' : 'light');
+    navigation.navigate('Permissions');
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <Text style={[styles.label, { color: colors.text }]}>Vyber jazyk</Text>
+      <Picker
+        selectedValue={language}
+        onValueChange={(value) => setLanguage(value)}
+        style={styles.picker}
+      >
+        <Picker.Item label="Slovenčina" value="sk" />
+        <Picker.Item label="English" value="en" />
+      </Picker>
+      <View style={styles.switchRow}>
+        <Text style={[styles.label, { color: colors.text }]}>Tmavý režim</Text>
+        <Switch value={darkMode} onValueChange={setDarkMode} />
+      </View>
+      <Button title="Pokračovať" onPress={handleContinue} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  label: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  picker: {
+    marginBottom: 20,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+});
+
+export default LanguageThemeScreen;

--- a/src/components/Onboarding/PermissionsScreen.tsx
+++ b/src/components/Onboarding/PermissionsScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Button, Platform } from 'react-native';
+import { requestMultiple, PERMISSIONS, RESULTS } from 'react-native-permissions';
+import { useTheme } from '../../theme/ThemeProvider';
+
+interface Props {
+  navigation: any;
+}
+
+const PermissionsScreen: React.FC<Props> = ({ navigation }) => {
+  const { colors } = useTheme();
+  const [denied, setDenied] = useState(false);
+
+  const requestPerms = async () => {
+    setDenied(false);
+    const permissions = Platform.select({
+      ios: [PERMISSIONS.IOS.CAMERA, PERMISSIONS.IOS.PHOTO_LIBRARY],
+      android: [PERMISSIONS.ANDROID.CAMERA, PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE],
+    }) as string[];
+
+    const statuses = await requestMultiple(permissions);
+    const granted = Object.values(statuses).every((s) => s === RESULTS.GRANTED);
+    if (granted) {
+      navigation.navigate('Features');
+    } else {
+      setDenied(true);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}> 
+      <Text style={[styles.text, { color: colors.text }]}>Aplikácia potrebuje prístup ku kamere a úložisku.</Text>
+      {denied && (
+        <Text style={[styles.warning, { color: colors.danger }]}>Povolenia boli odmietnuté.</Text>
+      )}
+      <Button title={denied ? 'Skúsiť znova' : 'Udelit povolenia'} onPress={requestPerms} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  text: {
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  warning: {
+    marginBottom: 20,
+  },
+});
+
+export default PermissionsScreen;

--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -1,84 +1,34 @@
-import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useTheme } from '../theme/ThemeProvider';
+import LanguageThemeScreen from './Onboarding/LanguageThemeScreen';
+import PermissionsScreen from './Onboarding/PermissionsScreen';
+import FeaturesScreen from './Onboarding/FeaturesScreen';
 
-interface OnboardingScreenProps {
+interface Props {
   onFinish: () => void;
 }
 
-const pages = [
-  {
-    title: 'Vitajte v BrewMate',
-    text: 'Objavte recepty a odporúčania pre vašu dokonalú kávu.',
-  },
-  {
-    title: 'Skenovanie',
-    text: 'Použite fotoaparát na skenovanie kávy a receptov.',
-  },
-  {
-    title: 'Povolenia',
-    text: 'Aplikácia potrebuje prístup k fotoaparátu na skenovanie a k úložisku pre uloženie vašich preferencií.',
-  },
-];
+const Stack = createStackNavigator();
 
-const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onFinish }) => {
-  const [page, setPage] = useState(0);
-  const { colors } = useTheme();
-
-  const handleNext = async () => {
-    if (page < pages.length - 1) {
-      setPage(page + 1);
-    } else {
-      await AsyncStorage.setItem('onboardingComplete', 'true');
-      onFinish();
-    }
+const OnboardingScreen: React.FC<Props> = ({ onFinish }) => {
+  const handleFinish = async () => {
+    await AsyncStorage.setItem('@OnboardingComplete', 'true');
+    onFinish();
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}> 
-      <Text style={[styles.title, { color: colors.text }]}>{pages[page].title}</Text>
-      <Text style={[styles.text, { color: colors.textSecondary }]}>{pages[page].text}</Text>
-      <TouchableOpacity
-        style={[styles.button, { backgroundColor: colors.primary }]}
-        onPress={handleNext}
-      >
-        <Text style={[styles.buttonText, { color: colors.cardBackground }]}> 
-          {page === pages.length - 1 ? 'Dokončiť' : 'Ďalej'}
-        </Text>
-      </TouchableOpacity>
-    </View>
+    <NavigationContainer independent>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="LanguageTheme" component={LanguageThemeScreen} />
+        <Stack.Screen name="Permissions" component={PermissionsScreen} />
+        <Stack.Screen name="Features">
+          {() => <FeaturesScreen onFinish={handleFinish} />}
+        </Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  text: {
-    fontSize: 16,
-    textAlign: 'center',
-    marginBottom: 40,
-  },
-  button: {
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-  },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
-});
-
 export default OnboardingScreen;
-

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,23 +1,33 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useColorScheme } from 'react-native';
 import { Colors, getColors } from './colors';
 
 interface ThemeContextProps {
   isDark: boolean;
   colors: Colors;
+  setScheme: (scheme: 'light' | 'dark') => void;
 }
 
 const ThemeContext = createContext<ThemeContextProps>({
   isDark: false,
   colors: getColors(false),
+  setScheme: () => {},
 });
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const isDark = useColorScheme() === 'dark';
-  const colors = getColors(isDark);
+  const systemScheme = useColorScheme();
+  const [scheme, setScheme] = useState<'light' | 'dark'>(systemScheme === 'dark' ? 'dark' : 'light');
+
+  useEffect(() => {
+    if (systemScheme) {
+      setScheme(systemScheme === 'dark' ? 'dark' : 'light');
+    }
+  }, [systemScheme]);
+
+  const colors = getColors(scheme === 'dark');
 
   return (
-    <ThemeContext.Provider value={{ isDark, colors }}>
+    <ThemeContext.Provider value={{ isDark: scheme === 'dark', colors, setScheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add onboarding flow with language/theme selection, permissions, and feature intro
- allow runtime theme switching via ThemeProvider
- show onboarding before authentication and persist completion flag

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69f602af4832a809289845e5d945d