### PR TITLE
Add scan option and tests for recent scans

### DIFF
--- a/__tests__/CoffeeTasteScanner.test.tsx
+++ b/__tests__/CoffeeTasteScanner.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { Text, TouchableOpacity, Alert } from 'react-native';
+import CoffeeTasteScanner from '../src/components/CoffeeTasteScanner';
+
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn(() => () => {}),
+  },
+}));
+
+jest.mock('react-native-vision-camera', () => ({
+  Camera: jest.fn(() => null),
+  useCameraDevice: jest.fn(() => ({})),
+  useCameraPermission: jest.fn(() => ({ hasPermission: true, requestPermission: jest.fn() })),
+}));
+
+jest.mock('react-native-image-picker', () => ({
+  launchImageLibrary: jest.fn((options, callback) => {
+    callback({ assets: [{ base64: 'abc123' }] });
+  }),
+}));
+
+jest.mock('react-native-fs', () => ({}));
+
+jest.mock('../src/services/ocrServices.ts', () => ({
+  processOCR: jest.fn(() => Promise.resolve({
+    corrected: 'text',
+    original: 'text',
+    scanId: '1',
+    isRecommended: false,
+    matchPercentage: 0,
+  })),
+  fetchOCRHistory: jest.fn(() => Promise.resolve([])),
+  deleteOCRRecord: jest.fn(),
+  rateOCRResult: jest.fn(),
+  markCoffeePurchased: jest.fn(),
+  extractCoffeeName: jest.fn(() => 'Test Coffee'),
+}));
+
+jest.mock('../src/services/offlineCache', () => ({
+  saveOCRResult: jest.fn(() => Promise.resolve()),
+  loadOCRResult: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../src/services/profileServices', () => ({
+  incrementProgress: jest.fn(() => Promise.resolve()),
+}));
+
+const addRecentScan = jest.fn(() => Promise.resolve());
+jest.mock('../src/services/coffeeServices.ts', () => ({
+  addRecentScan: (scan: any) => addRecentScan(scan),
+}));
+
+describe('CoffeeTasteScanner', () => {
+  beforeEach(() => {
+    addRecentScan.mockClear();
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  it('calls addRecentScan after selecting image', async () => {
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<CoffeeTasteScanner />);
+    });
+    const buttons = instance.root.findAllByType(TouchableOpacity);
+    const galleryButton = buttons.find(btn =>
+      btn.findAllByType(Text).some(t => t.props.children === 'Vybrať z galérie')
+    );
+    expect(galleryButton).toBeTruthy();
+    await ReactTestRenderer.act(async () => {
+      await galleryButton.props.onPress();
+    });
+    expect(addRecentScan).toHaveBeenCalled();
+  });
+});
+

--- a/__tests__/coffeeServices.test.ts
+++ b/__tests__/coffeeServices.test.ts
@@ -1,0 +1,39 @@
+import { addRecentScan, fetchRecentScans } from '../src/services/coffeeServices';
+
+const store: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: jest.fn(() => Promise.resolve({ isConnected: false })),
+  },
+}));
+
+describe('coffeeServices', () => {
+  beforeEach(() => {
+    Object.keys(store).forEach(k => delete store[k]);
+    const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    const NetInfo = require('@react-native-community/netinfo').default;
+    (NetInfo.fetch as jest.Mock).mockClear();
+  });
+
+  it('stores scan and returns it from fetchRecentScans', async () => {
+    await addRecentScan({ id: '1', name: 'Test Coffee' });
+    const scans = await fetchRecentScans(10);
+    expect(scans).toEqual([{ id: '1', name: 'Test Coffee' }]);
+  });
+});
+

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -342,14 +342,19 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
           </View>
         </View>
 
-        {recentScans.length > 0 && (
-          <View style={styles.recentScans}>
-            <View style={styles.sectionHeader}>
-              <Text style={styles.sectionTitle}>Naposledy naskenované</Text>
-            </View>
-            <RecentScansCarousel scans={recentScans} />
+        <View style={styles.recentScans}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Naposledy naskenované</Text>
+            <TouchableOpacity style={styles.seeAll} onPress={onScanPress}>
+              <Text style={styles.seeAllText}>Skenovať teraz</Text>
+            </TouchableOpacity>
           </View>
-        )}
+          {recentScans.length === 0 ? (
+            <Text style={{ color: '#666', paddingHorizontal: 16 }}>Zatiaľ nič naskenované</Text>
+          ) : (
+            <RecentScansCarousel scans={recentScans} />
+          )}
+        </View>
 
         {/* Recommendations */}
         <View style={styles.recommendations}>


### PR DESCRIPTION
## Summary
- Display recent scans section even when empty and include a 'Skenovať teraz' button
- Add tests ensuring recent scan storage and retrieval
- Verify scanner invokes recent scan storage after selecting an image

## Testing
- `npm install` (failed: 403 Forbidden)
- `npx jest` (failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c703304ea4832a9c120f5393fe9481