### PR TITLE
Implement offline caching and offline sync enhancements

### DIFF
--- a/src/services/contentServices.ts
+++ b/src/services/contentServices.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { coffeeOfflineManager } from '../offline';
 const tips = require('../../content/dailyTips.json');
 
 export interface Tip {
@@ -8,15 +9,28 @@ export interface Tip {
 }
 
 const LAST_TIP_KEY = 'lastTip';
+const OFFLINE_TIP_KEY = 'ai:dailyTip';
+const AI_CACHE_TTL = 24;
 
 export const fetchDailyTip = async (): Promise<Tip> => {
   const today = new Date().toISOString().slice(0, 10);
 
   try {
+    const offlineCached = await coffeeOfflineManager.getItem<Tip>(`${OFFLINE_TIP_KEY}:${today}`);
+    if (offlineCached) {
+      return offlineCached;
+    }
+
     const stored = await AsyncStorage.getItem(LAST_TIP_KEY);
     if (stored) {
       const parsed: Tip = JSON.parse(stored);
       if (parsed.date === today) {
+        await coffeeOfflineManager.setItem(
+          `${OFFLINE_TIP_KEY}:${today}`,
+          parsed,
+          AI_CACHE_TTL,
+          4,
+        );
         return parsed;
       }
     }
@@ -34,6 +48,17 @@ export const fetchDailyTip = async (): Promise<Tip> => {
     await AsyncStorage.setItem(LAST_TIP_KEY, JSON.stringify(tip));
   } catch (error) {
     console.error('Error saving last tip:', error);
+  }
+
+  try {
+    await coffeeOfflineManager.setItem(
+      `${OFFLINE_TIP_KEY}:${today}`,
+      tip,
+      AI_CACHE_TTL,
+      4,
+    );
+  } catch (error) {
+    console.error('Error caching daily tip:', error);
   }
 
   return tip;

--- a/src/services/recipeServices.ts
+++ b/src/services/recipeServices.ts
@@ -1,6 +1,23 @@
 import auth from '@react-native-firebase/auth';
 import { API_URL } from './api';
 import { Recipe, BrewDevice } from '../types/Recipe';
+import { coffeeOfflineManager, offlineSync } from '../offline';
+
+const TOP_RECIPES_CACHE_KEY = 'recipes:top';
+const RECIPE_HISTORY_CACHE_KEY = 'recipes:history';
+const USER_RECIPES_CACHE_KEY = 'recipes:user';
+const CACHE_TTL_DAYS = 24 * 7;
+const SECONDARY_CACHE_PRIORITY = 5;
+
+const isOfflineError = (error: unknown) => {
+  if (!error) return false;
+  const message = (error as Error)?.message?.toLowerCase?.() ?? '';
+  return (
+    message.includes('network request failed') ||
+    message.includes('offline') ||
+    message.includes('networkerror')
+  );
+};
 
 const loggedFetch = async (url: string, options: RequestInit) => {
   console.log('📤 [FE->BE]', url, options);
@@ -34,6 +51,7 @@ export const saveRecipe = async (
   taste: string,
   recipe: string
 ): Promise<RecipeHistory | null> => {
+  const payload = { method, taste, recipe };
   try {
     const token = await getAuthToken();
     if (!token) return null;
@@ -47,18 +65,52 @@ export const saveRecipe = async (
       body: JSON.stringify({ method, taste, recipe }),
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      if (res.status === 401) {
+        await offlineSync.enqueue('recipes:create', payload);
+        const optimistic: RecipeHistory = {
+          id: `offline-${Date.now()}`,
+          method,
+          taste,
+          recipe,
+          created_at: new Date().toISOString(),
+        };
+        return optimistic;
+      }
+      return null;
+    }
 
     const data = await res.json();
-    return {
+    const saved: RecipeHistory = {
       id: data.id?.toString() ?? '',
       method,
       taste,
       recipe,
       created_at: new Date().toISOString(),
     };
+    const cachedHistory = await coffeeOfflineManager.getItem<RecipeHistory[]>(
+      RECIPE_HISTORY_CACHE_KEY,
+    );
+    await coffeeOfflineManager.setItem(
+      RECIPE_HISTORY_CACHE_KEY,
+      [saved, ...(cachedHistory ?? [])].slice(0, 50),
+      CACHE_TTL_DAYS,
+      SECONDARY_CACHE_PRIORITY,
+    );
+    return saved;
   } catch (error) {
     console.error('Error saving recipe:', error);
+    if (isOfflineError(error)) {
+      await offlineSync.enqueue('recipes:create', payload);
+      const optimistic: RecipeHistory = {
+        id: `offline-${Date.now()}`,
+        method,
+        taste,
+        recipe,
+        created_at: new Date().toISOString(),
+      };
+      return optimistic;
+    }
     return null;
   }
 };
@@ -66,6 +118,9 @@ export const saveRecipe = async (
 export const fetchRecipeHistory = async (
   limit: number = 10
 ): Promise<RecipeHistory[]> => {
+  const cached = await coffeeOfflineManager.getItem<RecipeHistory[]>(
+    RECIPE_HISTORY_CACHE_KEY,
+  );
   try {
     const token = await getAuthToken();
     if (!token) return [];
@@ -79,18 +134,28 @@ export const fetchRecipeHistory = async (
 
     if (!res.ok) {
       console.warn('Failed to fetch recipe history');
-      return [];
+      return cached ?? [];
     }
 
-    const data = await res.json();
-    return data as RecipeHistory[];
+    const data = (await res.json()) as RecipeHistory[];
+    await coffeeOfflineManager.setItem(
+      RECIPE_HISTORY_CACHE_KEY,
+      data,
+      CACHE_TTL_DAYS,
+      SECONDARY_CACHE_PRIORITY,
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching recipe history:', error);
+    if (cached) {
+      return cached;
+    }
     return [];
   }
 };
 
 export const createRecipe = async (recipe: Recipe): Promise<Recipe | null> => {
+  const payload = { ...recipe };
   try {
     const token = await getAuthToken();
     if (!token) return null;
@@ -104,12 +169,40 @@ export const createRecipe = async (recipe: Recipe): Promise<Recipe | null> => {
       body: JSON.stringify(recipe),
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      if (res.status === 401) {
+        await offlineSync.enqueue('recipes:create', payload);
+        const optimistic = {
+          ...recipe,
+          id: recipe.id || `offline-${Date.now()}`,
+        } as Recipe;
+        return optimistic;
+      }
+      return null;
+    }
 
     const data = await res.json();
-    return { ...data, brewDevice: data.brewDevice as BrewDevice } as Recipe;
+    const created = { ...data, brewDevice: data.brewDevice as BrewDevice } as Recipe;
+    const cachedUserRecipes = await coffeeOfflineManager.getItem<Recipe[]>(
+      USER_RECIPES_CACHE_KEY,
+    );
+    await coffeeOfflineManager.setItem(
+      USER_RECIPES_CACHE_KEY,
+      [created, ...(cachedUserRecipes ?? [])].slice(0, 100),
+      CACHE_TTL_DAYS,
+      SECONDARY_CACHE_PRIORITY,
+    );
+    return created;
   } catch (error) {
     console.error('Error creating recipe:', error);
+    if (isOfflineError(error)) {
+      await offlineSync.enqueue('recipes:create', payload);
+      const optimistic = {
+        ...recipe,
+        id: recipe.id || `offline-${Date.now()}`,
+      } as Recipe;
+      return optimistic;
+    }
     return null;
   }
 };
@@ -118,18 +211,28 @@ const mapRecipes = (arr: any[]): Recipe[] =>
   arr.map((r) => ({ ...r, brewDevice: r.brewDevice as BrewDevice }));
 
 export const fetchRecipes = async (): Promise<Recipe[]> => {
+  const cached = await coffeeOfflineManager.getItem<Recipe[]>(TOP_RECIPES_CACHE_KEY);
   try {
     const res = await loggedFetch(`${API_URL}/recipes`, { method: 'GET' });
-    if (!res.ok) return [];
+    if (!res.ok) return cached ?? [];
     const data = await res.json();
-    return mapRecipes(data);
+    const mapped = mapRecipes(data);
+    await coffeeOfflineManager.setItem(
+      TOP_RECIPES_CACHE_KEY,
+      mapped.slice(0, 50),
+      CACHE_TTL_DAYS,
+      10,
+    );
+    return mapped;
   } catch (error) {
     console.error('Error fetching recipes:', error);
+    if (cached) return cached;
     return [];
   }
 };
 
 export const fetchUserRecipes = async (): Promise<Recipe[]> => {
+  const cached = await coffeeOfflineManager.getItem<Recipe[]>(USER_RECIPES_CACHE_KEY);
   try {
     const token = await getAuthToken();
     if (!token) return [];
@@ -137,11 +240,19 @@ export const fetchUserRecipes = async (): Promise<Recipe[]> => {
       method: 'GET',
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return [];
+    if (!res.ok) return cached ?? [];
     const data = await res.json();
-    return mapRecipes(data);
+    const mapped = mapRecipes(data);
+    await coffeeOfflineManager.setItem(
+      USER_RECIPES_CACHE_KEY,
+      mapped,
+      CACHE_TTL_DAYS,
+      SECONDARY_CACHE_PRIORITY,
+    );
+    return mapped;
   } catch (error) {
     console.error('Error fetching user recipes:', error);
+    if (cached) return cached;
     return [];
   }
 };


### PR DESCRIPTION
## Summary
- cache recipe, coffee, and scan data via `coffeeOfflineManager` with offline fallbacks
- enqueue recipe creation, ratings, and favorites for offline sync when API calls fail
- persist OpenAI responses and daily tips for reuse through the AI fallback system

## Testing
- ⚠️ `npx jest --runTestsByPath __tests__/contentServices.test.ts` *(fails: npm registry access forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfd2c7d24832aae503cc2f4ba4470