### PR TITLE
Restore settings profile with link to gamification

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,8 @@ import CoffeeTasteScanner from './src/components/CoffeeTasteScanner.tsx';
 import CoffeeReceipeScanner from './src/components/CoffeeReceipeScanner.tsx';
 import AllCoffeesScreen from './src/components/AllCoffeesScreen';
 import AIChatScreen from './src/components/AIChatScreen';
-import ProfileScreen from './src/screens/ProfileScreen';
+import UserProfile from './src/components/UserProfile';
+import GamificationScreen from './src/screens/GamificationScreen';
 import EditUserProfile from './src/components/EditUserProfile';
 import CoffeePreferenceForm from './src/components/CoffeePreferenceForm';
 import EditPreferences from './src/components/EditPreferences';
@@ -40,7 +41,8 @@ type ScreenName =
   | 'recipes'
   | 'recipe-steps'
   | 'favorites'
-  | 'inventory';
+  | 'inventory'
+  | 'gamification';
 
 const AppContent = (): React.JSX.Element | null => {
   const [currentScreen, setCurrentScreen] = useState<ScreenName>('home');
@@ -246,14 +248,36 @@ const AppContent = (): React.JSX.Element | null => {
         statusBarStyle={isDark ? 'light-content' : 'dark-content'}
         statusBarBackground={colors.primary}
       >
+        <UserProfile
+          onEdit={() => setCurrentScreen('edit-profile')}
+          onPreferences={() => setCurrentScreen('preferences')}
+          onBack={handleBackPress}
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+          onGamification={() => setCurrentScreen('gamification')}
+        />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'gamification') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
         <View style={styles.header}>
           <TouchableOpacity
             style={[styles.backButton, { backgroundColor: colors.primary }]}
-            onPress={handleBackPress}>
-            <Text style={styles.backButtonText}>← Spť</Text>
+            onPress={() => setCurrentScreen('profile')}>
+            <Text style={styles.backButtonText}>← Späť</Text>
           </TouchableOpacity>
         </View>
-        <ProfileScreen />
+        <GamificationScreen />
         <BottomNav
           active="profile"
           onHomePress={handleBackPress}

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -48,6 +48,7 @@ const UserProfile = ({
                        onRecipesPress,
                        onFavoritesPress,
                        onProfilePress,
+                       onGamification,
                      }: {
   onEdit: () => void;
   onPreferences: () => void;
@@ -58,6 +59,7 @@ const UserProfile = ({
   onRecipesPress: () => void;
   onFavoritesPress: () => void;
   onProfilePress: () => void;
+  onGamification: () => void;
 }) => {
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -307,6 +309,17 @@ const UserProfile = ({
             <Text style={styles.actionEmoji}>✏️</Text>
           </View>
           <Text style={styles.actionButtonText}>Upraviť profil</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.actionButton, styles.secondaryActionButton]}
+          onPress={onGamification}
+          activeOpacity={0.8}
+        >
+          <View style={styles.actionIcon}>
+            <Text style={styles.actionEmoji}>🏆</Text>
+          </View>
+          <Text style={styles.actionButtonText}>Gamifikácia</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
@@ -566,6 +579,7 @@ const styles = StyleSheet.create({
   },
   quickActions: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     marginHorizontal: scale(16),
     marginBottom: scale(16),
     gap: scale(10),

--- a/src/screens/GamificationScreen.tsx
+++ b/src/screens/GamificationScreen.tsx
@@ -4,7 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { badges, Badge } from '../data/badges';
 import { getUserProgress, UserProgress } from '../services/profileServices';
 
-const ProfileScreen: React.FC = () => {
+const GamificationScreen: React.FC = () => {
   const [progress, setProgress] = useState<UserProgress | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [newBadge, setNewBadge] = useState<Badge | null>(null);
@@ -84,4 +84,4 @@ const styles = StyleSheet.create({
   modalBadgeTitle: { fontSize:16 },
 });
 
-export default ProfileScreen;
+export default GamificationScreen;


### PR DESCRIPTION
## Summary
- Reinstated the original `UserProfile` as the main profile view and added a quick action to open gamification
- Introduced a dedicated `GamificationScreen` and navigation route
- Updated navigation logic to support switching between profile and gamification

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for @invertase/react-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68c559065b10832abb1f09537c3766bd