### PR TITLE
Integrate offline connectivity indicators into the app shell

### DIFF
--- a/src/components/offline/QueueStatusBadge.tsx
+++ b/src/components/offline/QueueStatusBadge.tsx
@@ -9,7 +9,8 @@ const QueueStatusBadge: React.FC = () => {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
-    offlineSync.addListener(setCount);
+    const unsubscribe = offlineSync.addListener(setCount);
+    return () => unsubscribe();
   }, []);
 
   if (count === 0) return null;

--- a/src/components/offline/index.ts
+++ b/src/components/offline/index.ts
@@ -1,0 +1,3 @@
+export { default as ConnectionStatusBar } from './ConnectionStatusBar';
+export { default as QueueStatusBadge } from './QueueStatusBadge';
+export { default as SyncProgressIndicator } from './SyncProgressIndicator';

--- a/src/offline/OfflineSync.ts
+++ b/src/offline/OfflineSync.ts
@@ -56,8 +56,20 @@ export class OfflineSync {
   /**
    * Zaregistruj listener na zmeny dĺžky fronty.
    */
-  public addListener(cb: (count: number) => void) {
+  public addListener(cb: (count: number) => void): () => void {
     this.listeners.push(cb);
+    void this.getQueue()
+      .then((queue) => {
+        cb(queue.length);
+      })
+      .catch(() => {
+        cb(0);
+      });
+    return () => this.removeListener(cb);
+  }
+
+  public removeListener(cb: (count: number) => void) {
+    this.listeners = this.listeners.filter((listener) => listener !== cb);
   }
 
   private notify(count: number) {

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -1,0 +1,2 @@
+export { coffeeOfflineManager } from './CoffeeOfflineManager';
+export { offlineSync } from './OfflineSync';


### PR DESCRIPTION
## Summary
- track offline sync queue state in `AppContent` and add the connection status, queue badge, and sync progress indicator to every rendered screen
- trigger offline cache housekeeping plus priority prefetches while exposing offline helpers through new index barrels
- allow offline queue listeners to unsubscribe to prevent memory leaks

## Testing
- npm run lint *(fails: ESLint 9 requires a modern config file)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf4682d64832a81d6e8bcbb2d7990