### PR TITLE
Add offline fallback for coffee scanner

### DIFF
--- a/__tests__/CoffeeTasteScanner.test.tsx
+++ b/__tests__/CoffeeTasteScanner.test.tsx
@@ -22,7 +22,11 @@ jest.mock('react-native-image-picker', () => ({
   }),
 }));
 
-jest.mock('react-native-fs', () => ({}));
+jest.mock('react-native-fs', () => ({
+  CachesDirectoryPath: '/tmp',
+  writeFile: jest.fn(() => Promise.resolve()),
+  readFile: jest.fn(() => Promise.resolve('')),
+}));
 
 jest.mock('../src/services/ocrServices.ts', () => ({
   processOCR: jest.fn(() => Promise.resolve({


### PR DESCRIPTION
## Summary
- integrate the offline recognition model into CoffeeTasteScanner, including gallery and camera flows with cached results and updated modal messaging
- add offline handling in processOCR so recognizeCoffee is used when ensureOnline detects offline usage
- adjust the CoffeeTasteScanner unit test mocks for the new filesystem usage

## Testing
- npm test -- CoffeeTasteScanner *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc38196958832a841e4e5d77aafd14