### PR TITLE
Configure module resolution aliases

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,16 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: [
+    [
+      'module-resolver',
+      {
+        root: ['./src'],
+        alias: {
+          src: './src',
+          '@components': './src/components',
+          '@services': './src/services',
+        },
+      },
+    ],
+  ],
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
 /**
@@ -6,6 +7,16 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
  *
  * @type {import('@react-native/metro-config').MetroConfig}
  */
-const config = {};
+const projectRoot = __dirname;
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+const config = {
+  resolver: {
+    alias: {
+      src: path.resolve(projectRoot, 'src'),
+      '@components': path.resolve(projectRoot, 'src/components'),
+      '@services': path.resolve(projectRoot, 'src/services'),
+    },
+  },
+};
+
+module.exports = mergeConfig(getDefaultConfig(projectRoot), config);

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
+    "babel-plugin-module-resolver": "^5.0.0",
     "react-test-renderer": "19.1.0",
     "typescript": "5.0.4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "baseUrl": ".",
     "paths": {
       "*": ["src/*", "*"],
+      "src/*": ["src/*"],
       "@components/*": ["src/components/*"],
       "@services/*": ["src/services/*"]
     }


### PR DESCRIPTION
## Summary
- add module-resolver plugin configuration for src, @components, and @services paths
- mirror the same aliases in Metro so bundler resolution matches Babel
- align TypeScript path mapping and declare the module-resolver dev dependency

## Testing
- not run (npm registry returned 403 errors when attempting to install dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68cc47d0414c832ab831f7eadaf6fcb4