### PR TITLE
Implement gamification system and replace nanoid usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.11.0",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
+        "date-fns": "^3.6.0",
         "dotenv": "^17.2.1",
         "expo-auth-session": "^6.2.1",
         "express": "^5.1.0",
@@ -29,9 +30,19 @@
         "react-native": "0.80.1",
         "react-native-dimensions": "^0.0.1",
         "react-native-fs": "^2.20.0",
+        "react-native-haptic-feedback": "^2.2.1",
         "react-native-image-picker": "^8.2.1",
+        "react-native-linear-gradient": "^2.8.3",
         "react-native-permissions": "^5.4.1",
-        "react-native-vision-camera": "^4.7.1"
+        "react-native-push-notification": "^8.1.1",
+        "react-native-safe-area-context": "^5.6.1",
+        "react-native-screens": "^4.16.0",
+        "react-native-sound": "^0.11.3",
+        "react-native-svg": "^15.8.0",
+        "react-native-vector-icons": "^10.3.0",
+        "react-native-vision-camera": "^4.7.1",
+        "react-native-3d-model-view": "^1.0.1",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
+    "date-fns": "^3.6.0",
     "expo-auth-session": "^6.2.1",
     "express": "^5.1.0",
     "firebase-admin": "^13.4.0",
@@ -41,6 +42,7 @@
     "react-native-dimensions": "^0.0.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.15.0",
+    "react-native-haptic-feedback": "^2.2.1",
     "react-native-reanimated": "^3.16.1",
     "react-native-image-picker": "^8.2.1",
     "react-native-linear-gradient": "^2.8.3",
@@ -50,7 +52,10 @@
     "react-native-screens": "^4.16.0",
     "react-native-svg": "^15.8.0",
     "react-native-vector-icons": "^10.3.0",
-    "react-native-vision-camera": "^4.7.1"
+    "react-native-vision-camera": "^4.7.1",
+    "react-native-3d-model-view": "^1.0.1",
+    "react-native-sound": "^0.11.3",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/gamification/AchievementShowcase.tsx
+++ b/src/components/gamification/AchievementShowcase.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Share } from 'react-native';
+import ModelView from 'react-native-3d-model-view';
+import Animated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
+import type { AchievementProgress, AchievementDefinition } from '../../types/gamification';
+
+interface Props {
+  achievements: (AchievementProgress & { definition?: AchievementDefinition })[];
+}
+
+const rarityColors: Record<string, string> = {
+  common: '#a0aec0',
+  rare: '#63b3ed',
+  epic: '#b794f4',
+  legendary: '#f6ad55',
+};
+
+/**
+ * 3D vitrína pre odznaky s možnosťou zdieľania.
+ */
+export const AchievementShowcase: React.FC<Props> = ({ achievements }) => {
+  const glow = useSharedValue(0.6);
+
+  useEffect(() => {
+    glow.value = withRepeat(withTiming(1, { duration: 1600 }), -1, true);
+  }, [glow]);
+
+  const glowStyle = useAnimatedStyle(() => ({
+    shadowOpacity: 0.6 + glow.value * 0.4,
+    transform: [{ scale: 0.95 + glow.value * 0.05 }],
+  }));
+
+  const handleShare = async (achievement: AchievementProgress & { definition?: AchievementDefinition }) => {
+    try {
+      await Share.share({
+        message: `Práve som získal odznak ${achievement.definition?.name ?? achievement.achievementId} v BrewMate! ☕️🔥`,
+      });
+    } catch (error) {
+      console.warn('AchievementShowcase: zdieľanie zlyhalo', error);
+    }
+  };
+
+  if (achievements.length === 0) {
+    return (
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyTitle}>Zbierka odznakov čaká</Text>
+        <Text style={styles.emptySubtitle}>Dokonči výzvy a objaví sa tu tvoja sláva.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {achievements.slice(0, 3).map((achievement) => {
+        const rarity = achievement.definition?.rarity ?? 'common';
+        const modelSource = achievement.definition?.featureUnlock?.endsWith('.glb')
+          ? { uri: achievement.definition?.featureUnlock }
+          : undefined;
+        return (
+          <Animated.View key={achievement.achievementId} style={[styles.card, glowStyle]}> 
+            <View style={[styles.badgeContainer, { borderColor: rarityColors[rarity] ?? '#a0aec0' }]}> 
+              {modelSource ? (
+                <ModelView
+                  style={styles.model}
+                  source={modelSource}
+                  scale={0.2}
+                  translateZ={-2}
+                  rotateX={20}
+                  rotateZ={45}
+                  autoPlay
+                />
+              ) : (
+                <View style={[styles.placeholder, { backgroundColor: rarityColors[rarity] ?? '#444' }]} />
+              )}
+            </View>
+            <Text style={styles.badgeTitle}>{achievement.definition?.name ?? achievement.achievementId}</Text>
+            <Text style={styles.badgeDescription}>{achievement.definition?.description ?? 'Unikátny odznak'}</Text>
+            <TouchableOpacity style={styles.shareButton} onPress={() => handleShare(achievement)}>
+              <Text style={styles.shareText}>Zdieľať</Text>
+            </TouchableOpacity>
+          </Animated.View>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    padding: 16,
+  },
+  card: {
+    width: 120,
+    backgroundColor: 'rgba(19, 20, 30, 0.9)',
+    borderRadius: 16,
+    padding: 12,
+    alignItems: 'center',
+    shadowColor: '#f6ad55',
+    shadowOffset: { width: 0, height: 0 },
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  badgeContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+  },
+  model: {
+    width: 80,
+    height: 80,
+  },
+  placeholder: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    opacity: 0.7,
+  },
+  badgeTitle: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  badgeDescription: {
+    color: '#cbd5f5',
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  shareButton: {
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: '#f6ad55',
+  },
+  shareText: {
+    color: '#1f1f2e',
+    fontWeight: '700',
+  },
+  emptyState: {
+    padding: 24,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  emptySubtitle: {
+    color: '#a0aec0',
+    marginTop: 4,
+  },
+});

--- a/src/components/gamification/DailyQuestCard.tsx
+++ b/src/components/gamification/DailyQuestCard.tsx
@@ -1,0 +1,156 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { PanGestureHandler } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import type { DailyQuestInstance } from '../../types/gamification';
+
+interface Props {
+  quest: DailyQuestInstance;
+  onClaim(): void;
+}
+
+/**
+ * Karta dennej výzvy so swipe interakciou a animáciou odmeny.
+ */
+export const DailyQuestCard: React.FC<Props> = ({ quest, onClaim }) => {
+  const translateX = useSharedValue(0);
+  const claimed = quest.completed;
+
+  const gesture = useAnimatedGestureHandler({
+    onActive: (event) => {
+      translateX.value = Math.min(Math.max(event.translationX, -40), 40);
+    },
+    onEnd: () => {
+      translateX.value = withSpring(0);
+    },
+  });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const rewardStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: claimed ? withSpring(1.1) : withTiming(1) }],
+    opacity: withTiming(claimed ? 1 : 0.8),
+  }));
+
+  const progressRatio = quest.goal === 0 ? 0 : quest.progress / quest.goal;
+  const countdown = useMemo(() => formatDistanceToNowStrict(parseISO(quest.expiresAt)), [quest.expiresAt]);
+
+  return (
+    <PanGestureHandler onGestureEvent={gesture}>
+      <Animated.View style={[styles.card, animatedStyle]}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{(quest.metadata as any)?.title ?? 'Denná výzva'}</Text>
+          <Animated.View style={[styles.reward, rewardStyle]}>
+            <Text style={styles.rewardText}>+{quest.xpReward} XP</Text>
+          </Animated.View>
+        </View>
+        <Text style={styles.description}>{(quest.metadata as any)?.description ?? ''}</Text>
+        <View style={styles.progressBar}>
+          <View style={[styles.progressFill, { width: `${Math.min(100, progressRatio * 100)}%` }]} />
+        </View>
+        <View style={styles.footer}>
+          <Text style={styles.progressLabel}>
+            {quest.progress}/{quest.goal}
+          </Text>
+          <Text style={styles.timer}>Do konca {countdown}</Text>
+        </View>
+        <TouchableOpacity
+          style={[styles.claimButton, claimed && styles.claimedButton]}
+          disabled={!claimed}
+          onPress={onClaim}
+        >
+          <Text style={[styles.claimText, claimed && styles.claimedText]}>{claimed ? 'Získať odmenu' : 'Pracuj na úlohe'}</Text>
+        </TouchableOpacity>
+      </Animated.View>
+    </PanGestureHandler>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: 'rgba(26, 28, 38, 0.95)',
+    borderRadius: 18,
+    padding: 16,
+    marginVertical: 10,
+    shadowColor: '#2d3748',
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  reward: {
+    backgroundColor: '#f6ad55',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  rewardText: {
+    color: '#1a1c26',
+    fontWeight: '700',
+  },
+  description: {
+    color: '#cbd5f5',
+    fontSize: 13,
+    marginTop: 6,
+  },
+  progressBar: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#2d3140',
+    overflow: 'hidden',
+    marginTop: 12,
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 4,
+    backgroundColor: '#63b3ed',
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  progressLabel: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  timer: {
+    color: '#a0aec0',
+    fontSize: 12,
+  },
+  claimButton: {
+    marginTop: 14,
+    borderRadius: 16,
+    backgroundColor: '#2d3748',
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  claimedButton: {
+    backgroundColor: '#48bb78',
+  },
+  claimText: {
+    color: '#9fa7bf',
+    fontWeight: '600',
+  },
+  claimedText: {
+    color: '#fff',
+  },
+});

--- a/src/components/gamification/LevelProgressBar.tsx
+++ b/src/components/gamification/LevelProgressBar.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import Animated, {
+  useAnimatedStyle,
+  useAnimatedProps,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  Easing,
+  type SharedValue,
+} from 'react-native-reanimated';
+import LinearGradient from 'react-native-linear-gradient';
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
+interface Props {
+  level: number;
+  currentXp: number;
+  xpToNextLevel: number;
+  title: string;
+}
+
+/**
+ * Animovaný kruhový progress bar s časticami pre levelovanie.
+ */
+export const LevelProgressBar: React.FC<Props> = ({ level, currentXp, xpToNextLevel, title }) => {
+  const progress = useSharedValue(0);
+  const pulse = useSharedValue(0);
+  const flyingXp = useSharedValue(0);
+
+  const strokeDasharray = useMemo(() => 2 * Math.PI * 64, []);
+
+  useEffect(() => {
+    const ratio = Math.min(1, xpToNextLevel === 0 ? 0 : currentXp / xpToNextLevel);
+    progress.value = withTiming(ratio, { duration: 800, easing: Easing.out(Easing.cubic) });
+    flyingXp.value = withTiming(currentXp, { duration: 600 });
+    if (ratio >= 1) {
+      pulse.value = withSpring(1, { damping: 12, stiffness: 120 }, () => {
+        pulse.value = withTiming(0, { duration: 400 });
+      });
+    }
+  }, [currentXp, progress, xpToNextLevel, pulse, flyingXp]);
+
+  const animatedProps = useAnimatedProps(() => ({
+    strokeDashoffset: strokeDasharray * (1 - progress.value),
+  }));
+
+  const pulseStyle = useAnimatedProps(() => ({
+    opacity: pulse.value,
+    r: 72 + pulse.value * 12,
+  }));
+
+  const xpText = useAnimatedProps(() => ({
+    text: `${Math.round(flyingXp.value)}/${xpToNextLevel}`,
+  }));
+
+  const particleAngles = useMemo(() => Array.from({ length: 8 }, (_, index) => index * (Math.PI / 4)), []);
+
+  return (
+    <View style={styles.container}>
+      <LinearGradient colors={['#35234b', '#1c1f2b']} style={styles.gradient}>
+        <Svg width={180} height={180} viewBox="0 0 180 180">
+          <AnimatedCircle
+            cx={90}
+            cy={90}
+            animatedProps={pulseStyle as any}
+            stroke="#C38FFF"
+            strokeWidth={2}
+            fill="none"
+          />
+          <Circle cx={90} cy={90} r={64} stroke="#1d1f2b" strokeWidth={14} fill="rgba(18,18,28,0.8)" />
+          <AnimatedCircle
+            cx={90}
+            cy={90}
+            r={64}
+            stroke="#ffdd8d"
+            strokeWidth={14}
+            strokeDasharray={`${strokeDasharray} ${strokeDasharray}`}
+            animatedProps={animatedProps}
+            strokeLinecap="round"
+            fill="transparent"
+          />
+        </Svg>
+        <View style={styles.textContainer}>
+          <Text style={styles.levelTitle}>{title}</Text>
+          <Text style={styles.levelNumber}>Level {level}</Text>
+          <AnimatedText style={styles.xpText} animatedProps={xpText as any}>
+            {`${currentXp}/${xpToNextLevel}`}
+          </AnimatedText>
+          <Text style={styles.caption}>XP do ďalšieho levelu</Text>
+        </View>
+        <View style={styles.particles}>
+          {particleAngles.map((angle) => (
+            <Particle key={angle} angle={angle} progress={progress} />
+          ))}
+        </View>
+      </LinearGradient>
+    </View>
+  );
+};
+
+const Particle: React.FC<{ angle: number; progress: SharedValue<number> }> = ({ angle, progress }) => {
+  const style = useAnimatedStyle(() => ({
+    opacity: progress.value,
+    transform: [
+      { translateX: Math.cos(angle) * 50 },
+      { translateY: Math.sin(angle) * 50 },
+      { scale: 0.8 + progress.value * 0.4 },
+    ],
+  }));
+
+  return <Animated.View style={[styles.particle, style]} />;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gradient: {
+    borderRadius: 20,
+    padding: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  textContainer: {
+    position: 'absolute',
+    alignItems: 'center',
+  },
+  levelTitle: {
+    color: '#d6ccff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  levelNumber: {
+    color: '#ffffff',
+    fontSize: 28,
+    fontWeight: '700',
+    marginTop: 8,
+  },
+  xpText: {
+    color: '#ffdd8d',
+    fontSize: 16,
+    marginTop: 4,
+    fontWeight: '500',
+  },
+  caption: {
+    color: '#9aa0b0',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  particles: {
+    position: 'absolute',
+    width: 160,
+    height: 160,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  particle: {
+    position: 'absolute',
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#ffdd8d',
+  },
+});

--- a/src/components/gamification/StatsRadarChart.tsx
+++ b/src/components/gamification/StatsRadarChart.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Svg, { Polygon, Line, Text as SvgText } from 'react-native-svg';
+import Animated, { useAnimatedProps, useSharedValue, withTiming } from 'react-native-reanimated';
+import type { RadarStat } from '../../types/gamification';
+
+interface Props {
+  stats: RadarStat[];
+}
+
+const AnimatedPolygon = Animated.createAnimatedComponent(Polygon);
+
+/**
+ * Radarový graf so štatistikami hráča.
+ */
+export const StatsRadarChart: React.FC<Props> = ({ stats }) => {
+  const animated = useSharedValue(0);
+  const animatedPlayerProps = useAnimatedProps(() => ({ opacity: animated.value }));
+  const animatedAverageProps = useAnimatedProps(() => ({ opacity: animated.value }));
+
+  useEffect(() => {
+    animated.value = withTiming(1, { duration: 600 });
+  }, [animated, stats]);
+
+  const points = useMemo(() => buildPoints(stats, (value) => value), [stats]);
+  const averagePoints = useMemo(() => buildPoints(stats, (value, stat) => stat.average), [stats]);
+
+  return (
+    <View style={styles.container}>
+      <Svg width={220} height={220} viewBox="-110 -110 220 220">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Polygon
+            key={index}
+            points={buildGrid(stats.length, (index + 1) / 4)}
+            stroke="rgba(255,255,255,0.1)"
+            strokeWidth={1}
+            fill="none"
+          />
+        ))}
+        {stats.map((stat, index) => {
+          const angle = (index / stats.length) * Math.PI * 2;
+          return (
+            <Line
+              key={stat.key}
+              x1={0}
+              y1={0}
+              x2={Math.cos(angle) * 100}
+              y2={Math.sin(angle) * 100}
+              stroke="rgba(255,255,255,0.1)"
+              strokeWidth={1}
+            />
+          );
+        })}
+        <AnimatedPolygon
+          points={points}
+          fill="rgba(99, 179, 237, 0.35)"
+          stroke="#63b3ed"
+          strokeWidth={2}
+          animatedProps={animatedPlayerProps}
+        />
+        <AnimatedPolygon
+          points={averagePoints}
+          fill="rgba(251, 211, 141, 0.25)"
+          stroke="#fbd38d"
+          strokeWidth={2}
+          animatedProps={animatedAverageProps}
+        />
+        {stats.map((stat, index) => {
+          const angle = (index / stats.length) * Math.PI * 2;
+          const x = Math.cos(angle) * 110;
+          const y = Math.sin(angle) * 110;
+          return (
+            <SvgText key={stat.key} x={x} y={y} fill="#fff" fontSize={12} textAnchor={x > 0 ? 'start' : 'end'}>
+              {labelMap[stat.key] ?? stat.key}
+            </SvgText>
+          );
+        })}
+      </Svg>
+      <View style={styles.legend}>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: '#63b3ed' }]} />
+          <Text style={styles.legendText}>Tvoje skóre</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: '#fbd38d' }]} />
+          <Text style={styles.legendText}>Komunita</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const labelMap: Record<RadarStat['key'], string> = {
+  brewing: 'Brew',
+  exploration: 'Objavy',
+  social: 'Komunita',
+  knowledge: 'Znalosti',
+};
+
+const buildGrid = (count: number, factor: number) => {
+  const angleStep = (Math.PI * 2) / count;
+  return Array.from({ length: count }, (_, index) => {
+    const angle = angleStep * index;
+    const radius = 100 * factor;
+    return `${Math.cos(angle) * radius},${Math.sin(angle) * radius}`;
+  }).join(' ');
+};
+
+const buildPoints = (stats: RadarStat[], selector: (value: number, stat: RadarStat) => number) => {
+  const angleStep = (Math.PI * 2) / stats.length;
+  return stats
+    .map((stat, index) => {
+      const value = selector(stat.value, stat);
+      const radius = (value / 100) * 100;
+      const angle = angleStep * index;
+      return `${Math.cos(angle) * radius},${Math.sin(angle) * radius}`;
+    })
+    .join(' ');
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  legend: {
+    flexDirection: 'row',
+    marginTop: 12,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 12,
+  },
+  legendDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    marginRight: 6,
+  },
+  legendText: {
+    color: '#a0aec0',
+  },
+});

--- a/src/hooks/useGamificationServices.tsx
+++ b/src/hooks/useGamificationServices.tsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import type { GamificationService } from '../services/gamification/GamificationService';
+
+const GamificationServiceContext = createContext<GamificationService | null>(null);
+
+interface ProviderProps {
+  service: GamificationService | null;
+  children: React.ReactNode;
+}
+
+/**
+ * Poskytuje gamifikačnú službu komponentom cez Context.
+ */
+export const GamificationServiceProvider: React.FC<ProviderProps> = ({ service, children }) => {
+  const value = useMemo(() => service, [service]);
+  return <GamificationServiceContext.Provider value={value}>{children}</GamificationServiceContext.Provider>;
+};
+
+export const useGamificationServices = () => useContext(GamificationServiceContext);

--- a/src/hooks/useGamificationStore.ts
+++ b/src/hooks/useGamificationStore.ts
@@ -1,0 +1,264 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  DailyQuestInstance,
+  GamificationStateSnapshot,
+  GamificationTitle,
+  LeaderboardEntry,
+  LeaderboardRange,
+  LeaderboardScope,
+  RadarStat,
+  SeasonalEventConfig,
+  SkillTreeNode,
+} from '../types/gamification';
+
+/**
+ * Rozhranie opisujúce stav gamifikácie.
+ */
+interface GamificationState {
+  userId: string | null;
+  level: number;
+  currentXp: number;
+  xpToNextLevel: number;
+  skillPoints: number;
+  title: GamificationTitle;
+  comboMultiplier: number;
+  doubleXpActive: boolean;
+  streakDays: number;
+  brewStreakDays: number;
+  perfectWeek: boolean;
+  freezeTokens: number;
+  skillTree: SkillTreeNode[];
+  achievements: AchievementProgress[];
+  achievementDefinitions: AchievementDefinition[];
+  featuredAchievements: string[];
+  dailyQuests: DailyQuestInstance[];
+  leaderboard: Record<`${LeaderboardScope}:${LeaderboardRange}`, LeaderboardEntry[]>;
+  radarStats: RadarStat[];
+  seasonalEvents: SeasonalEventConfig[];
+  initialized: boolean;
+  lastSyncAt?: string;
+  pendingXpQueue: { source: string; amount: number; timestamp: string }[];
+  setUser(userId: string | null): void;
+  hydrate(snapshot: GamificationStateSnapshot): void;
+  setInitialized(value: boolean): void;
+  addXp(amount: number, xpToNextLevel: number, comboMultiplier: number): void;
+  setLevel(level: number): void;
+  setSkillPoints(points: number): void;
+  spendSkillPoint(nodeId: string): void;
+  setDoubleXp(active: boolean): void;
+  setTitle(title: GamificationTitle): void;
+  updateStreaks(params: { streakDays: number; brewStreakDays: number; perfectWeek: boolean; freezeTokens: number }): void;
+  setAchievements(achievements: AchievementProgress[]): void;
+  setAchievementDefinitions(definitions: AchievementDefinition[]): void;
+  updateAchievementProgress(progress: AchievementProgress): void;
+  setFeaturedAchievements(ids: string[]): void;
+  setDailyQuests(quests: DailyQuestInstance[]): void;
+  updateQuestProgress(questId: string, data: Partial<DailyQuestInstance>): void;
+  setLeaderboard(key: `${LeaderboardScope}:${LeaderboardRange}`, entries: LeaderboardEntry[]): void;
+  setRadarStats(stats: RadarStat[]): void;
+  setSeasonalEvents(events: SeasonalEventConfig[]): void;
+  enqueueXp(source: string, amount: number): void;
+  flushXpQueue(): { source: string; amount: number; timestamp: string }[];
+}
+
+/**
+ * Východiskový stav gamifikácie pre nového používateľa.
+ */
+const DEFAULT_STATE: Omit<GamificationState, keyof GamificationStateSnapshot | 'setUser' | 'hydrate' | 'setInitialized' | 'addXp' | 'setLevel' | 'setSkillPoints' | 'spendSkillPoint' | 'setDoubleXp' | 'setTitle' | 'updateStreaks' | 'setAchievements' | 'updateAchievementProgress' | 'setDailyQuests' | 'updateQuestProgress' | 'setLeaderboard' | 'setRadarStats' | 'setSeasonalEvents' | 'enqueueXp' | 'flushXpQueue'> = {
+  userId: null,
+  level: 1,
+  currentXp: 0,
+  xpToNextLevel: 100,
+  skillPoints: 0,
+  title: 'Coffee Curious',
+  comboMultiplier: 1,
+  doubleXpActive: false,
+  streakDays: 0,
+  brewStreakDays: 0,
+  perfectWeek: false,
+  freezeTokens: 0,
+  skillTree: [],
+  achievements: [],
+  achievementDefinitions: [],
+  featuredAchievements: [],
+  dailyQuests: [],
+  leaderboard: {},
+  radarStats: [],
+  seasonalEvents: [],
+  initialized: false,
+  pendingXpQueue: [],
+};
+
+/**
+ * Zustand store pre gamifikačný stav aplikácie.
+ */
+export const useGamificationStore = create<GamificationState>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULT_STATE,
+      setUser(userId) {
+        set({ userId });
+      },
+      hydrate(snapshot) {
+        set({
+          userId: snapshot.userId,
+          level: snapshot.level,
+          currentXp: snapshot.currentXp,
+          xpToNextLevel: snapshot.xpToNextLevel,
+          skillPoints: snapshot.skillPoints,
+          comboMultiplier: snapshot.comboMultiplier,
+          doubleXpActive: snapshot.doubleXpActive,
+          title: snapshot.title,
+          streakDays: snapshot.streakDays,
+          brewStreakDays: snapshot.brewStreakDays,
+          perfectWeek: snapshot.perfectWeek,
+          freezeTokens: snapshot.freezeTokens,
+          radarStats: snapshot.radarStats,
+          skillTree: snapshot.skillTree,
+        });
+      },
+      setInitialized(value) {
+        set({ initialized: value, lastSyncAt: new Date().toISOString() });
+      },
+      addXp(amount, xpToNextLevel, comboMultiplier) {
+        set((state) => ({
+          currentXp: Math.max(0, state.currentXp + amount),
+          xpToNextLevel,
+          comboMultiplier,
+        }));
+      },
+      setLevel(level) {
+        set({ level });
+      },
+      setSkillPoints(points) {
+        set({ skillPoints: points });
+      },
+      spendSkillPoint(nodeId) {
+        set((state) => {
+          if (state.skillPoints <= 0) {
+            return state;
+          }
+          return {
+            skillPoints: state.skillPoints - 1,
+            skillTree: state.skillTree.map((node) =>
+              node.id === nodeId ? { ...node, unlocked: true } : node,
+            ),
+          };
+        });
+      },
+      setDoubleXp(active) {
+        set({ doubleXpActive: active });
+      },
+      setTitle(title) {
+        set({ title });
+      },
+      updateStreaks({ streakDays, brewStreakDays, perfectWeek, freezeTokens }) {
+        set({ streakDays, brewStreakDays, perfectWeek, freezeTokens });
+      },
+      setAchievements(achievements) {
+        set({ achievements });
+      },
+      setAchievementDefinitions(definitions) {
+        set({ achievementDefinitions: definitions });
+      },
+      setFeaturedAchievements(ids) {
+        set({ featuredAchievements: ids });
+      },
+      updateAchievementProgress(progress) {
+        set((state) => ({
+          achievements: state.achievements.some((item) => item.achievementId === progress.achievementId)
+            ? state.achievements.map((item) =>
+                item.achievementId === progress.achievementId ? { ...item, ...progress } : item,
+              )
+            : [...state.achievements, progress],
+        }));
+      },
+      setDailyQuests(quests) {
+        set({ dailyQuests: quests });
+      },
+      updateQuestProgress(questId, data) {
+        set((state) => ({
+          dailyQuests: state.dailyQuests.map((quest) =>
+            quest.id === questId ? { ...quest, ...data } : quest,
+          ),
+        }));
+      },
+      setLeaderboard(key, entries) {
+        set((state) => ({ leaderboard: { ...state.leaderboard, [key]: entries } }));
+      },
+      setRadarStats(stats) {
+        set({ radarStats: stats });
+      },
+      setSeasonalEvents(events) {
+        set({ seasonalEvents: events });
+      },
+      enqueueXp(source, amount) {
+        set((state) => ({
+          pendingXpQueue: [
+            ...state.pendingXpQueue,
+            { source, amount, timestamp: new Date().toISOString() },
+          ].slice(-50),
+        }));
+      },
+      flushXpQueue() {
+        const queue = get().pendingXpQueue;
+        set({ pendingXpQueue: [] });
+        return queue;
+      },
+    }),
+    {
+      name: 'brewmate-gamification-state',
+      storage: {
+        getItem: async (name) => {
+          const value = await AsyncStorage.getItem(name);
+          return value ? JSON.parse(value) : null;
+        },
+        setItem: async (name, value) => {
+          await AsyncStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: async (name) => {
+          await AsyncStorage.removeItem(name);
+        },
+      },
+      partialize: (state) => ({
+        userId: state.userId,
+        level: state.level,
+        currentXp: state.currentXp,
+        xpToNextLevel: state.xpToNextLevel,
+        skillPoints: state.skillPoints,
+        title: state.title,
+        comboMultiplier: state.comboMultiplier,
+        doubleXpActive: state.doubleXpActive,
+        streakDays: state.streakDays,
+        brewStreakDays: state.brewStreakDays,
+        perfectWeek: state.perfectWeek,
+        freezeTokens: state.freezeTokens,
+        skillTree: state.skillTree,
+        achievements: state.achievements,
+        achievementDefinitions: state.achievementDefinitions,
+        featuredAchievements: state.featuredAchievements,
+        dailyQuests: state.dailyQuests,
+        seasonalEvents: state.seasonalEvents,
+        radarStats: state.radarStats,
+      }),
+      version: 2,
+      migrate: async (persistedState, version) => {
+        if (version < 2) {
+          return {
+            ...DEFAULT_STATE,
+            ...persistedState,
+            seasonalEvents: [],
+            radarStats: persistedState?.radarStats ?? [],
+          } satisfies Partial<GamificationState>;
+        }
+        return persistedState as GamificationState;
+      },
+    },
+  ),
+);
+
+export type GamificationStoreState = ReturnType<typeof useGamificationStore.getState>;

--- a/src/screens/GamificationScreen.tsx
+++ b/src/screens/GamificationScreen.tsx
@@ -1,87 +1,243 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { View, Text, FlatList, StyleSheet, Modal, Animated } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { badges, Badge } from '../data/badges';
-import { getUserProgress, UserProgress } from '../services/profileServices';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { ScrollView, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
+import { LevelProgressBar } from '../components/gamification/LevelProgressBar';
+import { AchievementShowcase } from '../components/gamification/AchievementShowcase';
+import { DailyQuestCard } from '../components/gamification/DailyQuestCard';
+import { StatsRadarChart } from '../components/gamification/StatsRadarChart';
+import { useGamificationStore } from '../hooks/useGamificationStore';
+import { useGamificationServices } from '../hooks/useGamificationServices';
 
 const GamificationScreen: React.FC = () => {
-  const [progress, setProgress] = useState<UserProgress | null>(null);
-  const [modalVisible, setModalVisible] = useState(false);
-  const [newBadge, setNewBadge] = useState<Badge | null>(null);
-  const scaleAnim = useRef(new Animated.Value(0)).current;
+  const services = useGamificationServices();
+  const {
+    level,
+    currentXp,
+    xpToNextLevel,
+    title,
+    dailyQuests,
+    achievements,
+    achievementDefinitions,
+    radarStats,
+    seasonalEvents,
+    streakDays,
+    comboMultiplier,
+    doubleXpActive,
+    leaderboard,
+  } = useGamificationStore((state) => ({
+    level: state.level,
+    currentXp: state.currentXp,
+    xpToNextLevel: state.xpToNextLevel,
+    title: state.title,
+    dailyQuests: state.dailyQuests,
+    achievements: state.achievements,
+    achievementDefinitions: state.achievementDefinitions,
+    radarStats: state.radarStats,
+    seasonalEvents: state.seasonalEvents,
+    streakDays: state.streakDays,
+    comboMultiplier: state.comboMultiplier,
+    doubleXpActive: state.doubleXpActive,
+    leaderboard: state.leaderboard,
+  }));
+
+  const showcaseData = useMemo(
+    () =>
+      achievements
+        .filter((achievement) => achievement.unlockedAt)
+        .map((progress) => ({
+          ...progress,
+          definition: achievementDefinitions.find((item) => item.id === progress.achievementId),
+        })),
+    [achievements, achievementDefinitions],
+  );
 
   useEffect(() => {
-    const load = async () => {
-      const p = await getUserProgress();
-      setProgress(p);
-      if (p.lastBadge) {
-        const badge = badges.find((b) => b.id === p.lastBadge) || null;
-        setNewBadge(badge);
-        setModalVisible(true);
-        Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true }).start();
-        p.lastBadge = undefined;
-        await AsyncStorage.setItem('userProgress', JSON.stringify(p));
+    if (!services) {
+      return;
+    }
+    void services.refreshLeaderboards('global', 'weekly');
+  }, [services]);
+
+  const handleQuestClaim = useCallback(
+    (questId: string) => {
+      if (!services) {
+        return;
       }
-    };
-    load();
-  }, [scaleAnim]);
+      void services.getDailyQuestService().applyProgress(questId, 0);
+    },
+    [services],
+  );
 
-  const unlocked = progress?.badges || [];
+  const handleLeaderboardPress = useCallback(() => {
+    if (!services) {
+      return;
+    }
+    void services.refreshLeaderboards('global', 'weekly');
+  }, [services]);
 
-  const renderBadge = ({ item }: { item: Badge }) => {
-    const isUnlocked = unlocked.includes(item.id);
-    return (
-      <View style={[styles.badge, { opacity: isUnlocked ? 1 : 0.3 }]}> 
-        <Text style={styles.badgeIcon}>{item.icon}</Text>
-        <Text style={styles.badgeText}>{item.title}</Text>
-      </View>
-    );
-  };
-
-  const levelPercent = progress ? ((progress.level - 1) / 9) * 100 : 0;
+  const topLeaderboard = useMemo(() => leaderboard['global:weekly'] ?? [], [leaderboard]);
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.levelText}>Úroveň {progress?.level || 1}/10</Text>
-      <View style={styles.progressBar}>
-        <View style={[styles.progressFill, { width: `${levelPercent}%` }]} />
-      </View>
-
-      <FlatList
-        data={badges}
-        renderItem={renderBadge}
-        keyExtractor={(item) => item.id}
-        numColumns={3}
-        contentContainerStyle={styles.badgeGrid}
-      />
-
-      <Modal visible={modalVisible} transparent animationType="fade">
-        <View style={styles.modalBackdrop}>
-          <Animated.View style={[styles.modalContent, { transform: [{ scale: scaleAnim }] }]}> 
-            <Text style={styles.modalEmoji}>🎉</Text>
-            <Text style={styles.modalText}>Gratulujeme!</Text>
-            {newBadge && <Text style={styles.modalBadgeTitle}>{newBadge.title}</Text>}
-          </Animated.View>
+    <ScrollView contentContainerStyle={styles.container}>
+      <Animated.View entering={FadeInDown.duration(600)} style={styles.section}>
+        <LevelProgressBar level={level} currentXp={currentXp} xpToNextLevel={xpToNextLevel} title={title} />
+        <View style={styles.metaRow}>
+          <Text style={styles.metaText}>Denný streak: {streakDays} dní</Text>
+          <Text style={styles.metaText}>Combo: {comboMultiplier.toFixed(2)}x</Text>
+          {doubleXpActive && <Text style={styles.doubleXp}>DOUBLE XP aktívne</Text>}
         </View>
-      </Modal>
-    </View>
+      </Animated.View>
+
+      <Animated.View entering={FadeInUp.delay(150)} style={styles.section}>
+        <Text style={styles.sectionTitle}>Aktuálne výzvy</Text>
+        {dailyQuests.map((quest) => (
+          <DailyQuestCard key={quest.id} quest={quest} onClaim={() => handleQuestClaim(quest.id)} />
+        ))}
+        {dailyQuests.length === 0 && <Text style={styles.empty}>Žiadne denné úlohy. Vráť sa neskôr!</Text>}
+      </Animated.View>
+
+      <Animated.View entering={FadeInUp.delay(300)} style={styles.section}>
+        <Text style={styles.sectionTitle}>Trofeje</Text>
+        <AchievementShowcase achievements={showcaseData} />
+      </Animated.View>
+
+      <Animated.View entering={FadeInUp.delay(450)} style={styles.section}>
+        <Text style={styles.sectionTitle}>Tvoje štatistiky</Text>
+        {radarStats.length > 0 ? <StatsRadarChart stats={radarStats} /> : <Text style={styles.empty}>Zbierame dáta…</Text>}
+      </Animated.View>
+
+      <Animated.View entering={FadeInUp.delay(600)} style={styles.section}>
+        <View style={styles.leaderboardHeader}>
+          <Text style={styles.sectionTitle}>Top hráči</Text>
+          <TouchableOpacity style={styles.leaderboardButton} onPress={handleLeaderboardPress}>
+            <Text style={styles.leaderboardButtonText}>Celý rebríček →</Text>
+          </TouchableOpacity>
+        </View>
+        {topLeaderboard.slice(0, 3).map((entry) => (
+          <View key={entry.userId} style={styles.leaderboardRow}>
+            <Text style={styles.leaderboardRank}>#{entry.rank}</Text>
+            <View style={styles.leaderboardInfo}>
+              <Text style={styles.leaderboardName}>{entry.displayName}</Text>
+              <Text style={styles.leaderboardSubtitle}>{entry.title}</Text>
+            </View>
+            <Text style={styles.leaderboardXp}>{entry.xp} XP</Text>
+          </View>
+        ))}
+        {topLeaderboard.length === 0 && <Text style={styles.empty}>Rebríček sa pripravuje…</Text>}
+      </Animated.View>
+
+      {seasonalEvents.length > 0 && (
+        <Animated.View entering={FadeInUp.delay(750)} style={styles.section}>
+          <Text style={styles.sectionTitle}>Sezónne udalosti</Text>
+          {seasonalEvents.map((event) => (
+            <View key={event.id} style={styles.eventCard}>
+              <Text style={styles.eventTitle}>{event.title}</Text>
+              <Text style={styles.eventSubtitle}>{event.theme}</Text>
+              <Text style={styles.eventBonus}>Bonus XP: {event.bonusXpMultiplier}x</Text>
+            </View>
+          ))}
+        </Animated.View>
+      )}
+    </ScrollView>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20 },
-  levelText: { fontSize: 18, marginBottom: 10, textAlign: 'center' },
-  progressBar: { height: 10, backgroundColor: '#eee', borderRadius: 5, overflow: 'hidden', marginBottom: 20 },
-  progressFill: { height: '100%', backgroundColor: '#6B4423' },
-  badgeGrid: { alignItems: 'center' },
-  badge: { width: '30%', margin: '1.5%', alignItems: 'center' },
-  badgeIcon: { fontSize: 32 },
-  badgeText: { fontSize: 12, textAlign: 'center', marginTop: 4 },
-  modalBackdrop: { flex:1, backgroundColor:'rgba(0,0,0,0.5)', justifyContent:'center', alignItems:'center' },
-  modalContent: { backgroundColor:'#fff', padding:30, borderRadius:10, alignItems:'center' },
-  modalEmoji: { fontSize:48, marginBottom:10 },
-  modalText: { fontSize:20, fontWeight:'bold', marginBottom:10 },
-  modalBadgeTitle: { fontSize:16 },
+  container: {
+    padding: 16,
+    backgroundColor: '#0f1118',
+  },
+  section: {
+    marginBottom: 24,
+    backgroundColor: 'rgba(21, 23, 34, 0.92)',
+    borderRadius: 20,
+    padding: 16,
+  },
+  sectionTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 16,
+  },
+  metaText: {
+    color: '#cbd5f5',
+    fontSize: 12,
+  },
+  doubleXp: {
+    color: '#f6ad55',
+    fontWeight: '700',
+  },
+  empty: {
+    color: '#a0aec0',
+    textAlign: 'center',
+  },
+  leaderboardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  leaderboardButton: {
+    backgroundColor: '#f6ad55',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  leaderboardButtonText: {
+    color: '#1a1d29',
+    fontWeight: '700',
+  },
+  leaderboardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  leaderboardRank: {
+    color: '#f6ad55',
+    width: 40,
+    fontWeight: '700',
+  },
+  leaderboardInfo: {
+    flex: 1,
+  },
+  leaderboardName: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  leaderboardSubtitle: {
+    color: '#a0aec0',
+    fontSize: 12,
+  },
+  leaderboardXp: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  eventCard: {
+    backgroundColor: '#1c1f2b',
+    borderRadius: 16,
+    padding: 12,
+    marginBottom: 12,
+  },
+  eventTitle: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  eventSubtitle: {
+    color: '#cbd5f5',
+    marginTop: 4,
+  },
+  eventBonus: {
+    color: '#f6ad55',
+    marginTop: 4,
+    fontWeight: '600',
+  },
 });
 
 export default GamificationScreen;

--- a/src/screens/LeaderboardScreen.tsx
+++ b/src/screens/LeaderboardScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, FlatList, RefreshControl, Image } from 'react-native';
+import Animated, { FadeInDown, FadeInRight } from 'react-native-reanimated';
+import type { LeaderboardEntry, LeaderboardRange, LeaderboardScope } from '../types/gamification';
+import { useGamificationStore } from '../hooks/useGamificationStore';
+import { useGamificationServices } from '../hooks/useGamificationServices';
+
+const scopes: LeaderboardScope[] = ['global', 'friends', 'local'];
+const ranges: LeaderboardRange[] = ['weekly', 'monthly', 'all_time'];
+
+/**
+ * Obrazovka rebríčkov s animovaným prechodom.
+ */
+const LeaderboardScreen: React.FC = () => {
+  const [activeScope, setActiveScope] = useState<LeaderboardScope>('global');
+  const [activeRange, setActiveRange] = useState<LeaderboardRange>('weekly');
+  const [refreshing, setRefreshing] = useState(false);
+  const { leaderboard, title } = useGamificationStore((state) => ({ leaderboard: state.leaderboard, title: state.title }));
+  const services = useGamificationServices();
+
+  const data = useMemo(() => leaderboard[`${activeScope}:${activeRange}`] ?? [], [leaderboard, activeScope, activeRange]);
+
+  const fetchLeaderboard = useCallback(async () => {
+    if (!services) {
+      return;
+    }
+    setRefreshing(true);
+    await services.refreshLeaderboards(activeScope, activeRange);
+    setRefreshing(false);
+  }, [services, activeScope, activeRange]);
+
+  useEffect(() => {
+    void fetchLeaderboard();
+  }, [fetchLeaderboard]);
+
+  const renderItem = useCallback(({ item }: { item: LeaderboardEntry }) => (
+    <Animated.View entering={FadeInRight.delay(item.rank * 40)} style={styles.row}>
+      <Text style={styles.rank}>#{item.rank}</Text>
+      <View style={styles.profile}>
+        {item.avatarUrl ? (
+          <Image source={{ uri: item.avatarUrl }} style={styles.avatar} />
+        ) : (
+          <View style={styles.avatarPlaceholder}>
+            <Text style={styles.avatarInitial}>{item.displayName?.[0] ?? '?'}</Text>
+          </View>
+        )}
+        <View>
+          <Text style={styles.name}>{item.displayName}</Text>
+          <Text style={styles.subtitle}>{item.title}</Text>
+        </View>
+      </View>
+      <View style={styles.points}>
+        <Text style={styles.xp}>{item.xp} XP</Text>
+        <Text style={[styles.trend, trendColor(item.trend)]}>{trendLabel(item.trend)}</Text>
+      </View>
+    </Animated.View>
+  ), []);
+
+  return (
+    <View style={styles.container}>
+      <Animated.View entering={FadeInDown.duration(600)}>
+        <Text style={styles.heading}>Rebríčky</Text>
+        <Text style={styles.subtitleHeading}>Titul: {title}</Text>
+      </Animated.View>
+      <View style={styles.segmented}>
+        {scopes.map((scope) => (
+          <TouchableOpacity key={scope} onPress={() => setActiveScope(scope)} style={[styles.segmentButton, activeScope === scope && styles.segmentActive]}>
+            <Text style={[styles.segmentText, activeScope === scope && styles.segmentTextActive]}>{scope.toUpperCase()}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <View style={styles.segmentedRange}>
+        {ranges.map((range) => (
+          <TouchableOpacity key={range} onPress={() => setActiveRange(range)} style={[styles.segmentButton, activeRange === range && styles.segmentActive]}>
+            <Text style={[styles.segmentText, activeRange === range && styles.segmentTextActive]}>{range.toUpperCase()}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <FlatList
+        data={data}
+        keyExtractor={(item) => item.userId}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={fetchLeaderboard} />}
+        ListEmptyComponent={<Text style={styles.empty}>Zatiaľ žiadne dáta</Text>}
+      />
+    </View>
+  );
+};
+
+const trendLabel = (trend: LeaderboardEntry['trend']) => {
+  switch (trend) {
+    case 'up':
+      return '▲';
+    case 'down':
+      return '▼';
+    default:
+      return '—';
+  }
+};
+
+const trendColor = (trend: LeaderboardEntry['trend']) => {
+  switch (trend) {
+    case 'up':
+      return { color: '#48bb78' };
+    case 'down':
+      return { color: '#f56565' };
+    default:
+      return { color: '#a0aec0' };
+  }
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#11131b',
+    paddingTop: 48,
+  },
+  heading: {
+    color: '#fff',
+    fontSize: 28,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  subtitleHeading: {
+    color: '#a0aec0',
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  segmented: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 24,
+  },
+  segmentedRange: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  segmentButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    marginHorizontal: 6,
+    borderRadius: 16,
+    backgroundColor: '#1c1f2b',
+  },
+  segmentActive: {
+    backgroundColor: '#f6ad55',
+  },
+  segmentText: {
+    color: '#cbd5f5',
+    fontWeight: '600',
+  },
+  segmentTextActive: {
+    color: '#1c1f2b',
+  },
+  listContent: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#1a1d29',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 12,
+  },
+  rank: {
+    color: '#f6ad55',
+    fontWeight: '800',
+    width: 40,
+  },
+  profile: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    marginRight: 12,
+  },
+  avatarPlaceholder: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#2d3140',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  avatarInitial: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+  name: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  subtitle: {
+    color: '#cbd5f5',
+    fontSize: 12,
+  },
+  points: {
+    alignItems: 'flex-end',
+  },
+  xp: {
+    color: '#fff',
+    fontWeight: '700',
+  },
+  trend: {
+    marginTop: 4,
+  },
+  empty: {
+    color: '#a0aec0',
+    textAlign: 'center',
+    marginTop: 40,
+  },
+});
+
+export default LeaderboardScreen;

--- a/src/services/analytics/GamificationAnalytics.ts
+++ b/src/services/analytics/GamificationAnalytics.ts
@@ -1,0 +1,38 @@
+import { InteractionManager } from 'react-native';
+import type { GamificationAnalyticsAdapter, GamificationEvent } from '../../types/gamification';
+
+/**
+ * Analytika pre gamifikačné udalosti s optimalizáciou výkonu.
+ */
+export class GamificationAnalytics implements GamificationAnalyticsAdapter {
+  constructor(private readonly transport: (event: GamificationEvent) => Promise<void>) {}
+
+  /**
+   * Sledovanie udalosti odložíme až po vykreslení UI, aby sme neblokovali interakcie.
+   */
+  async track(event: GamificationEvent): Promise<void> {
+    await new Promise<void>((resolve) => {
+      InteractionManager.runAfterInteractions(() => {
+        this.transport(event).finally(resolve);
+      });
+    });
+  }
+}
+
+/**
+ * Základná implementácia transportu cez HTTP/Supabase funkciu.
+ */
+export const createHttpGamificationTransport = (endpoint: string) =>
+  async (event: GamificationEvent) => {
+    try {
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(event),
+      });
+    } catch (error) {
+      console.warn('GamificationAnalytics: HTTP transport zlyhal', error);
+    }
+  };

--- a/src/services/audio/SoundEffectManager.ts
+++ b/src/services/audio/SoundEffectManager.ts
@@ -1,0 +1,52 @@
+import Sound from 'react-native-sound';
+import { Platform } from 'react-native';
+import type { GamificationSoundEffectManager } from '../../types/gamification';
+
+/**
+ * Jednoduchý manager na prehrávanie gamifikačných zvukov.
+ */
+export class SoundEffectManager implements GamificationSoundEffectManager {
+  private cache: Map<string, Sound> = new Map();
+
+  constructor(private readonly soundMapping: Record<string, string | undefined>) {
+    Sound.setCategory('Ambient', true);
+  }
+
+  /**
+   * Prehrá zvukový efekt podľa kľúča.
+   */
+  async play(effect: 'level_up' | 'achievement' | 'quest_complete' | 'xp_gain'): Promise<void> {
+    const fileName = this.soundMapping[effect];
+    if (!fileName) {
+      return;
+    }
+
+    const cached = this.cache.get(effect);
+    if (cached) {
+      cached.stop();
+      cached.play();
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const sound = new Sound(fileName, Platform.OS === 'ios' ? Sound.MAIN_BUNDLE : Sound.ANDROID, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        this.cache.set(effect, sound);
+        sound.play(() => resolve());
+      });
+    }).catch((error) => {
+      console.warn('SoundEffectManager: prehrávanie zlyhalo', error);
+    });
+  }
+
+  /**
+   * Vyčistí všetky nahraté zvuky.
+   */
+  dispose(): void {
+    this.cache.forEach((sound) => sound.release());
+    this.cache.clear();
+  }
+}

--- a/src/services/experiments/ABTestManager.ts
+++ b/src/services/experiments/ABTestManager.ts
@@ -1,0 +1,72 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { GamificationABTestAssignment } from '../../types/gamification';
+import { randomId } from '../../utils/randomId';
+
+/**
+ * Jednoduchý A/B testovací manager s persistenciou.
+ */
+export class ABTestManager {
+  private readonly storageKey = 'brewmate-ab-tests';
+  private assignments: Record<string, GamificationABTestAssignment> = {};
+
+  constructor() {
+    void this.hydrate();
+  }
+
+  /**
+   * Hydratuje uložené priradenia z AsyncStorage.
+   */
+  private async hydrate() {
+    try {
+      const raw = await AsyncStorage.getItem(this.storageKey);
+      if (raw) {
+        this.assignments = JSON.parse(raw);
+      }
+    } catch (error) {
+      console.warn('ABTestManager: Nepodarilo sa načítať priradenia', error);
+    }
+  }
+
+  private async persist() {
+    try {
+      await AsyncStorage.setItem(this.storageKey, JSON.stringify(this.assignments));
+    } catch (error) {
+      console.warn('ABTestManager: Nepodarilo sa uložiť priradenia', error);
+    }
+  }
+
+  /**
+   * Vráti variant testu a priradí nový ak neexistuje.
+   */
+  async getVariant(testName: string, variants: string[]): Promise<GamificationABTestAssignment> {
+    if (this.assignments[testName]) {
+      return this.assignments[testName];
+    }
+
+    const index = Math.floor(Math.random() * variants.length);
+    const assignment: GamificationABTestAssignment = {
+      testName,
+      variant: variants[index],
+      assignedAt: new Date().toISOString(),
+    };
+
+    this.assignments[testName] = assignment;
+    await this.persist();
+    return assignment;
+  }
+
+  /**
+   * Reset testov – využíva sa pri ručnom čistení alebo debug režime.
+   */
+  async reset(): Promise<void> {
+    this.assignments = {};
+    await AsyncStorage.removeItem(this.storageKey);
+  }
+
+  /**
+   * Generuje anonymné ID používateľa pre experimenty.
+   */
+  static anonymousId(): string {
+    return randomId({ prefix: 'ab', length: 16 });
+  }
+}

--- a/src/services/gamification/AchievementManager.ts
+++ b/src/services/gamification/AchievementManager.ts
@@ -1,0 +1,319 @@
+import type { StoreApi } from 'zustand';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  GamificationAnalyticsAdapter,
+  GamificationHaptics,
+  GamificationSoundEffectManager,
+} from '../../types/gamification';
+import type { GamificationStoreState } from '../../hooks/useGamificationStore';
+import { randomId } from '../../utils/randomId';
+import { SupabaseGamificationAdapter } from './SupabaseGamificationAdapter';
+import { XpEngine } from './XpEngine';
+
+export interface AchievementEventContext {
+  type:
+    | 'brew_completed'
+    | 'perfect_brew'
+    | 'daily_streak'
+    | 'social_share'
+    | 'exploration'
+    | 'mentor_help'
+    | 'night_brew'
+    | 'consistency'
+    | 'hidden_trigger';
+  amount?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface AchievementManagerDeps {
+  store: StoreApi<GamificationStoreState>;
+  supabase: SupabaseGamificationAdapter;
+  xpEngine: XpEngine;
+  analytics: GamificationAnalyticsAdapter;
+  sounds: GamificationSoundEffectManager;
+  haptics: GamificationHaptics;
+}
+
+const FALLBACK_ACHIEVEMENTS: AchievementDefinition[] = [
+  {
+    id: 'first-brew',
+    name: 'First Brew',
+    description: 'Dokonči prvý zápis kávy',
+    category: 'beginner',
+    rarity: 'common',
+    milestones: [1],
+    rewardXp: 50,
+  },
+  {
+    id: 'week-streak',
+    name: 'Week Streak',
+    description: 'Udrž si 7 dňový streak',
+    category: 'beginner',
+    rarity: 'common',
+    milestones: [7],
+    rewardXp: 120,
+  },
+  {
+    id: 'espresso-master',
+    name: 'Espresso Master',
+    description: 'Dosiahni 50 perfektných extrakcií',
+    category: 'skills',
+    rarity: 'epic',
+    milestones: [10, 25, 50],
+    rewardXp: 400,
+    rewardSkillPoints: 1,
+    featureUnlock: 'advanced_espresso_insights',
+  },
+  {
+    id: 'latte-artist',
+    name: 'Latte Artist',
+    description: 'Zdieľaj 20 latté fotografií',
+    category: 'skills',
+    rarity: 'rare',
+    milestones: [5, 10, 20],
+    rewardXp: 250,
+  },
+  {
+    id: 'bean-explorer',
+    name: 'Bean Explorer',
+    description: 'Objav zrná z 10 krajín',
+    category: 'exploration',
+    rarity: 'rare',
+    milestones: [3, 6, 10],
+    rewardXp: 300,
+  },
+  {
+    id: 'method-master',
+    name: 'Method Master',
+    description: 'Vyskúšaj 6 rôznych brew metód',
+    category: 'exploration',
+    rarity: 'epic',
+    milestones: [3, 6],
+    rewardXp: 260,
+  },
+  {
+    id: 'helpful-barista',
+    name: 'Helpful Barista',
+    description: 'Pomôž komunite minimálne 10 krát',
+    category: 'social',
+    rarity: 'rare',
+    milestones: [3, 6, 10],
+    rewardXp: 240,
+    rewardSkillPoints: 1,
+  },
+  {
+    id: 'trendsetter',
+    name: 'Trendsetter',
+    description: 'Zdieľaj 15 odporúčaní receptov',
+    category: 'social',
+    rarity: 'epic',
+    milestones: [5, 10, 15],
+    rewardXp: 320,
+  },
+  {
+    id: 'night-owl',
+    name: 'Night Owl',
+    description: 'Uvar kávu medzi 23:00 a 02:00',
+    category: 'hidden',
+    rarity: 'legendary',
+    milestones: [1],
+    rewardXp: 500,
+    isHidden: true,
+  },
+  {
+    id: 'perfectionist',
+    name: 'Perfectionist',
+    description: '5 perfektných brew v jednom týždni',
+    category: 'hidden',
+    rarity: 'legendary',
+    milestones: [5],
+    rewardXp: 650,
+    rewardSkillPoints: 2,
+  },
+];
+
+/**
+ * Správca achievementov zabezpečuje logiku progresu a odmien.
+ */
+export class AchievementManager {
+  private definitions: Map<string, AchievementDefinition> = new Map();
+
+  constructor(private readonly deps: AchievementManagerDeps) {}
+
+  async initialize(): Promise<void> {
+    const definitions = await this.deps.supabase.fetchAchievements();
+    const finalDefinitions = definitions.length > 0 ? definitions : FALLBACK_ACHIEVEMENTS;
+    this.definitions = new Map(finalDefinitions.map((item) => [item.id, item]));
+    const storeState = this.deps.store.getState();
+    if (typeof storeState.setAchievementDefinitions === 'function') {
+      storeState.setAchievementDefinitions(finalDefinitions);
+    }
+
+    if (definitions.length === 0) {
+      console.info('AchievementManager: používam fallback definície');
+    }
+  }
+
+  /**
+   * Aktualizuje progres konkrétneho achievementu.
+   */
+  private async updateProgress(definition: AchievementDefinition, increment: number): Promise<void> {
+    const current = this.deps.store
+      .getState()
+      .achievements.find((item) => item.achievementId === definition.id);
+
+    const progressValue = Math.max(0, (current?.progress ?? 0) + increment);
+    const completedMilestones = new Set(current?.completedMilestones ?? []);
+
+    definition.milestones.forEach((milestone) => {
+      if (progressValue >= milestone) {
+        completedMilestones.add(milestone);
+      }
+    });
+
+    const unlocked = completedMilestones.size === definition.milestones.length;
+    const updated: AchievementProgress = {
+      achievementId: definition.id,
+      progress: progressValue,
+      completedMilestones: Array.from(completedMilestones).sort((a, b) => a - b),
+      unlockedAt: unlocked ? current?.unlockedAt ?? new Date().toISOString() : current?.unlockedAt,
+      featured: current?.featured ?? false,
+    };
+
+    this.deps.store.getState().updateAchievementProgress(updated);
+    await this.deps.supabase.updateAchievement(updated);
+
+    if (unlocked && (!current || !current.unlockedAt)) {
+      await this.handleCompletion(definition, updated);
+    }
+  }
+
+  private async handleCompletion(definition: AchievementDefinition, progress: AchievementProgress) {
+    this.deps.haptics.success();
+    await this.deps.sounds.play('achievement');
+    await this.deps.analytics.track({
+      type: 'achievement_unlocked',
+      payload: {
+        id: definition.id,
+        rarity: definition.rarity,
+        category: definition.category,
+      },
+    });
+
+    if (definition.rewardXp > 0) {
+      await this.deps.xpEngine.applyXp({ source: 'event_reward', baseAmount: definition.rewardXp });
+    }
+    if (definition.rewardSkillPoints) {
+      const { skillPoints } = this.deps.store.getState();
+      this.deps.store.setState({ skillPoints: skillPoints + definition.rewardSkillPoints });
+    }
+
+    if (definition.featureUnlock) {
+      console.info('AchievementManager: odomknutá funkcia', definition.featureUnlock);
+    }
+
+    const state = this.deps.store.getState();
+    if (typeof state.setFeaturedAchievements === 'function') {
+      const featured = Array.from(new Set([...(state.featuredAchievements ?? []), definition.id])).slice(0, 6);
+      state.setFeaturedAchievements(featured);
+    }
+  }
+
+  /**
+   * Vyhodnotenie viacnásobných spúšťačov paralelne.
+   */
+  async evaluate(events: AchievementEventContext[]): Promise<void> {
+    await Promise.all(
+      events.map(async (event) => {
+        switch (event.type) {
+          case 'brew_completed':
+            await this.track('first-brew', 1);
+            break;
+          case 'perfect_brew':
+            await Promise.all([
+              this.track('espresso-master', event.amount ?? 1),
+              this.track('perfectionist', event.metadata?.weeklyPerfects ? Number(event.metadata.weeklyPerfects) : 0),
+            ]);
+            break;
+          case 'daily_streak':
+            await this.track('week-streak', event.amount ?? 1);
+            break;
+          case 'social_share':
+            await Promise.all([
+              this.track('latte-artist', event.amount ?? 1),
+              this.track('trendsetter', event.amount ?? 1),
+            ]);
+            break;
+          case 'exploration':
+            await Promise.all([
+              this.track('bean-explorer', event.metadata?.countriesDiscovered ? Number(event.metadata.countriesDiscovered) : 1),
+              this.track('method-master', event.metadata?.methodsDiscovered ? Number(event.metadata.methodsDiscovered) : 0),
+            ]);
+            break;
+          case 'mentor_help':
+            await this.track('helpful-barista', event.amount ?? 1);
+            break;
+          case 'night_brew':
+            await this.track('night-owl', 1);
+            break;
+          case 'consistency':
+            await this.track('perfectionist', event.amount ?? 1);
+            break;
+          case 'hidden_trigger':
+            if (event.metadata?.achievementId) {
+              await this.track(String(event.metadata.achievementId), event.amount ?? 1);
+            }
+            break;
+          default:
+            break;
+        }
+      }),
+    );
+  }
+
+  private async track(id: string, increment: number): Promise<void> {
+    if (increment <= 0) {
+      return;
+    }
+    const definition = this.definitions.get(id);
+    if (!definition) {
+      return;
+    }
+    await this.updateProgress(definition, increment);
+  }
+
+  /**
+   * Vytvorí placeholder achievement ak chýba v supabase (pre debug účely).
+   */
+  async ensureAchievement(definition: AchievementDefinition): Promise<void> {
+    if (this.definitions.has(definition.id)) {
+      return;
+    }
+    await this.deps.supabase.updateAchievement({
+      achievementId: definition.id,
+      progress: 0,
+      completedMilestones: [],
+    });
+    this.definitions.set(definition.id, definition);
+  }
+
+  /**
+   * Pomocná metóda na vytvorenie dočasného achievementu.
+   */
+  static createCustomAchievement(partial: Partial<AchievementDefinition>): AchievementDefinition {
+    return {
+      id: partial.id ?? randomId({ prefix: 'ach', length: 8 }),
+      name: partial.name ?? 'Custom Achievement',
+      description: partial.description ?? 'Dočasná výzva',
+      category: partial.category ?? 'hidden',
+      rarity: partial.rarity ?? 'rare',
+      milestones: partial.milestones ?? [1],
+      rewardXp: partial.rewardXp ?? 100,
+      rewardSkillPoints: partial.rewardSkillPoints,
+      featureUnlock: partial.featureUnlock,
+      isHidden: partial.isHidden ?? false,
+    };
+  }
+}
+

--- a/src/services/gamification/DailyQuestService.ts
+++ b/src/services/gamification/DailyQuestService.ts
@@ -1,0 +1,321 @@
+import { addHours, differenceInMinutes, isAfter, isBefore, parseISO } from 'date-fns';
+import type { StoreApi } from 'zustand';
+import type {
+  DailyQuestInstance,
+  DailyQuestTemplate,
+  GamificationAnalyticsAdapter,
+  GamificationNotificationChannel,
+} from '../../types/gamification';
+import type { GamificationStoreState } from '../../hooks/useGamificationStore';
+import { randomId } from '../../utils/randomId';
+import { SupabaseGamificationAdapter } from './SupabaseGamificationAdapter';
+import { XpEngine } from './XpEngine';
+
+interface QuestPreferences {
+  preferredMethods?: string[];
+  activeSeasonalTheme?: string;
+}
+
+interface DailyQuestServiceDeps {
+  store: StoreApi<GamificationStoreState>;
+  supabase: SupabaseGamificationAdapter;
+  xpEngine: XpEngine;
+  analytics: GamificationAnalyticsAdapter;
+  notifications: GamificationNotificationChannel;
+}
+
+const QUEST_TEMPLATES: DailyQuestTemplate[] = [
+  {
+    id: 'morning-brew',
+    title: 'Ranná káva',
+    description: 'Uvar kávu medzi 5:00 a 11:00',
+    difficulty: 'easy',
+    xpReward: 25,
+    requirements: { timeWindow: ['05:00', '11:00'], brews: 1 },
+    category: 'ritual',
+  },
+  {
+    id: 'ai-trust',
+    title: 'Dôveruj AI',
+    description: 'Použi BrewMate odporúčanie',
+    difficulty: 'easy',
+    xpReward: 20,
+    requirements: { action: 'use_ai_suggestion' },
+    category: 'knowledge',
+  },
+  {
+    id: 'photo-note',
+    title: 'Fotograf',
+    description: 'Pridaj fotku a poznámku k brew',
+    difficulty: 'easy',
+    xpReward: 25,
+    requirements: { photo: true, note: true },
+    category: 'social',
+  },
+  {
+    id: 'perfect-extraction',
+    title: 'Perfektná extrakcia',
+    description: 'Dosiahni hodnotenie 4+ hviezdičky',
+    difficulty: 'medium',
+    xpReward: 40,
+    requirements: { rating: 4 },
+    category: 'skills',
+  },
+  {
+    id: 'experimenter',
+    title: 'Experimentátor',
+    description: 'Vyskúšaj nový recept alebo metódu',
+    difficulty: 'medium',
+    xpReward: 35,
+    requirements: { newRecipe: true },
+    category: 'exploration',
+  },
+  {
+    id: 'consistency',
+    title: 'Konzistencia',
+    description: 'Uvar dvakrát tú istú kávu',
+    difficulty: 'medium',
+    xpReward: 45,
+    requirements: { repeatBrew: 2 },
+    category: 'ritual',
+  },
+  {
+    id: 'master-challenge',
+    title: 'Majstrovská výzva',
+    description: 'Použi 3 metódy s hodnotením 4+',
+    difficulty: 'hard',
+    xpReward: 90,
+    requirements: { methods: 3, rating: 4 },
+    category: 'skills',
+  },
+  {
+    id: 'mentor',
+    title: 'Mentor',
+    description: 'Pomôž dvom používateľom',
+    difficulty: 'hard',
+    xpReward: 80,
+    requirements: { communityHelp: 2 },
+    category: 'social',
+  },
+  {
+    id: 'weekend-warrior',
+    title: 'Weekend Warrior',
+    description: 'Priprav Chemex/V60/Syphon cez víkend',
+    difficulty: 'special',
+    xpReward: 180,
+    requirements: { methods: ['Chemex', 'V60', 'Syphon'], weekendOnly: true },
+    category: 'event',
+  },
+  {
+    id: 'monthly-marathon',
+    title: 'Mesačná výzva',
+    description: 'Dokonči 20 brew počas mesiaca',
+    difficulty: 'special',
+    xpReward: 220,
+    requirements: { monthlyBrews: 20 },
+    category: 'event',
+  },
+];
+
+/**
+ * Služba pre generovanie a správu denných questov.
+ */
+export class DailyQuestService {
+  private templates: DailyQuestTemplate[] = QUEST_TEMPLATES;
+
+  constructor(private readonly deps: DailyQuestServiceDeps) {}
+
+  async initialize(): Promise<void> {
+    const templates = await this.deps.supabase.fetchDailyQuestTemplates();
+    if (templates.length > 0) {
+      this.templates = templates;
+    }
+  }
+
+  /**
+   * Inteligentne vyberie úlohy podľa levelu a preferencií.
+   */
+  async assignDailyQuests(preferences: QuestPreferences = {}): Promise<void> {
+    const state = this.deps.store.getState();
+    const now = new Date();
+    const existing = state.dailyQuests.filter((quest) => isAfter(parseISO(quest.expiresAt), now));
+
+    if (existing.length >= 3) {
+      return;
+    }
+
+    const easyPool = this.filterTemplates('easy', state.level, preferences);
+    const mediumPool = this.filterTemplates('medium', state.level, preferences);
+    const hardPool = this.filterTemplates('hard', state.level, preferences);
+    const specialPool = this.filterTemplates('special', state.level, preferences);
+
+    const toAssign: DailyQuestTemplate[] = [];
+    if (easyPool.length > 0) {
+      toAssign.push(this.pickRandom(easyPool, existing));
+    }
+    if (mediumPool.length > 0) {
+      toAssign.push(this.pickRandom(mediumPool, existing));
+    }
+    if (state.level > 10 && hardPool.length > 0) {
+      toAssign.push(this.pickRandom(hardPool, existing));
+    }
+    if (specialPool.length > 0 && now.getDay() === 6) {
+      toAssign.push(this.pickRandom(specialPool, existing));
+    }
+
+    const newQuests = await Promise.all(
+      toAssign.map(async (template) => {
+        const assignedAt = new Date();
+        const expiresAt = template.difficulty === 'special' ? addHours(assignedAt, 72) : addHours(assignedAt, 24);
+        const quest: DailyQuestInstance = {
+          id: randomId({ prefix: 'quest', length: 10 }),
+          templateId: template.id,
+          assignedAt: assignedAt.toISOString(),
+          expiresAt: expiresAt.toISOString(),
+          progress: 0,
+          goal: this.deriveGoal(template),
+          completed: false,
+          xpReward: template.xpReward,
+          metadata: { title: template.title, description: template.description },
+        };
+        await this.deps.supabase.upsertDailyQuest(quest);
+        await this.deps.notifications.scheduleQuestReminder(quest);
+        return quest;
+      }),
+    );
+
+    const updated = [...existing, ...newQuests];
+    this.deps.store.getState().setDailyQuests(updated);
+  }
+
+  private filterTemplates(difficulty: DailyQuestTemplate['difficulty'], level: number, preferences: QuestPreferences) {
+    return this.templates.filter((template) => {
+      if (template.difficulty !== difficulty) {
+        return false;
+      }
+      if (preferences.preferredMethods && Array.isArray(template.requirements?.methods)) {
+        return template.requirements.methods.some((method: string) => preferences.preferredMethods?.includes(method));
+      }
+      if (difficulty === 'special' && level < 15) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  private pickRandom(pool: DailyQuestTemplate[], existing: DailyQuestInstance[]): DailyQuestTemplate {
+    const rotation = pool.filter((template) => !existing.some((quest) => quest.templateId === template.id));
+    const source = rotation.length > 0 ? rotation : pool;
+    return source[Math.floor(Math.random() * source.length)];
+  }
+
+  private deriveGoal(template: DailyQuestTemplate): number {
+    if (typeof template.requirements?.brews === 'number') {
+      return template.requirements.brews;
+    }
+    if (typeof template.requirements?.methods === 'number') {
+      return template.requirements.methods;
+    }
+    if (typeof template.requirements?.monthlyBrews === 'number') {
+      return template.requirements.monthlyBrews;
+    }
+    if (typeof template.requirements?.communityHelp === 'number') {
+      return template.requirements.communityHelp;
+    }
+    if (typeof template.requirements?.repeatBrew === 'number') {
+      return template.requirements.repeatBrew;
+    }
+    return 1;
+  }
+
+  /**
+   * Aktualizuje progres questov a odmeňuje XP.
+   */
+  async applyProgress(questId: string, progressDelta = 1): Promise<void> {
+    const state = this.deps.store.getState();
+    const quest = state.dailyQuests.find((item) => item.id === questId);
+    if (!quest || quest.completed) {
+      return;
+    }
+
+    const now = new Date();
+    if (isBefore(parseISO(quest.expiresAt), now)) {
+      return;
+    }
+
+    const progress = Math.min(quest.goal, quest.progress + progressDelta);
+    const completed = progress >= quest.goal;
+    const updatedQuest: DailyQuestInstance = { ...quest, progress, completed };
+    this.deps.store.getState().updateQuestProgress(questId, updatedQuest);
+    await this.deps.supabase.upsertDailyQuest(updatedQuest);
+
+    if (completed) {
+      await this.deps.notifications.cancelQuestReminder(questId);
+      await this.deps.analytics.track({
+        type: 'quest_completed',
+        payload: { questId, templateId: quest.templateId, xpReward: quest.xpReward },
+      });
+      await this.deps.xpEngine.applyXp({ source: 'daily_quest', baseAmount: quest.xpReward });
+      await this.deps.xpEngine.applyXp({ source: 'streak_bonus', baseAmount: this.calculateQuestCombo(state.dailyQuests) });
+    }
+  }
+
+  private calculateQuestCombo(quests: DailyQuestInstance[]): number {
+    const completedToday = quests.filter((quest) => quest.completed && differenceInMinutes(new Date(), parseISO(quest.assignedAt)) < 24 * 60);
+    if (completedToday.length === 0) {
+      return 0;
+    }
+    return completedToday.length * 10;
+  }
+
+  /**
+   * Automatická detekcia splnenia napríklad pri uložení brew.
+   */
+  async autoCompleteFromEvent(event: { type: string; payload: Record<string, unknown> }): Promise<void> {
+    const state = this.deps.store.getState();
+    await Promise.all(
+      state.dailyQuests.map(async (quest) => {
+        if (quest.completed) {
+          return;
+        }
+        const template = this.templates.find((item) => item.id === quest.templateId);
+        if (!template) {
+          return;
+        }
+        const shouldComplete = this.matchesEvent(template, event);
+        if (shouldComplete) {
+          await this.applyProgress(quest.id, quest.goal);
+        }
+      }),
+    );
+  }
+
+  private matchesEvent(template: DailyQuestTemplate, event: { type: string; payload: Record<string, unknown> }): boolean {
+    switch (template.id) {
+      case 'morning-brew': {
+        const time = String(event.payload.timestamp ?? '');
+        return event.type === 'brew' && /^0[5-9]:|^1[0-1]:/.test(time.split('T')[1] ?? '');
+      }
+      case 'ai-trust':
+        return event.type === 'ai_suggestion';
+      case 'photo-note':
+        return event.type === 'brew' && Boolean(event.payload.photo && event.payload.note);
+      case 'perfect-extraction':
+        return event.type === 'brew' && Number(event.payload.rating ?? 0) >= 4;
+      case 'experimenter':
+        return event.type === 'recipe_new' || Boolean(event.payload.newMethod);
+      case 'consistency':
+        return event.type === 'brew_repeat';
+      case 'master-challenge':
+        return event.type === 'brew' && Number(event.payload.rating ?? 0) >= 4 && Array.isArray(event.payload.methods);
+      case 'mentor':
+        return event.type === 'community_help';
+      case 'weekend-warrior':
+        return event.type === 'brew' && Array.isArray(event.payload.methods);
+      case 'monthly-marathon':
+        return event.type === 'monthly_summary' && Number(event.payload.count ?? 0) >= 20;
+      default:
+        return false;
+    }
+  }
+}

--- a/src/services/gamification/GamificationNotifications.ts
+++ b/src/services/gamification/GamificationNotifications.ts
@@ -1,0 +1,40 @@
+import PushNotification from 'react-native-push-notification';
+import type { GamificationNotificationChannel, DailyQuestInstance } from '../../types/gamification';
+
+const CHANNEL_ID = 'brewmate-gamification';
+
+PushNotification.createChannel(
+  {
+    channelId: CHANNEL_ID,
+    channelName: 'BrewMate questy',
+    channelDescription: 'Pripomienky denných výziev',
+    importance: 4,
+  },
+  () => {},
+);
+
+/**
+ * Lokálne notifikácie pre denné questy.
+ */
+export class GamificationNotifications implements GamificationNotificationChannel {
+  async scheduleQuestReminder(quest: DailyQuestInstance): Promise<void> {
+    const date = new Date(quest.expiresAt);
+    date.setHours(date.getHours() - 2);
+    if (date <= new Date()) {
+      return;
+    }
+    PushNotification.localNotificationSchedule({
+      channelId: CHANNEL_ID,
+      id: quest.id,
+      title: 'Nezabudni na výzvu',
+      message: `${quest.metadata?.title ?? 'Denná úloha'} čaká na dokončenie`,
+      date,
+      allowWhileIdle: true,
+      userInfo: { questId: quest.id },
+    });
+  }
+
+  async cancelQuestReminder(questId: string): Promise<void> {
+    PushNotification.cancelLocalNotifications({ id: questId });
+  }
+}

--- a/src/services/gamification/GamificationService.ts
+++ b/src/services/gamification/GamificationService.ts
@@ -1,0 +1,290 @@
+import { differenceInCalendarDays, startOfDay } from 'date-fns';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { StoreApi } from 'zustand';
+import type {
+  GamificationAnalyticsAdapter,
+  GamificationEvent,
+  GamificationHaptics,
+  GamificationNotificationChannel,
+  GamificationSoundEffectManager,
+  LeaderboardRange,
+  LeaderboardScope,
+  SeasonalEventConfig,
+  XpSource,
+} from '../../types/gamification';
+import type { GamificationStoreState } from '../../hooks/useGamificationStore';
+import { XpEngine } from './XpEngine';
+import { AchievementManager, type AchievementEventContext } from './AchievementManager';
+import { DailyQuestService } from './DailyQuestService';
+import { SupabaseGamificationAdapter } from './SupabaseGamificationAdapter';
+import { GamificationNotifications } from './GamificationNotifications';
+
+interface GamificationServiceDeps {
+  supabaseClient: SupabaseClient;
+  userId: string;
+  store: StoreApi<GamificationStoreState>;
+  analytics: GamificationAnalyticsAdapter;
+  sounds: GamificationSoundEffectManager;
+  haptics: GamificationHaptics;
+  notifications?: GamificationNotificationChannel;
+}
+
+interface AntiCheatSample {
+  timestamp: number;
+  source: XpSource;
+  amount: number;
+}
+
+/**
+ * Orchestruje všetky časti gamifikačného systému.
+ */
+export class GamificationService {
+  private readonly supabaseAdapter: SupabaseGamificationAdapter;
+  private readonly xpEngine: XpEngine;
+  private readonly achievementManager: AchievementManager;
+  private readonly dailyQuestService: DailyQuestService;
+  private readonly antiCheatWindow: AntiCheatSample[] = [];
+  private seasonalMultiplier = 1;
+
+  constructor(private readonly deps: GamificationServiceDeps) {
+    this.supabaseAdapter = new SupabaseGamificationAdapter(deps.supabaseClient, deps.userId);
+    const notifications = deps.notifications ?? new GamificationNotifications();
+    this.xpEngine = new XpEngine({
+      store: deps.store,
+      analytics: deps.analytics,
+      haptics: deps.haptics,
+      sounds: deps.sounds,
+      seasonalMultiplier: () => this.seasonalMultiplier,
+    });
+    this.achievementManager = new AchievementManager({
+      store: deps.store,
+      supabase: this.supabaseAdapter,
+      xpEngine: this.xpEngine,
+      analytics: deps.analytics,
+      sounds: deps.sounds,
+      haptics: deps.haptics,
+    });
+    this.dailyQuestService = new DailyQuestService({
+      store: deps.store,
+      supabase: this.supabaseAdapter,
+      xpEngine: this.xpEngine,
+      analytics: deps.analytics,
+      notifications,
+    });
+  }
+
+  async initialize(): Promise<void> {
+    const [state, achievements, quests, events] = await Promise.all([
+      this.supabaseAdapter.fetchState(),
+      this.supabaseAdapter.fetchUserAchievements(),
+      this.supabaseAdapter.fetchUserDailyProgress(),
+      this.supabaseAdapter.fetchSeasonalEvents(),
+    ]);
+
+    await this.achievementManager.initialize();
+    await this.dailyQuestService.initialize();
+
+    const xpToNext = this.xpEngine.calculateXpForLevel(state.level);
+
+    this.deps.store.setState({
+      userId: this.deps.userId,
+      level: state.level,
+      currentXp: state.currentXp,
+      xpToNextLevel: xpToNext,
+      skillPoints: state.skillPoints,
+      comboMultiplier: state.comboMultiplier,
+      doubleXpActive: state.doubleXpActive,
+      title: this.xpEngine.getTitleForLevel(state.level),
+      streakDays: state.streakDays,
+      brewStreakDays: state.brewStreakDays,
+      perfectWeek: state.perfectWeek,
+      freezeTokens: state.freezeTokens,
+      skillTree: state.skillTree,
+      achievements,
+      dailyQuests: quests,
+      seasonalEvents: events,
+      initialized: true,
+    });
+
+    if (!state.radarStats || state.radarStats.length === 0) {
+      this.deps.store.getState().setRadarStats?.([
+        { key: 'brewing', value: 55, average: 50 },
+        { key: 'exploration', value: 45, average: 40 },
+        { key: 'social', value: 35, average: 30 },
+        { key: 'knowledge', value: 60, average: 55 },
+      ]);
+    }
+
+    this.updateSeasonalMultiplier(events);
+    await this.dailyQuestService.assignDailyQuests();
+  }
+
+  private updateSeasonalMultiplier(events: SeasonalEventConfig[]) {
+    if (events.length === 0) {
+      this.seasonalMultiplier = 1;
+      return;
+    }
+    this.seasonalMultiplier = events.reduce((max, event) => Math.max(max, event.bonusXpMultiplier), 1);
+  }
+
+  async addXp(source: XpSource, amount: number, metadata?: Record<string, unknown>): Promise<void> {
+    if (this.isAnomalousGain({ amount, source })) {
+      console.warn('GamificationService: Detegovaný podozrivý XP zisk', source, amount);
+      return;
+    }
+    this.antiCheatWindow.push({ timestamp: Date.now(), amount, source });
+    await this.xpEngine.applyXp({ source, baseAmount: amount, metadata });
+    await this.supabaseAdapter.upsertState({
+      current_level: this.deps.store.getState().level,
+      current_xp: this.deps.store.getState().currentXp,
+      skill_points: this.deps.store.getState().skillPoints,
+    });
+  }
+
+  async handleBrewEvent(event: { rating: number; timestamp: string; methods: string[]; perfect?: boolean }): Promise<void> {
+    await this.addXp(event.perfect ? 'perfect_brew' : 'brew', event.perfect ? 50 : 10, {
+      rating: event.rating,
+    });
+
+    const achievements: AchievementEventContext[] = [
+      { type: 'brew_completed' },
+    ];
+
+    if (event.perfect) {
+      achievements.push({ type: 'perfect_brew', amount: 1, metadata: { weeklyPerfects: 1 } });
+    }
+
+    if (event.methods.length >= 3 && event.rating >= 4) {
+      achievements.push({
+        type: 'exploration',
+        metadata: { methodsDiscovered: event.methods.length },
+      });
+    }
+
+    await this.achievementManager.evaluate(achievements);
+
+    await this.dailyQuestService.autoCompleteFromEvent({
+      type: 'brew',
+      payload: {
+        rating: event.rating,
+        methods: event.methods,
+        timestamp: event.timestamp,
+      },
+    });
+
+    await this.updateBrewStreak(new Date(event.timestamp));
+  }
+
+  async handleCommunityHelp(count = 1): Promise<void> {
+    await this.addXp('help_others', 15 * count);
+    await this.achievementManager.evaluate([{ type: 'mentor_help', amount: count }]);
+    await this.dailyQuestService.autoCompleteFromEvent({
+      type: 'community_help',
+      payload: { count },
+    });
+  }
+
+  async updateLoginStreak(): Promise<void> {
+    const state = this.deps.store.getState();
+    const now = startOfDay(new Date());
+    const lastSync = state.lastSyncAt ? startOfDay(new Date(state.lastSyncAt)) : null;
+    let streak = state.streakDays;
+    let freezeTokens = state.freezeTokens;
+
+    if (!lastSync || differenceInCalendarDays(now, lastSync) === 1) {
+      streak += 1;
+    } else if (differenceInCalendarDays(now, lastSync) > 1) {
+      if (freezeTokens > 0) {
+        freezeTokens -= 1;
+      } else {
+        streak = 1;
+      }
+    }
+
+    this.deps.store.getState().updateStreaks({
+      streakDays: streak,
+      brewStreakDays: state.brewStreakDays,
+      perfectWeek: state.perfectWeek,
+      freezeTokens,
+    });
+
+    await this.achievementManager.evaluate([{ type: 'daily_streak', amount: streak }]);
+    await this.deps.analytics.track({ type: 'streak_update', payload: { streak } });
+  }
+
+  private async updateBrewStreak(date: Date): Promise<void> {
+    const state = this.deps.store.getState();
+    const now = startOfDay(date);
+    const lastSync = state.lastSyncAt ? startOfDay(new Date(state.lastSyncAt)) : null;
+    let brewStreak = state.brewStreakDays;
+
+    if (!lastSync || differenceInCalendarDays(now, lastSync) === 0) {
+      brewStreak = Math.max(brewStreak, 1);
+    } else if (differenceInCalendarDays(now, lastSync) === 1) {
+      brewStreak += 1;
+    } else {
+      brewStreak = 1;
+    }
+
+    const perfectWeek = brewStreak >= 7;
+
+    this.deps.store.getState().updateStreaks({
+      streakDays: state.streakDays,
+      brewStreakDays: brewStreak,
+      perfectWeek,
+      freezeTokens: state.freezeTokens,
+    });
+
+    if (perfectWeek) {
+      await this.addXp('streak_bonus', 120);
+    }
+  }
+
+  async refreshLeaderboards(scope: LeaderboardScope, range: LeaderboardRange): Promise<void> {
+    const entries = await this.supabaseAdapter.fetchLeaderboards(scope, range);
+    this.deps.store.getState().setLeaderboard(`${scope}:${range}`, entries);
+  }
+
+  async sync(): Promise<void> {
+    const snapshot = this.deps.store.getState();
+    await this.supabaseAdapter.upsertState({
+      current_level: snapshot.level,
+      current_xp: snapshot.currentXp,
+      skill_points: snapshot.skillPoints,
+      skill_tree: snapshot.skillTree,
+      streak_days: snapshot.streakDays,
+      brew_streak_days: snapshot.brewStreakDays,
+      perfect_week: snapshot.perfectWeek,
+      combo_multiplier: snapshot.comboMultiplier,
+      double_xp_active: snapshot.doubleXpActive,
+    });
+
+    await Promise.all(snapshot.dailyQuests.map((quest) => this.supabaseAdapter.upsertDailyQuest(quest)));
+    await Promise.all(snapshot.achievements.map((achievement) => this.supabaseAdapter.updateAchievement(achievement)));
+  }
+
+  private isAnomalousGain(sample: AntiCheatSample): boolean {
+    const now = Date.now();
+    this.antiCheatWindow.splice(0, this.antiCheatWindow.length, ...this.antiCheatWindow.filter((item) => now - item.timestamp < 60_000));
+    const total = this.antiCheatWindow.reduce((sum, item) => sum + item.amount, 0) + sample.amount;
+    const highSpike = sample.amount > 500;
+    const rateLimited = this.antiCheatWindow.length > 10;
+    return highSpike || rateLimited || total > 1000;
+  }
+
+  async trackEvent(event: GamificationEvent): Promise<void> {
+    await this.deps.analytics.track(event);
+  }
+
+  getXpEngine(): XpEngine {
+    return this.xpEngine;
+  }
+
+  getAchievementManager(): AchievementManager {
+    return this.achievementManager;
+  }
+
+  getDailyQuestService(): DailyQuestService {
+    return this.dailyQuestService;
+  }
+}

--- a/src/services/gamification/SupabaseGamificationAdapter.ts
+++ b/src/services/gamification/SupabaseGamificationAdapter.ts
@@ -1,0 +1,252 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  DailyQuestInstance,
+  DailyQuestTemplate,
+  GamificationStateSnapshot,
+  LeaderboardEntry,
+  LeaderboardRange,
+  LeaderboardScope,
+  SeasonalEventConfig,
+} from '../../types/gamification';
+
+interface UserLevelRow {
+  user_id: string;
+  current_level: number;
+  current_xp: number;
+  skill_points: number;
+  skill_tree: unknown;
+  streak_days: number;
+  brew_streak_days: number;
+  perfect_week: boolean;
+  freeze_tokens: number;
+  combo_multiplier: number;
+  double_xp_active: boolean;
+}
+
+/**
+ * Adaptér zodpovedný za čítanie a zapisovanie dát do Supabase.
+ */
+export class SupabaseGamificationAdapter {
+  constructor(private readonly client: SupabaseClient, private readonly userId: string) {}
+
+  async fetchState(): Promise<GamificationStateSnapshot> {
+    const { data, error } = await this.client
+      .from<UserLevelRow>('user_levels')
+      .select('*')
+      .eq('user_id', this.userId)
+      .maybeSingle();
+
+    if (error) {
+      console.warn('SupabaseGamificationAdapter: fetchState error', error);
+    }
+
+    const row = data ?? {
+      current_level: 1,
+      current_xp: 0,
+      skill_points: 0,
+      skill_tree: [],
+      streak_days: 0,
+      brew_streak_days: 0,
+      perfect_week: false,
+      freeze_tokens: 1,
+      combo_multiplier: 1,
+      double_xp_active: false,
+    };
+
+    return {
+      userId: this.userId,
+      level: row.current_level,
+      currentXp: row.current_xp,
+      xpToNextLevel: 0,
+      skillPoints: row.skill_points,
+      comboMultiplier: row.combo_multiplier ?? 1,
+      doubleXpActive: row.double_xp_active ?? false,
+      title: 'Coffee Curious',
+      streakDays: row.streak_days ?? 0,
+      brewStreakDays: row.brew_streak_days ?? 0,
+      perfectWeek: row.perfect_week ?? false,
+      freezeTokens: row.freeze_tokens ?? 0,
+      radarStats: [],
+      skillTree: (row.skill_tree as unknown[])?.map((node) => node) ?? [],
+    };
+  }
+
+  async upsertState(state: Partial<UserLevelRow>): Promise<void> {
+    const { error } = await this.client
+      .from('user_levels')
+      .upsert({
+        user_id: this.userId,
+        ...state,
+        updated_at: new Date().toISOString(),
+      });
+    if (error) {
+      console.warn('SupabaseGamificationAdapter: upsertState error', error);
+    }
+  }
+
+  async fetchAchievements(): Promise<AchievementDefinition[]> {
+    const { data, error } = await this.client.from('achievements').select('*');
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: achievements fallback', error);
+      return [];
+    }
+
+    return data.map((row: any) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      category: row.category,
+      rarity: row.rarity,
+      milestones: row.milestones ?? [row.goal ?? 1],
+      rewardXp: row.reward_xp ?? 0,
+      rewardSkillPoints: row.reward_skill_points ?? 0,
+      featureUnlock: row.feature_unlock ?? undefined,
+      isHidden: row.is_hidden ?? false,
+    }));
+  }
+
+  async fetchUserAchievements(): Promise<AchievementProgress[]> {
+    const { data, error } = await this.client
+      .from('user_achievements')
+      .select('*')
+      .eq('user_id', this.userId);
+
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: user achievements fallback', error);
+      return [];
+    }
+
+    return data.map((row: any) => ({
+      achievementId: row.achievement_id,
+      progress: row.progress,
+      completedMilestones: row.completed_milestones ?? [],
+      unlockedAt: row.unlocked_at ?? undefined,
+      featured: row.featured ?? false,
+    }));
+  }
+
+  async updateAchievement(progress: AchievementProgress): Promise<void> {
+    const { error } = await this.client.from('user_achievements').upsert({
+      user_id: this.userId,
+      achievement_id: progress.achievementId,
+      progress: progress.progress,
+      completed_milestones: progress.completedMilestones,
+      unlocked_at: progress.unlockedAt,
+      featured: progress.featured ?? false,
+      updated_at: new Date().toISOString(),
+    });
+    if (error) {
+      console.warn('SupabaseGamificationAdapter: updateAchievement error', error);
+    }
+  }
+
+  async fetchDailyQuestTemplates(): Promise<DailyQuestTemplate[]> {
+    const { data, error } = await this.client.from('daily_quests').select('*');
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: quest template fallback', error);
+      return [];
+    }
+    return data.map((row: any) => ({
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      difficulty: row.difficulty,
+      xpReward: row.xp_reward,
+      requirements: row.requirements,
+      category: row.category,
+    }));
+  }
+
+  async fetchUserDailyProgress(): Promise<DailyQuestInstance[]> {
+    const today = new Date().toISOString().split('T')[0];
+    const { data, error } = await this.client
+      .from('user_daily_progress')
+      .select('*')
+      .eq('user_id', this.userId)
+      .gte('expires_at', today);
+
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: user daily progress fallback', error);
+      return [];
+    }
+
+    return data.map((row: any) => ({
+      id: row.id,
+      templateId: row.template_id,
+      assignedAt: row.assigned_at,
+      expiresAt: row.expires_at,
+      progress: row.progress,
+      goal: row.goal,
+      completed: row.completed,
+      xpReward: row.xp_reward,
+      metadata: row.metadata ?? {},
+    }));
+  }
+
+  async upsertDailyQuest(quest: DailyQuestInstance): Promise<void> {
+    const { error } = await this.client.from('user_daily_progress').upsert({
+      id: quest.id,
+      user_id: this.userId,
+      template_id: quest.templateId,
+      assigned_at: quest.assignedAt,
+      expires_at: quest.expiresAt,
+      progress: quest.progress,
+      goal: quest.goal,
+      completed: quest.completed,
+      xp_reward: quest.xpReward,
+      metadata: quest.metadata,
+      updated_at: new Date().toISOString(),
+    });
+    if (error) {
+      console.warn('SupabaseGamificationAdapter: upsertDailyQuest error', error);
+    }
+  }
+
+  async fetchLeaderboards(scope: LeaderboardScope, range: LeaderboardRange): Promise<LeaderboardEntry[]> {
+    const { data, error } = await this.client
+      .rpc('fetch_leaderboard', { scope, range, user_id: this.userId })
+      .single();
+
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: leaderboard fallback', error);
+      return [];
+    }
+
+    return (data.entries ?? []).map((entry: any) => ({
+      userId: entry.user_id,
+      displayName: entry.display_name,
+      avatarUrl: entry.avatar_url ?? undefined,
+      xp: entry.xp,
+      rank: entry.rank,
+      trend: entry.trend,
+      countryCode: entry.country_code ?? undefined,
+      title: entry.title ?? 'Coffee Curious',
+    }));
+  }
+
+  async fetchSeasonalEvents(): Promise<SeasonalEventConfig[]> {
+    const now = new Date().toISOString();
+    const { data, error } = await this.client
+      .from('seasonal_events')
+      .select('*')
+      .lte('start_at', now)
+      .gte('end_at', now);
+
+    if (error || !data) {
+      console.warn('SupabaseGamificationAdapter: seasonal events fallback', error);
+      return [];
+    }
+
+    return data.map((row: any) => ({
+      id: row.id,
+      title: row.title,
+      theme: row.theme,
+      startAt: row.start_at,
+      endAt: row.end_at,
+      bonusXpMultiplier: row.bonus_xp_multiplier ?? 1,
+      featuredAchievements: row.featured_achievements ?? [],
+    }));
+  }
+}

--- a/src/services/gamification/XpEngine.ts
+++ b/src/services/gamification/XpEngine.ts
@@ -1,0 +1,144 @@
+import { isWeekend } from 'date-fns';
+import type { StoreApi } from 'zustand';
+import {
+  type GamificationAnalyticsAdapter,
+  type GamificationHaptics,
+  type GamificationSoundEffectManager,
+  type GamificationTitle,
+  type XpSource,
+} from '../../types/gamification';
+import type { GamificationStoreState } from '../../hooks/useGamificationStore';
+
+const TITLES: GamificationTitle[] = [
+  'Coffee Curious',
+  'Bean Explorer',
+  'Flavor Scholar',
+  'Extraction Tactician',
+  'Aroma Virtuoso',
+  'Roast Strategist',
+  'Sensory Sage',
+  'Mythic Alchemist',
+  'Legendary Brewmaster',
+];
+
+interface ApplyXpOptions {
+  source: XpSource;
+  baseAmount: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface XpEngineDependencies {
+  store: StoreApi<GamificationStoreState>;
+  analytics: GamificationAnalyticsAdapter;
+  haptics: GamificationHaptics;
+  sounds: GamificationSoundEffectManager;
+  seasonalMultiplier?: () => number;
+  isDoubleXpOverride?: () => boolean;
+}
+
+/**
+ * Hlavný engine pre XP systém vrátane double XP víkendov a combo násobiča.
+ */
+export class XpEngine {
+  constructor(private readonly deps: XpEngineDependencies) {}
+
+  /**
+   * Exponenciálna XP krivka podľa zadania.
+   */
+  calculateXpForLevel(level: number): number {
+    return Math.round(100 * Math.pow(1.5, level - 1));
+  }
+
+  /**
+   * Odvodzuje titul podľa levelu.
+   */
+  getTitleForLevel(level: number): GamificationTitle {
+    const index = Math.min(TITLES.length - 1, Math.floor((level - 1) / Math.ceil(50 / TITLES.length)));
+    return TITLES[index];
+  }
+
+  /**
+   * Násobič podľa streaku (max 2x pri 30+ dňoch).
+   */
+  getComboMultiplier(streakDays: number): number {
+    if (streakDays <= 0) {
+      return 1;
+    }
+    const capped = Math.min(30, streakDays);
+    return 1 + capped * 0.03;
+  }
+
+  private isDoubleXpActive(): boolean {
+    if (this.deps.isDoubleXpOverride?.()) {
+      return true;
+    }
+    return isWeekend(new Date());
+  }
+
+  /**
+   * Hlavná metóda pre aplikovanie XP.
+   */
+  async applyXp({ source, baseAmount, metadata }: ApplyXpOptions): Promise<void> {
+    const state = this.deps.store.getState();
+    const seasonalMultiplier = this.deps.seasonalMultiplier?.() ?? 1;
+    const comboMultiplier = this.getComboMultiplier(state.streakDays);
+    const doubleXp = this.isDoubleXpActive() || state.doubleXpActive;
+    const doubleMultiplier = doubleXp ? 2 : 1;
+    const totalGain = Math.round(baseAmount * comboMultiplier * doubleMultiplier * seasonalMultiplier);
+
+    let level = state.level;
+    let currentXp = state.currentXp + totalGain;
+    let xpToNext = this.calculateXpForLevel(level);
+    let skillPoints = state.skillPoints;
+    let leveledUp = false;
+
+    while (currentXp >= xpToNext && level < 50) {
+      currentXp -= xpToNext;
+      level += 1;
+      xpToNext = this.calculateXpForLevel(level);
+      if (level % 5 === 0) {
+        skillPoints += 1;
+      }
+      leveledUp = true;
+    }
+
+    this.deps.store.setState({
+      currentXp,
+      level,
+      xpToNextLevel: xpToNext,
+      skillPoints,
+      comboMultiplier,
+      doubleXpActive: doubleXp,
+      title: this.getTitleForLevel(level),
+    });
+
+    await this.deps.analytics.track({
+      type: 'xp_gain',
+      payload: {
+        source,
+        baseAmount,
+        totalGain,
+        comboMultiplier,
+        doubleXp,
+        seasonalMultiplier,
+        level,
+        metadata,
+      },
+    });
+
+    this.deps.haptics.impact();
+    await this.deps.sounds.play('xp_gain');
+
+    if (leveledUp) {
+      this.deps.haptics.notification();
+      await this.deps.sounds.play('level_up');
+      await this.deps.analytics.track({
+        type: 'level_up',
+        payload: {
+          level,
+          skillPoints,
+        },
+      });
+    }
+  }
+}

--- a/src/services/haptics/GamificationHaptics.ts
+++ b/src/services/haptics/GamificationHaptics.ts
@@ -1,0 +1,30 @@
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import type { GamificationHaptics } from '../../types/gamification';
+
+const OPTIONS = { enableVibrateFallback: true, ignoreAndroidSystemSettings: false };
+
+/**
+ * Implementácia haptiky prispôsobená pre gamifikáciu.
+ */
+export class GamificationHapticManager implements GamificationHaptics {
+  /**
+   * Jemný pocit úspechu pri menších odmenách.
+   */
+  success(): void {
+    ReactNativeHapticFeedback.trigger('notificationSuccess', OPTIONS);
+  }
+
+  /**
+   * Výrazný dopad pri získaní XP alebo posune.
+   */
+  impact(): void {
+    ReactNativeHapticFeedback.trigger('impactMedium', OPTIONS);
+  }
+
+  /**
+   * Používa sa pri upozorneniach alebo level up.
+   */
+  notification(): void {
+    ReactNativeHapticFeedback.trigger('notificationWarning', OPTIONS);
+  }
+}

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -1,0 +1,178 @@
+import type { Json } from './supabase';
+
+/**
+ * Tituly priraďované hráčom podľa levelu.
+ */
+export type GamificationTitle =
+  | 'Coffee Curious'
+  | 'Bean Explorer'
+  | 'Flavor Scholar'
+  | 'Extraction Tactician'
+  | 'Aroma Virtuoso'
+  | 'Roast Strategist'
+  | 'Sensory Sage'
+  | 'Mythic Alchemist'
+  | 'Legendary Brewmaster';
+
+/**
+ * Všetky zdroje XP ktoré aplikácia sleduje.
+ */
+export type XpSource =
+  | 'brew'
+  | 'perfect_brew'
+  | 'help_others'
+  | 'daily_quest'
+  | 'streak_bonus'
+  | 'event_reward'
+  | 'skill_training'
+  | 'exploration'
+  | 'social_share';
+
+export type AchievementRarity = 'common' | 'rare' | 'epic' | 'legendary';
+
+export type AchievementCategory =
+  | 'beginner'
+  | 'skills'
+  | 'exploration'
+  | 'social'
+  | 'hidden';
+
+export interface AchievementDefinition {
+  id: string;
+  name: string;
+  description: string;
+  category: AchievementCategory;
+  rarity: AchievementRarity;
+  milestones: number[];
+  rewardXp: number;
+  rewardSkillPoints?: number;
+  featureUnlock?: string;
+  isHidden?: boolean;
+}
+
+export interface AchievementProgress {
+  achievementId: string;
+  progress: number;
+  completedMilestones: number[];
+  unlockedAt?: string;
+  featured?: boolean;
+}
+
+export type DailyQuestDifficulty = 'easy' | 'medium' | 'hard' | 'special';
+
+export interface DailyQuestTemplate {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: DailyQuestDifficulty;
+  xpReward: number;
+  requirements: Json;
+  category: 'ritual' | 'exploration' | 'social' | 'skill' | 'event';
+}
+
+export interface DailyQuestInstance {
+  id: string;
+  templateId: string;
+  assignedAt: string;
+  expiresAt: string;
+  progress: number;
+  goal: number;
+  completed: boolean;
+  xpReward: number;
+  metadata: Json;
+}
+
+export interface LeaderboardEntry {
+  userId: string;
+  displayName: string;
+  avatarUrl?: string;
+  xp: number;
+  rank: number;
+  trend?: 'up' | 'down' | 'steady';
+  countryCode?: string;
+  title: GamificationTitle;
+}
+
+export type LeaderboardScope = 'global' | 'friends' | 'local';
+
+export type LeaderboardRange = 'weekly' | 'monthly' | 'all_time';
+
+export interface RadarStat {
+  key: 'brewing' | 'exploration' | 'social' | 'knowledge';
+  value: number;
+  average: number;
+}
+
+export interface SkillTreeNode {
+  id: string;
+  name: string;
+  description: string;
+  unlocked: boolean;
+  prerequisites: string[];
+  bonuses: Record<string, number>;
+}
+
+export interface GamificationStateSnapshot {
+  userId: string;
+  level: number;
+  currentXp: number;
+  xpToNextLevel: number;
+  skillPoints: number;
+  comboMultiplier: number;
+  doubleXpActive: boolean;
+  title: GamificationTitle;
+  streakDays: number;
+  brewStreakDays: number;
+  perfectWeek: boolean;
+  freezeTokens: number;
+  streakFrozenUntil?: string;
+  radarStats: RadarStat[];
+  skillTree: SkillTreeNode[];
+}
+
+export interface GamificationEvent {
+  type: 'xp_gain' | 'level_up' | 'achievement_unlocked' | 'quest_completed' | 'streak_update';
+  payload: Record<string, unknown>;
+}
+
+export interface SeasonalEventConfig {
+  id: string;
+  title: string;
+  theme: string;
+  startAt: string;
+  endAt: string;
+  bonusXpMultiplier: number;
+  featuredAchievements: string[];
+}
+
+export interface AntiCheatReport {
+  userId: string;
+  timestamp: string;
+  reason: 'rate_limit' | 'anomaly' | 'suspicious_pattern';
+  details: Json;
+}
+
+export interface GamificationABTestAssignment {
+  testName: string;
+  variant: string;
+  assignedAt: string;
+}
+
+export interface GamificationAnalyticsAdapter {
+  track(event: GamificationEvent): Promise<void>;
+}
+
+export interface GamificationNotificationChannel {
+  scheduleQuestReminder(quest: DailyQuestInstance): Promise<void>;
+  cancelQuestReminder(questId: string): Promise<void>;
+}
+
+export interface GamificationSoundEffectManager {
+  play(effect: 'level_up' | 'achievement' | 'quest_complete' | 'xp_gain'): Promise<void>;
+}
+
+export interface GamificationHaptics {
+  success(): void;
+  impact(): void;
+  notification(): void;
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,7 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];

--- a/src/utils/randomId.ts
+++ b/src/utils/randomId.ts
@@ -1,0 +1,38 @@
+/**
+ * Generuje pseudo-náhodné ID vhodné pre identifikátory v aplikácii.
+ * Preferuje kryptograficky bezpečné generovanie ak je dostupné,
+ * v opačnom prípade fallback na Math.random.
+ */
+export interface RandomIdOptions {
+  /** Počet generovaných znakov bez prefixu. */
+  length?: number;
+  /** Voliteľný prefix oddelený pomlčkou. */
+  prefix?: string;
+}
+
+const DEFAULT_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+type MaybeCrypto = {
+  getRandomValues?: (array: Uint32Array) => Uint32Array;
+};
+
+const createIndexes = (count: number): number[] => {
+  const alphabetLength = DEFAULT_ALPHABET.length;
+  const cryptoInstance: MaybeCrypto | undefined = (globalThis as typeof globalThis & { crypto?: MaybeCrypto }).crypto;
+
+  if (cryptoInstance && typeof cryptoInstance.getRandomValues === 'function') {
+    const values = cryptoInstance.getRandomValues(new Uint32Array(count));
+    return Array.from(values, (value) => value % alphabetLength);
+  }
+
+  return Array.from({ length: count }, () => Math.floor(Math.random() * alphabetLength));
+};
+
+/**
+ * Vytvorí identifikátor s voliteľným prefixom.
+ */
+export const randomId = ({ length = 12, prefix }: RandomIdOptions = {}): string => {
+  const indexes = createIndexes(length);
+  const id = indexes.map((index) => DEFAULT_ALPHABET[index]).join('');
+  return prefix ? `${prefix}-${id}` : id;
+};


### PR DESCRIPTION
## Summary
- introduce gamification domain models, Zustand store, and service layer that orchestrates leveling, quests, achievements, analytics, haptics, audio, and notifications
- add animated UI for gamification (level progress, achievement showcase, quest cards, radar stats) together with a leaderboard screen and provider wiring in App.tsx
- replace the nanoid dependency with a shared randomId utility and make sound effect configuration resilient when bundled assets are unavailable

## Testing
- npm run lint *(fails: ESLint 9.x requires migration to the new eslint.config.js format)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c338dc8832a8cf997547f840863