### PR TITLE
Integrate personalization controls into profile

### DIFF
--- a/src/services/Personalization.ts
+++ b/src/services/Personalization.ts
@@ -1,0 +1,38 @@
+import { privacyManager as basePrivacyManager, preferenceEngine, PERSONALIZATION_USER_ID } from './personalizationGateway';
+import type { TrackingPreferences, TasteProfileVector } from '../types/Personalization';
+import type { ExportPayload } from '../types/Personalization';
+import { PrivacyManager } from './PrivacyManager';
+
+export const DEFAULT_COMMUNITY_AVERAGE: TasteProfileVector = {
+  sweetness: 5,
+  acidity: 5,
+  bitterness: 5,
+  body: 5,
+};
+
+export const optIn: { dataControl: (keyof TrackingPreferences)[] } = {
+  dataControl: ['analytics', 'autoTracking', 'communityInsights'],
+};
+
+const manager: PrivacyManager = basePrivacyManager;
+
+export const privacyManager = {
+  manager,
+  loadPreferences(): Promise<TrackingPreferences> {
+    return manager.loadPreferences(PERSONALIZATION_USER_ID);
+  },
+  exportData(): Promise<ExportPayload> {
+    return manager.exportUserData(PERSONALIZATION_USER_ID);
+  },
+  deleteData(): Promise<void> {
+    return manager.deleteUserData(PERSONALIZATION_USER_ID);
+  },
+  canProcess(flag: keyof TrackingPreferences): Promise<boolean> {
+    return manager.canProcess(flag, PERSONALIZATION_USER_ID);
+  },
+  buildCommunityInsights(): ReturnType<PrivacyManager['buildCommunityInsights']> {
+    return manager.buildCommunityInsights(PERSONALIZATION_USER_ID);
+  },
+};
+
+export { preferenceEngine, PERSONALIZATION_USER_ID };


### PR DESCRIPTION
## Summary
- load personalization profile data via the preference engine when the profile screen mounts and on refresh
- render the taste profile radar visualization and new data control actions that honour privacy opt-in flags
- expose shared personalization helpers, including a privacy manager wrapper, for reuse across the app

## Testing
- npm run lint *(fails: ESLint 9 expects an eslint.config.js; repository still uses .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c88b91a558832ab8b95957f8053fb4