### PR TITLE
Use new profile screen in app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,7 @@ import CoffeeTasteScanner from './src/components/CoffeeTasteScanner.tsx';
 import CoffeeReceipeScanner from './src/components/CoffeeReceipeScanner.tsx';
 import AllCoffeesScreen from './src/components/AllCoffeesScreen';
 import AIChatScreen from './src/components/AIChatScreen';
-import UserProfile from './src/components/UserProfile';
+import ProfileScreen from './src/screens/ProfileScreen';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
 import EditPreferences from './src/components/EditPreferences';
@@ -121,10 +121,6 @@ const AppContent = (): React.JSX.Element | null => {
 
   const handleBackPress = () => {
     setCurrentScreen('home');
-  };
-
-  const handleEditProfilePress = () => {
-    setCurrentScreen('edit-profile');
   };
 
   if (checkingOnboarding) {
@@ -251,10 +247,9 @@ const AppContent = (): React.JSX.Element | null => {
             <Text style={styles.backButtonText}>← Spť</Text>
           </TouchableOpacity>
         </View>
-        <UserProfile
-          onEdit={handleEditProfilePress}
-          onPreferences={() => setCurrentScreen('edit-preferences')}
-          onForm={() => setCurrentScreen('preferences')}
+        <ProfileScreen />
+        <BottomNav
+          active="profile"
           onHomePress={handleBackPress}
           onDiscoverPress={handleDiscoverPress}
           onRecipesPress={handleRecipesPress}


### PR DESCRIPTION
## Summary
- replace UserProfile import with ProfileScreen
- render ProfileScreen with bottom navigation when viewing the profile

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@invertase%2freact-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe26b76c832a908f5890c845de5c