### PR TITLE
Add inventory screen navigation from home

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,6 +26,7 @@ import ResponsiveWrapper from './src/components/ResponsiveWrapper';
 import SavedRecipesScreen from './src/components/SavedRecipesScreen';
 import BottomNav from './src/components/BottomNav';
 import { scheduleLowStockCheck } from './src/utils/reminders';
+import InventoryScreen from './src/screens/InventoryScreen';
 
 type ScreenName =
   | 'home'
@@ -38,7 +39,8 @@ type ScreenName =
   | 'discover'
   | 'recipes'
   | 'recipe-steps'
-  | 'favorites';
+  | 'favorites'
+  | 'inventory';
 
 const AppContent = (): React.JSX.Element | null => {
   const [currentScreen, setCurrentScreen] = useState<ScreenName>('home');
@@ -117,6 +119,10 @@ const AppContent = (): React.JSX.Element | null => {
 
   const handleFavoritesPress = () => {
     setCurrentScreen('favorites');
+  };
+
+  const handleInventoryPress = () => {
+    setCurrentScreen('inventory');
   };
 
   const handleBackPress = () => {
@@ -358,6 +364,33 @@ const AppContent = (): React.JSX.Element | null => {
     );
   }
 
+  if (currentScreen === 'inventory') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.backButton, { backgroundColor: colors.primary }]}
+            onPress={handleBackPress}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+        </View>
+        <InventoryScreen />
+        <BottomNav
+          active="home"
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+      </ResponsiveWrapper>
+    );
+  }
+
   if (currentScreen === 'discover') {
     return (
       <ResponsiveWrapper
@@ -391,6 +424,7 @@ const AppContent = (): React.JSX.Element | null => {
         onDiscoverPress={handleDiscoverPress}
         onRecipesPress={handleRecipesPress}
         onFavoritesPress={handleFavoritesPress}
+        onInventoryPress={handleInventoryPress}
       />
     </ResponsiveWrapper>
   );

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -38,6 +38,7 @@ interface HomeScreenProps {
   onDiscoverPress: () => void;
   onRecipesPress: () => void;
   onFavoritesPress: () => void;
+  onInventoryPress: () => void;
   userName?: string;
 }
 
@@ -49,6 +50,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                                                  onDiscoverPress,
                                                  onRecipesPress,
                                                  onFavoritesPress,
+                                                 onInventoryPress,
                                                userName = 'Martin',
                                              }) => {
   const [refreshing, setRefreshing] = useState(false);
@@ -303,10 +305,13 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
         </View>
 
         {/* Coffee Inventory */}
-        <View style={styles.coffeeInventory}>
+        <TouchableOpacity
+          style={styles.coffeeInventory}
+          onPress={onInventoryPress}
+          activeOpacity={0.8}>
           <Text style={styles.inventoryTitle}>📦 Počet balíkov kávy</Text>
           <Text style={styles.inventoryCount}>{coffeeCount}</Text>
-        </View>
+        </TouchableOpacity>
 
         {/* Taste Profile */}
         <View style={styles.tasteProfile}>


### PR DESCRIPTION
## Summary
- add `InventoryScreen` and new `inventory` screen state in `App.tsx`
- link coffee inventory card on Home screen to Inventory screen
- provide back navigation and bottom nav on Inventory screen

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for @invertase/react-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68c700739c78832aab9952d2be7d516a