### PR TITLE
Add seasonal gamification schema and Supabase adapter support

### DIFF
--- a/db/update_gamification_schema.sql
+++ b/db/update_gamification_schema.sql
@@ -1,0 +1,321 @@
+-- Rozšírenie gamifikačnej schémy o sezónne a bonusové polia
+-- Skript je idempotentný a je bezpečné spúšťať ho viackrát.
+
+-- Základná tabuľka pre stav gamifikácie používateľa
+create table if not exists public.gamification_state_snapshots (
+    user_id uuid primary key references auth.users(id) on delete cascade,
+    total_xp integer not null default 0,
+    level integer not null default 1,
+    xp_to_next_level integer not null default 100,
+    lifetime_points integer not null default 0,
+    unclaimed_points integer not null default 0,
+    streak_count integer not null default 0,
+    longest_streak integer not null default 0,
+    last_streak_reset_at timestamptz,
+    last_updated_at timestamptz not null default now(),
+    metadata jsonb not null default '{}'::jsonb
+);
+
+alter table if exists public.gamification_state_snapshots
+    add column if not exists season_id uuid,
+    add column if not exists season_level integer not null default 1,
+    add column if not exists season_xp integer not null default 0,
+    add column if not exists season_points integer not null default 0,
+    add column if not exists season_rank integer,
+    add column if not exists season_tier text,
+    add column if not exists season_bonus_multiplier numeric(4,2) not null default 1.0,
+    add column if not exists season_bonus_expires_at timestamptz,
+    add column if not exists season_xp_to_next_level integer not null default 100,
+    add column if not exists boost_multiplier numeric(4,2) not null default 1.0,
+    add column if not exists boost_expires_at timestamptz;
+
+comment on column public.gamification_state_snapshots.season_id is 'Aktuálne aktívna sezóna pre používateľa';
+comment on column public.gamification_state_snapshots.season_points is 'Sezónne body získané počas aktuálnej sezóny';
+comment on column public.gamification_state_snapshots.season_bonus_multiplier is 'Multiplikátor bodov získaný počas dočasných bonusov';
+
+-- Definícia denných questov
+create table if not exists public.quest_definitions (
+    id uuid primary key default gen_random_uuid(),
+    code text unique not null,
+    title text not null,
+    description text not null,
+    category text not null default 'daily',
+    rarity text not null default 'common',
+    target_value integer not null default 1,
+    reward_points integer not null default 0,
+    reward_xp integer not null default 0,
+    reward_items jsonb not null default '[]'::jsonb,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists public.daily_quest_instances (
+    id uuid primary key default gen_random_uuid(),
+    quest_definition_id uuid not null references public.quest_definitions(id) on delete cascade,
+    user_id uuid not null references auth.users(id) on delete cascade,
+    status text not null default 'pending',
+    progress integer not null default 0,
+    target integer not null default 1,
+    reward_points integer not null default 0,
+    reward_xp integer not null default 0,
+    started_at timestamptz not null default now(),
+    last_progress_at timestamptz not null default now(),
+    available_from timestamptz not null default now(),
+    expires_at timestamptz,
+    completed_at timestamptz,
+    claimed_at timestamptz,
+    metadata jsonb not null default '{}'::jsonb
+);
+
+alter table if exists public.daily_quest_instances
+    add column if not exists last_progress_at timestamptz not null default now(),
+    add column if not exists season_id uuid,
+    add column if not exists season_points integer not null default 0,
+    add column if not exists boost_multiplier numeric(4,2) not null default 1.0,
+    add column if not exists boost_expires_at timestamptz;
+
+comment on column public.daily_quest_instances.season_points is 'Dodatočné sezónne body priradené za splnenie questu';
+comment on column public.daily_quest_instances.boost_multiplier is 'Multiplikátor pokroku pre konkrétny quest';
+
+-- Definície achievementov
+create table if not exists public.achievement_definitions (
+    id uuid primary key default gen_random_uuid(),
+    code text unique not null,
+    title text not null,
+    description text not null,
+    category text not null default 'general',
+    tier text not null default 'bronze',
+    target_value integer not null default 1,
+    reward_points integer not null default 0,
+    reward_badge text,
+    reward_items jsonb not null default '[]'::jsonb,
+    is_secret boolean not null default false,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+alter table if exists public.achievement_definitions
+    add column if not exists is_seasonal boolean not null default false,
+    add column if not exists season_id uuid,
+    add column if not exists reward_xp integer not null default 0,
+    add column if not exists reward_currency jsonb not null default '{}'::jsonb;
+
+comment on column public.achievement_definitions.is_seasonal is 'Určuje, či je achievement viazaný na konkrétnu sezónu';
+comment on column public.achievement_definitions.reward_currency is 'Štruktúra bonusových odmien (napr. tokeny, kupóny)';
+
+-- Prepojenie achievementov s používateľmi
+create table if not exists public.user_achievements (
+    id uuid primary key default gen_random_uuid(),
+    achievement_id uuid not null references public.achievement_definitions(id) on delete cascade,
+    user_id uuid not null references auth.users(id) on delete cascade,
+    progress integer not null default 0,
+    target integer not null default 1,
+    unlocked_at timestamptz,
+    last_progress_at timestamptz not null default now(),
+    metadata jsonb not null default '{}'::jsonb,
+    unique(achievement_id, user_id)
+);
+
+-- Pohľad kombinujúci stav používateľa so sezónnymi údajmi
+create or replace view public.v_gamification_season_progress as
+select
+    s.user_id,
+    s.total_xp,
+    s.level,
+    s.xp_to_next_level,
+    s.lifetime_points,
+    s.unclaimed_points,
+    s.streak_count,
+    s.longest_streak,
+    s.last_streak_reset_at,
+    s.season_id,
+    s.season_level,
+    s.season_xp,
+    s.season_points,
+    s.season_rank,
+    s.season_tier,
+    s.season_bonus_multiplier,
+    s.season_bonus_expires_at,
+    s.season_xp_to_next_level,
+    s.boost_multiplier,
+    s.boost_expires_at,
+    s.last_updated_at,
+    s.metadata
+from public.gamification_state_snapshots s;
+
+-- Pohľad s aktívnymi dennými questami vrátane rozšírených polí
+create or replace view public.v_active_daily_quests as
+select
+    i.id,
+    i.quest_definition_id,
+    i.user_id,
+    i.status,
+    i.progress,
+    i.target,
+    i.reward_points,
+    i.reward_xp,
+    i.season_id,
+    i.season_points,
+    i.boost_multiplier,
+    i.boost_expires_at,
+    i.started_at,
+    i.available_from,
+    i.last_progress_at,
+    i.expires_at,
+    i.completed_at,
+    i.claimed_at,
+    i.metadata,
+    q.title,
+    q.description,
+    q.category,
+    q.rarity,
+    q.reward_items as definition_reward_items,
+    q.metadata as definition_metadata
+from public.daily_quest_instances i
+join public.quest_definitions q on q.id = i.quest_definition_id;
+
+-- RPC funkcia na aktualizáciu stavu gamifikácie s novými poliami
+create or replace function public.gamification_upsert_state(
+    p_user_id uuid,
+    p_total_xp integer default null,
+    p_level integer default null,
+    p_xp_to_next_level integer default null,
+    p_lifetime_points integer default null,
+    p_unclaimed_points integer default null,
+    p_streak_count integer default null,
+    p_longest_streak integer default null,
+    p_last_streak_reset_at timestamptz default null,
+    p_season_id uuid default null,
+    p_season_level integer default null,
+    p_season_xp integer default null,
+    p_season_points integer default null,
+    p_season_rank integer default null,
+    p_season_tier text default null,
+    p_season_bonus_multiplier numeric(4,2) default null,
+    p_season_bonus_expires_at timestamptz default null,
+    p_season_xp_to_next_level integer default null,
+    p_boost_multiplier numeric(4,2) default null,
+    p_boost_expires_at timestamptz default null,
+    p_metadata jsonb default null
+)
+returns public.gamification_state_snapshots
+language plpgsql
+as $$
+begin
+    insert into public.gamification_state_snapshots as s (
+        user_id,
+        total_xp,
+        level,
+        xp_to_next_level,
+        lifetime_points,
+        unclaimed_points,
+        streak_count,
+        longest_streak,
+        last_streak_reset_at,
+        season_id,
+        season_level,
+        season_xp,
+        season_points,
+        season_rank,
+        season_tier,
+        season_bonus_multiplier,
+        season_bonus_expires_at,
+        season_xp_to_next_level,
+        boost_multiplier,
+        boost_expires_at,
+        metadata,
+        last_updated_at
+    ) values (
+        p_user_id,
+        coalesce(p_total_xp, 0),
+        coalesce(p_level, 1),
+        coalesce(p_xp_to_next_level, 100),
+        coalesce(p_lifetime_points, 0),
+        coalesce(p_unclaimed_points, 0),
+        coalesce(p_streak_count, 0),
+        coalesce(p_longest_streak, 0),
+        p_last_streak_reset_at,
+        p_season_id,
+        coalesce(p_season_level, 1),
+        coalesce(p_season_xp, 0),
+        coalesce(p_season_points, 0),
+        p_season_rank,
+        p_season_tier,
+        coalesce(p_season_bonus_multiplier, 1.0),
+        p_season_bonus_expires_at,
+        coalesce(p_season_xp_to_next_level, 100),
+        coalesce(p_boost_multiplier, 1.0),
+        p_boost_expires_at,
+        coalesce(p_metadata, '{}'::jsonb),
+        now()
+    )
+    on conflict (user_id) do update set
+        total_xp = coalesce(p_total_xp, s.total_xp),
+        level = coalesce(p_level, s.level),
+        xp_to_next_level = coalesce(p_xp_to_next_level, s.xp_to_next_level),
+        lifetime_points = coalesce(p_lifetime_points, s.lifetime_points),
+        unclaimed_points = coalesce(p_unclaimed_points, s.unclaimed_points),
+        streak_count = coalesce(p_streak_count, s.streak_count),
+        longest_streak = coalesce(p_longest_streak, s.longest_streak),
+        last_streak_reset_at = coalesce(p_last_streak_reset_at, s.last_streak_reset_at),
+        season_id = coalesce(p_season_id, s.season_id),
+        season_level = coalesce(p_season_level, s.season_level),
+        season_xp = coalesce(p_season_xp, s.season_xp),
+        season_points = coalesce(p_season_points, s.season_points),
+        season_rank = coalesce(p_season_rank, s.season_rank),
+        season_tier = coalesce(p_season_tier, s.season_tier),
+        season_bonus_multiplier = coalesce(p_season_bonus_multiplier, s.season_bonus_multiplier),
+        season_bonus_expires_at = coalesce(p_season_bonus_expires_at, s.season_bonus_expires_at),
+        season_xp_to_next_level = coalesce(p_season_xp_to_next_level, s.season_xp_to_next_level),
+        boost_multiplier = coalesce(p_boost_multiplier, s.boost_multiplier),
+        boost_expires_at = coalesce(p_boost_expires_at, s.boost_expires_at),
+        metadata = coalesce(p_metadata, s.metadata),
+        last_updated_at = now()
+    returning *;
+end;
+$$;
+
+-- Funkcia na zaznamenanie postupu v denných questoch s multiplikátorom
+create or replace function public.gamification_apply_daily_quest_progress(
+    p_instance_id uuid,
+    p_increment integer default 1,
+    p_boost_override numeric(4,2) default null
+)
+returns public.daily_quest_instances
+language plpgsql
+as $$
+declare
+    v_instance public.daily_quest_instances;
+    v_multiplier numeric(4,2);
+begin
+    select * into v_instance from public.daily_quest_instances where id = p_instance_id for update;
+    if not found then
+        raise exception 'Quest instance % not found', p_instance_id;
+    end if;
+
+    if v_instance.status in ('completed', 'claimed', 'expired') then
+        return v_instance;
+    end if;
+
+    v_multiplier := coalesce(p_boost_override, v_instance.boost_multiplier, 1.0);
+
+    update public.daily_quest_instances
+    set
+        progress = least(v_instance.target, v_instance.progress + ceil(p_increment * v_multiplier)),
+        status = case
+            when least(v_instance.target, v_instance.progress + ceil(p_increment * v_multiplier)) >= v_instance.target then 'completed'
+            else 'active'
+        end,
+        completed_at = case
+            when least(v_instance.target, v_instance.progress + ceil(p_increment * v_multiplier)) >= v_instance.target then coalesce(v_instance.completed_at, now())
+            else v_instance.completed_at
+        end,
+        last_progress_at = now()
+    where id = p_instance_id
+    returning * into v_instance;
+
+    return v_instance;
+end;
+$$;

--- a/src/services/gamification/SupabaseGamificationAdapter.ts
+++ b/src/services/gamification/SupabaseGamificationAdapter.ts
@@ -1,0 +1,659 @@
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+
+import type {
+  AchievementDefinition,
+  AchievementReward,
+  DailyQuestInstance,
+  DailyQuestStatus,
+  GamificationOverview,
+  GamificationStatePatch,
+  GamificationStateSnapshot,
+} from '../../types/gamification';
+
+const isMissingFunction = (error: PostgrestError | null | undefined): boolean => {
+  if (!error) {
+    return false;
+  }
+  if (error.code === '42883' || error.code === '404') {
+    return true;
+  }
+  const message = error.message ?? '';
+  return /function .* does not exist/i.test(message) || /rpc function .* not found/i.test(message);
+};
+
+const isMissingRelation = (error: PostgrestError | null | undefined): boolean => {
+  if (!error) {
+    return false;
+  }
+  return error.code === '42P01' || /relation .* does not exist/i.test(error.message ?? '');
+};
+
+const toNumber = (value: unknown, fallback: number = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+};
+
+const toOptionalNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const parsed = toNumber(value, Number.NaN);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const toBoolean = (value: unknown, fallback: boolean = false): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    if (/^(true|t|1)$/i.test(value)) {
+      return true;
+    }
+    if (/^(false|f|0)$/i.test(value)) {
+      return false;
+    }
+  }
+  return fallback;
+};
+
+const toDateString = (value: unknown): string | null => {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return null;
+};
+
+const toStringOrNull = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return null;
+};
+
+const parseJson = <T>(value: unknown): T | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'object') {
+    return value as T;
+  }
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as T;
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter: JSON parse failed', error);
+      return null;
+    }
+  }
+  return null;
+};
+
+const normaliseQuestStatus = (value: unknown): DailyQuestStatus => {
+  if (typeof value === 'string') {
+    const normalised = value.toLowerCase() as DailyQuestStatus;
+    if (['pending', 'active', 'completed', 'claimed', 'expired'].includes(normalised)) {
+      return normalised;
+    }
+  }
+  return 'pending';
+};
+
+const mapRewardItems = (value: unknown): AchievementReward[] => {
+  const parsed = parseJson<AchievementReward[] | Record<string, unknown>[]>(value);
+  if (!parsed) {
+    return [];
+  }
+  if (Array.isArray(parsed)) {
+    return parsed
+      .map(item => {
+        if (!item) {
+          return null;
+        }
+        const candidate = item as AchievementReward & Record<string, unknown>;
+        const type = typeof candidate.type === 'string' ? (candidate.type as AchievementReward['type']) : 'item';
+        const mapped: AchievementReward = {
+          type,
+          value: candidate.value ?? candidate.reward ?? candidate.amount ?? 0,
+        };
+        if (candidate.metadata && typeof candidate.metadata === 'object') {
+          mapped.metadata = candidate.metadata as Record<string, unknown>;
+        }
+        return mapped;
+      })
+      .filter((item): item is AchievementReward => Boolean(item));
+  }
+  return [];
+};
+
+const mergeMetadata = (
+  primary?: Record<string, unknown>,
+  secondary?: Record<string, unknown> | null,
+): Record<string, unknown> | undefined => {
+  if (!primary && !secondary) {
+    return undefined;
+  }
+  return {
+    ...(secondary ?? {}),
+    ...(primary ?? {}),
+  };
+};
+
+const RPC_FETCH_STATE_FUNCTIONS = [
+  { name: 'gamification_fetch_state_v2', argument: 'p_user_id' },
+  { name: 'gamification_fetch_state', argument: 'p_user_id' },
+  { name: 'fetch_gamification_state', argument: 'user_id' },
+];
+
+const RPC_UPSERT_STATE_FUNCTIONS = ['gamification_upsert_state_v2', 'gamification_upsert_state'];
+
+const RPC_LIST_QUESTS_FUNCTIONS = [
+  { name: 'gamification_list_daily_quests_v2', argument: 'p_user_id' },
+  { name: 'gamification_list_daily_quests', argument: 'p_user_id' },
+];
+
+const RPC_APPLY_QUEST_PROGRESS_FUNCTIONS = [
+  'gamification_apply_daily_quest_progress_v2',
+  'gamification_apply_daily_quest_progress',
+];
+
+const RPC_CLAIM_QUEST_FUNCTIONS = [
+  'gamification_claim_daily_quest_v2',
+  'gamification_claim_daily_quest',
+];
+
+const resolveRpcRow = <T>(data: T | T[] | null | undefined): T | null => {
+  if (!data) {
+    return null;
+  }
+  if (Array.isArray(data)) {
+    return (data[0] as T | undefined) ?? null;
+  }
+  return data;
+};
+
+const ensureArray = <T>(value: T | T[] | null | undefined): T[] => {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const normalisePatchPayload = (patch: GamificationStatePatch): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {
+    p_user_id: patch.userId,
+  };
+
+  if (patch.totalXp !== undefined) payload.p_total_xp = patch.totalXp;
+  if (patch.level !== undefined) payload.p_level = patch.level;
+  if (patch.xpToNextLevel !== undefined) payload.p_xp_to_next_level = patch.xpToNextLevel;
+  if (patch.lifetimePoints !== undefined) payload.p_lifetime_points = patch.lifetimePoints;
+  if (patch.unclaimedPoints !== undefined) payload.p_unclaimed_points = patch.unclaimedPoints;
+  if (patch.streakCount !== undefined) payload.p_streak_count = patch.streakCount;
+  if (patch.longestStreak !== undefined) payload.p_longest_streak = patch.longestStreak;
+  if (patch.lastStreakResetAt !== undefined) payload.p_last_streak_reset_at = patch.lastStreakResetAt;
+  if (patch.seasonId !== undefined) payload.p_season_id = patch.seasonId;
+  if (patch.seasonLevel !== undefined) payload.p_season_level = patch.seasonLevel;
+  if (patch.seasonXp !== undefined) payload.p_season_xp = patch.seasonXp;
+  if (patch.seasonPoints !== undefined) payload.p_season_points = patch.seasonPoints;
+  if (patch.seasonRank !== undefined) payload.p_season_rank = patch.seasonRank;
+  if (patch.seasonTier !== undefined) payload.p_season_tier = patch.seasonTier;
+  if (patch.seasonBonusMultiplier !== undefined) payload.p_season_bonus_multiplier = patch.seasonBonusMultiplier;
+  if (patch.seasonBonusExpiresAt !== undefined) payload.p_season_bonus_expires_at = patch.seasonBonusExpiresAt;
+  if (patch.seasonXpToNextLevel !== undefined) payload.p_season_xp_to_next_level = patch.seasonXpToNextLevel;
+  if (patch.boostMultiplier !== undefined) payload.p_boost_multiplier = patch.boostMultiplier;
+  if (patch.boostExpiresAt !== undefined) payload.p_boost_expires_at = patch.boostExpiresAt;
+  if (patch.metadata !== undefined) payload.p_metadata = patch.metadata ?? {};
+
+  return payload;
+};
+
+export class SupabaseGamificationAdapter {
+  constructor(private readonly client: SupabaseClient) {}
+
+  private mapState(row: Record<string, any>): GamificationStateSnapshot {
+    return {
+      userId: toStringOrNull(row.user_id ?? row.userId) ?? '',
+      totalXp: toNumber(row.total_xp ?? row.totalXp),
+      level: toNumber(row.level),
+      xpToNextLevel: toNumber(row.xp_to_next_level ?? row.xpToNextLevel, 100),
+      lifetimePoints: toNumber(row.lifetime_points ?? row.lifetimePoints),
+      unclaimedPoints: toNumber(row.unclaimed_points ?? row.unclaimedPoints),
+      streakCount: toNumber(row.streak_count ?? row.streakCount),
+      longestStreak: toNumber(row.longest_streak ?? row.longestStreak),
+      lastStreakResetAt: toDateString(row.last_streak_reset_at ?? row.lastStreakResetAt ?? null),
+      seasonId: toStringOrNull(row.season_id ?? row.seasonId ?? null),
+      seasonLevel: toNumber(row.season_level ?? row.seasonLevel ?? 1, 1),
+      seasonXp: toNumber(row.season_xp ?? row.seasonXp),
+      seasonPoints: toNumber(row.season_points ?? row.seasonPoints),
+      seasonRank: toOptionalNumber(row.season_rank ?? row.seasonRank),
+      seasonTier: toStringOrNull(row.season_tier ?? row.seasonTier ?? null),
+      seasonBonusMultiplier: toNumber(row.season_bonus_multiplier ?? row.seasonBonusMultiplier, 1),
+      seasonBonusExpiresAt: toDateString(row.season_bonus_expires_at ?? row.seasonBonusExpiresAt ?? null),
+      seasonXpToNextLevel: toNumber(row.season_xp_to_next_level ?? row.seasonXpToNextLevel, 100),
+      boostMultiplier: toNumber(row.boost_multiplier ?? row.boostMultiplier, 1),
+      boostExpiresAt: toDateString(row.boost_expires_at ?? row.boostExpiresAt ?? null),
+      lastUpdatedAt: toDateString(row.last_updated_at ?? row.lastUpdatedAt ?? new Date()) ?? new Date().toISOString(),
+      metadata: parseJson<Record<string, unknown>>(row.metadata ?? row.extra ?? null) ?? undefined,
+    };
+  }
+
+  private mapDailyQuest(row: Record<string, any>): DailyQuestInstance {
+    const metadata = mergeMetadata(
+      parseJson<Record<string, unknown>>(row.metadata ?? null) ?? undefined,
+      parseJson<Record<string, unknown>>(row.definition_metadata ?? null) ?? undefined,
+    );
+
+    return {
+      id: toStringOrNull(row.id) ?? '',
+      questDefinitionId: toStringOrNull(row.quest_definition_id ?? row.questDefinitionId) ?? '',
+      userId: toStringOrNull(row.user_id ?? row.userId) ?? '',
+      status: normaliseQuestStatus(row.status),
+      progress: toNumber(row.progress),
+      target: toNumber(row.target ?? row.target_value ?? 1, 1),
+      rewardPoints: toNumber(row.reward_points ?? row.rewardPoints),
+      rewardXp: toNumber(row.reward_xp ?? row.rewardXp),
+      seasonId: toStringOrNull(row.season_id ?? row.seasonId ?? null),
+      seasonPoints: toNumber(row.season_points ?? row.seasonPoints),
+      boostMultiplier: toNumber(row.boost_multiplier ?? row.boostMultiplier, 1),
+      boostExpiresAt: toDateString(row.boost_expires_at ?? row.boostExpiresAt ?? null),
+      startedAt: toDateString(row.started_at ?? row.startedAt ?? new Date()) ?? new Date().toISOString(),
+      availableFrom: toDateString(row.available_from ?? row.availableFrom ?? row.started_at ?? row.startedAt ?? new Date()) ?? new Date().toISOString(),
+      lastProgressAt: toDateString(row.last_progress_at ?? row.lastProgressAt ?? row.started_at ?? row.startedAt ?? new Date()) ?? new Date().toISOString(),
+      expiresAt: toDateString(row.expires_at ?? row.expiresAt ?? null),
+      completedAt: toDateString(row.completed_at ?? row.completedAt ?? null),
+      claimedAt: toDateString(row.claimed_at ?? row.claimedAt ?? null),
+      metadata,
+    };
+  }
+
+  private mapAchievement(row: Record<string, any>): AchievementDefinition {
+    return {
+      id: toStringOrNull(row.id) ?? '',
+      code: toStringOrNull(row.code) ?? '',
+      title: toStringOrNull(row.title) ?? '',
+      description: toStringOrNull(row.description) ?? '',
+      category: toStringOrNull(row.category) ?? 'general',
+      tier: (toStringOrNull(row.tier) as AchievementDefinition['tier']) ?? 'bronze',
+      targetValue: toNumber(row.target_value ?? row.targetValue ?? 1, 1),
+      rewardPoints: toNumber(row.reward_points ?? row.rewardPoints),
+      rewardXp: toNumber(row.reward_xp ?? row.rewardXp),
+      rewardBadge: toStringOrNull(row.reward_badge ?? row.rewardBadge ?? null),
+      rewardItems: mapRewardItems(row.reward_items ?? row.rewardItems),
+      rewardCurrency: parseJson<Record<string, unknown>>(row.reward_currency ?? row.rewardCurrency ?? null) ?? undefined,
+      isSecret: toBoolean(row.is_secret ?? row.isSecret, false),
+      isSeasonal: toBoolean(row.is_seasonal ?? row.isSeasonal, false),
+      seasonId: toStringOrNull(row.season_id ?? row.seasonId ?? null) ?? undefined,
+      metadata: parseJson<Record<string, unknown>>(row.metadata ?? null) ?? undefined,
+      createdAt: toDateString(row.created_at ?? row.createdAt ?? null) ?? undefined,
+      updatedAt: toDateString(row.updated_at ?? row.updatedAt ?? null) ?? undefined,
+    };
+  }
+
+  public async fetchOverview(userId: string): Promise<GamificationOverview> {
+    const [state, dailyQuests, achievements] = await Promise.all([
+      this.fetchState(userId),
+      this.listDailyQuests(userId),
+      this.listAchievements(),
+    ]);
+
+    return { state, dailyQuests, achievements };
+  }
+
+  public async fetchState(userId: string): Promise<GamificationStateSnapshot | null> {
+    for (const rpc of RPC_FETCH_STATE_FUNCTIONS) {
+      try {
+        const { data, error } = await this.client.rpc(rpc.name, { [rpc.argument]: userId });
+        if (error) {
+          if (isMissingFunction(error)) {
+            continue;
+          }
+          console.warn(`SupabaseGamificationAdapter.fetchState RPC ${rpc.name} failed`, error);
+          continue;
+        }
+        const row = resolveRpcRow(data as Record<string, any> | Record<string, any>[] | null);
+        if (row) {
+          return this.mapState(row as Record<string, any>);
+        }
+      } catch (error) {
+        console.warn(`SupabaseGamificationAdapter.fetchState RPC ${rpc.name} threw`, error);
+      }
+    }
+
+    try {
+      const { data, error } = await this.client
+        .from('v_gamification_season_progress')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle<Record<string, any>>();
+
+      if (error) {
+        if (!isMissingRelation(error)) {
+          console.warn('SupabaseGamificationAdapter.fetchState view fallback failed', error);
+        }
+      }
+
+      if (data) {
+        return this.mapState(data);
+      }
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.fetchState view fallback threw', error);
+    }
+
+    try {
+      const { data, error } = await this.client
+        .from('gamification_state_snapshots')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle<Record<string, any>>();
+
+      if (error) {
+        if (!isMissingRelation(error)) {
+          console.warn('SupabaseGamificationAdapter.fetchState table fallback failed', error);
+        }
+        return null;
+      }
+
+      return data ? this.mapState(data) : null;
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.fetchState table fallback threw', error);
+      return null;
+    }
+  }
+
+  public async upsertState(patch: GamificationStatePatch): Promise<GamificationStateSnapshot | null> {
+    const payload = normalisePatchPayload(patch);
+
+    for (const rpc of RPC_UPSERT_STATE_FUNCTIONS) {
+      try {
+        const { data, error } = await this.client.rpc(rpc, payload);
+        if (error) {
+          if (isMissingFunction(error)) {
+            continue;
+          }
+          console.warn(`SupabaseGamificationAdapter.upsertState RPC ${rpc} failed`, error);
+          continue;
+        }
+        const row = resolveRpcRow(data as Record<string, any> | Record<string, any>[] | null);
+        if (row) {
+          return this.mapState(row as Record<string, any>);
+        }
+      } catch (error) {
+        console.warn(`SupabaseGamificationAdapter.upsertState RPC ${rpc} threw`, error);
+      }
+    }
+
+    try {
+      const upsertPayload: Record<string, unknown> = {
+        user_id: patch.userId,
+        total_xp: patch.totalXp,
+        level: patch.level,
+        xp_to_next_level: patch.xpToNextLevel,
+        lifetime_points: patch.lifetimePoints,
+        unclaimed_points: patch.unclaimedPoints,
+        streak_count: patch.streakCount,
+        longest_streak: patch.longestStreak,
+        last_streak_reset_at: patch.lastStreakResetAt,
+        season_id: patch.seasonId,
+        season_level: patch.seasonLevel,
+        season_xp: patch.seasonXp,
+        season_points: patch.seasonPoints,
+        season_rank: patch.seasonRank,
+        season_tier: patch.seasonTier,
+        season_bonus_multiplier: patch.seasonBonusMultiplier,
+        season_bonus_expires_at: patch.seasonBonusExpiresAt,
+        season_xp_to_next_level: patch.seasonXpToNextLevel,
+        boost_multiplier: patch.boostMultiplier,
+        boost_expires_at: patch.boostExpiresAt,
+        metadata: patch.metadata,
+      };
+
+      Object.keys(upsertPayload).forEach(key => {
+        if (upsertPayload[key] === undefined) {
+          delete upsertPayload[key];
+        }
+      });
+
+      const { error } = await this.client
+        .from('gamification_state_snapshots')
+        .upsert(upsertPayload, { onConflict: 'user_id' });
+
+      if (error) {
+        console.warn('SupabaseGamificationAdapter.upsertState table upsert failed', error);
+        return null;
+      }
+
+      return this.fetchState(patch.userId);
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.upsertState table upsert threw', error);
+      return null;
+    }
+  }
+
+  public async listDailyQuests(userId: string): Promise<DailyQuestInstance[]> {
+    for (const rpc of RPC_LIST_QUESTS_FUNCTIONS) {
+      try {
+        const { data, error } = await this.client.rpc(rpc.name, { [rpc.argument]: userId });
+        if (error) {
+          if (isMissingFunction(error)) {
+            continue;
+          }
+          console.warn(`SupabaseGamificationAdapter.listDailyQuests RPC ${rpc.name} failed`, error);
+          continue;
+        }
+        const rows = ensureArray(data as Record<string, any>[] | Record<string, any> | null);
+        if (rows.length > 0) {
+          return rows.map(row => this.mapDailyQuest(row as Record<string, any>));
+        }
+      } catch (error) {
+        console.warn(`SupabaseGamificationAdapter.listDailyQuests RPC ${rpc.name} threw`, error);
+      }
+    }
+
+    try {
+      const { data, error } = await this.client
+        .from('v_active_daily_quests')
+        .select('*')
+        .eq('user_id', userId);
+
+      if (error) {
+        if (!isMissingRelation(error)) {
+          console.warn('SupabaseGamificationAdapter.listDailyQuests view fallback failed', error);
+        }
+      }
+
+      if (data && data.length > 0) {
+        return data.map(row => this.mapDailyQuest(row as Record<string, any>));
+      }
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.listDailyQuests view fallback threw', error);
+    }
+
+    try {
+      const { data, error } = await this.client
+        .from('daily_quest_instances')
+        .select('*')
+        .eq('user_id', userId);
+
+      if (error) {
+        if (!isMissingRelation(error)) {
+          console.warn('SupabaseGamificationAdapter.listDailyQuests table fallback failed', error);
+        }
+        return [];
+      }
+
+      return (data ?? []).map(row => this.mapDailyQuest(row as Record<string, any>));
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.listDailyQuests table fallback threw', error);
+      return [];
+    }
+  }
+
+  public async applyDailyQuestProgress(
+    questInstanceId: string,
+    increment: number = 1,
+    boostOverride?: number,
+  ): Promise<DailyQuestInstance | null> {
+    for (const rpc of RPC_APPLY_QUEST_PROGRESS_FUNCTIONS) {
+      try {
+        const { data, error } = await this.client.rpc(rpc, {
+          p_instance_id: questInstanceId,
+          p_increment: increment,
+          p_boost_override: boostOverride,
+        });
+        if (error) {
+          if (isMissingFunction(error)) {
+            continue;
+          }
+          console.warn(`SupabaseGamificationAdapter.applyDailyQuestProgress RPC ${rpc} failed`, error);
+          continue;
+        }
+        const row = resolveRpcRow(data as Record<string, any>[] | Record<string, any> | null);
+        if (row) {
+          return this.mapDailyQuest(row as Record<string, any>);
+        }
+      } catch (error) {
+        console.warn(`SupabaseGamificationAdapter.applyDailyQuestProgress RPC ${rpc} threw`, error);
+      }
+    }
+
+    return this.applyQuestProgressFallback(questInstanceId, increment, boostOverride);
+  }
+
+  private async applyQuestProgressFallback(
+    questInstanceId: string,
+    increment: number,
+    boostOverride?: number,
+  ): Promise<DailyQuestInstance | null> {
+    try {
+      const { data: existing, error: fetchError } = await this.client
+        .from('daily_quest_instances')
+        .select('*')
+        .eq('id', questInstanceId)
+        .maybeSingle<Record<string, any>>();
+
+      if (fetchError || !existing) {
+        if (fetchError && !isMissingRelation(fetchError)) {
+          console.warn('SupabaseGamificationAdapter.applyQuestProgressFallback fetch failed', fetchError);
+        }
+        return null;
+      }
+
+      const target = toNumber(existing.target ?? existing.target_value ?? 1, 1);
+      const progress = toNumber(existing.progress ?? 0);
+      const multiplier = boostOverride ?? toNumber(existing.boost_multiplier ?? 1, 1);
+      const incremented = Math.ceil(Math.max(0, increment) * Math.max(multiplier, 0));
+      const nextProgress = Math.min(target, progress + incremented);
+      const isCompleted = nextProgress >= target;
+
+      const updatePayload: Record<string, unknown> = {
+        progress: nextProgress,
+        status: isCompleted ? 'completed' : 'active',
+        completed_at: isCompleted ? existing.completed_at ?? new Date().toISOString() : existing.completed_at ?? null,
+        last_progress_at: new Date().toISOString(),
+      };
+
+      const { data, error } = await this.client
+        .from('daily_quest_instances')
+        .update(updatePayload)
+        .eq('id', questInstanceId)
+        .select('*')
+        .maybeSingle<Record<string, any>>();
+
+      if (error) {
+        console.warn('SupabaseGamificationAdapter.applyQuestProgressFallback update failed', error);
+        return null;
+      }
+
+      return data ? this.mapDailyQuest(data) : null;
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.applyQuestProgressFallback threw', error);
+      return null;
+    }
+  }
+
+  public async claimDailyQuest(questInstanceId: string): Promise<DailyQuestInstance | null> {
+    for (const rpc of RPC_CLAIM_QUEST_FUNCTIONS) {
+      try {
+        const { data, error } = await this.client.rpc(rpc, { p_instance_id: questInstanceId });
+        if (error) {
+          if (isMissingFunction(error)) {
+            continue;
+          }
+          console.warn(`SupabaseGamificationAdapter.claimDailyQuest RPC ${rpc} failed`, error);
+          continue;
+        }
+        const row = resolveRpcRow(data as Record<string, any>[] | Record<string, any> | null);
+        if (row) {
+          return this.mapDailyQuest(row as Record<string, any>);
+        }
+      } catch (error) {
+        console.warn(`SupabaseGamificationAdapter.claimDailyQuest RPC ${rpc} threw`, error);
+      }
+    }
+
+    try {
+      const now = new Date().toISOString();
+      const { data, error } = await this.client
+        .from('daily_quest_instances')
+        .update({ status: 'claimed', claimed_at: now })
+        .eq('id', questInstanceId)
+        .select('*')
+        .maybeSingle<Record<string, any>>();
+
+      if (error) {
+        console.warn('SupabaseGamificationAdapter.claimDailyQuest fallback update failed', error);
+        return null;
+      }
+
+      return data ? this.mapDailyQuest(data) : null;
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.claimDailyQuest fallback threw', error);
+      return null;
+    }
+  }
+
+  public async listAchievements(): Promise<AchievementDefinition[]> {
+    try {
+      const { data, error } = await this.client
+        .from('achievement_definitions')
+        .select('*');
+
+      if (error) {
+        if (!isMissingRelation(error)) {
+          console.warn('SupabaseGamificationAdapter.listAchievements query failed', error);
+        }
+        return [];
+      }
+
+      return (data ?? []).map(row => this.mapAchievement(row as Record<string, any>));
+    } catch (error) {
+      console.warn('SupabaseGamificationAdapter.listAchievements threw', error);
+      return [];
+    }
+  }
+}
+
+export default SupabaseGamificationAdapter;

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -1,0 +1,87 @@
+export type DailyQuestStatus = 'pending' | 'active' | 'completed' | 'claimed' | 'expired';
+
+export type AchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond';
+
+export interface AchievementReward {
+  type: 'xp' | 'points' | 'badge' | 'item' | 'currency' | 'perk';
+  value: number | string | Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AchievementDefinition {
+  id: string;
+  code: string;
+  title: string;
+  description: string;
+  category: string;
+  tier: AchievementTier;
+  targetValue: number;
+  rewardPoints: number;
+  rewardXp: number;
+  rewardBadge?: string | null;
+  rewardItems: AchievementReward[];
+  rewardCurrency?: Record<string, unknown>;
+  isSecret: boolean;
+  isSeasonal: boolean;
+  seasonId?: string | null;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface DailyQuestInstance {
+  id: string;
+  questDefinitionId: string;
+  userId: string;
+  status: DailyQuestStatus;
+  progress: number;
+  target: number;
+  rewardPoints: number;
+  rewardXp: number;
+  seasonId?: string | null;
+  seasonPoints: number;
+  boostMultiplier: number;
+  boostExpiresAt?: string | null;
+  startedAt: string;
+  availableFrom: string;
+  lastProgressAt: string;
+  expiresAt?: string | null;
+  completedAt?: string | null;
+  claimedAt?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GamificationStateSnapshot {
+  userId: string;
+  totalXp: number;
+  level: number;
+  xpToNextLevel: number;
+  lifetimePoints: number;
+  unclaimedPoints: number;
+  streakCount: number;
+  longestStreak: number;
+  lastStreakResetAt?: string | null;
+  seasonId?: string | null;
+  seasonLevel: number;
+  seasonXp: number;
+  seasonPoints: number;
+  seasonRank?: number | null;
+  seasonTier?: string | null;
+  seasonBonusMultiplier: number;
+  seasonBonusExpiresAt?: string | null;
+  seasonXpToNextLevel: number;
+  boostMultiplier: number;
+  boostExpiresAt?: string | null;
+  lastUpdatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GamificationOverview {
+  state: GamificationStateSnapshot | null;
+  dailyQuests: DailyQuestInstance[];
+  achievements: AchievementDefinition[];
+}
+
+export type GamificationStatePatch = Partial<Omit<GamificationStateSnapshot, 'userId' | 'lastUpdatedAt'>> & {
+  userId: string;
+};


### PR DESCRIPTION
## Summary
- add an idempotent Supabase migration that introduces seasonal gamification columns, helper views and RPCs
- define strongly typed gamification models with new seasonal and bonus fields
- implement a SupabaseGamificationAdapter that reads/writes the extended schema with graceful fallbacks

## Testing
- npm run lint *(fails: ESLint 9.x requires eslint.config.* migration in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfaa2d0378832abc940b3f6703af83