### PR TITLE
Add gamification service orchestration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 // App.tsx
-import React, { useState, useEffect, useMemo, createContext } from 'react';
+import React, { useState, useEffect, useMemo, useRef, createContext } from 'react';
 import {
   StyleSheet,
   Text,
@@ -42,6 +42,15 @@ import { MorningRitualManager } from './src/services/MorningRitualManager';
 import { PreferenceLearningEngine } from './src/services/PreferenceLearningEngine';
 import { CoffeeDiary } from './src/services/CoffeeDiary';
 import { PrivacyManager } from './src/services/PrivacyManager';
+import GamificationService from './src/services/gamification/GamificationService';
+import { createGamificationStore } from './src/services/gamification/GamificationStore';
+import { GamificationServiceProvider } from './src/services/gamification/GamificationServiceProvider';
+import {
+  createDefaultGamificationAnalytics,
+  createDefaultGamificationHaptics,
+  createDefaultGamificationNotifications,
+  createDefaultGamificationSoundPlayer,
+} from './src/services/gamification/dependencyFactories';
 import {
   CalendarProvider,
   DiaryStorageAdapter,
@@ -334,9 +343,16 @@ class SupabaseLearningEventAdapter implements LearningEventProvider {
 interface AppContentProps {
   personalization: PersonalizationContextValue;
   setPersonalization: React.Dispatch<React.SetStateAction<PersonalizationContextValue>>;
+  gamificationService: GamificationService | null;
+  setGamificationService: React.Dispatch<React.SetStateAction<GamificationService | null>>;
 }
 
-const AppContent = ({ personalization, setPersonalization }: AppContentProps): React.JSX.Element | null => {
+const AppContent = ({
+  personalization,
+  setPersonalization,
+  gamificationService,
+  setGamificationService,
+}: AppContentProps): React.JSX.Element | null => {
   const [currentScreen, setCurrentScreen] = useState<ScreenName>('home');
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [generatedRecipe, setGeneratedRecipe] = useState('');
@@ -348,6 +364,57 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
   const { isDark, colors } = useTheme();
   const { ready: personalizationReady, morningRitualManager, learningEngine, userId } = personalization;
   const indicatorVisible = syncVisible || queueLength > 0;
+  const gamificationStoreRef = useRef(createGamificationStore());
+  const gamificationAnalyticsRef = useRef(createDefaultGamificationAnalytics());
+  const gamificationSoundsRef = useRef(createDefaultGamificationSoundPlayer());
+  const gamificationHapticsRef = useRef(createDefaultGamificationHaptics());
+  const gamificationNotificationsRef = useRef(createDefaultGamificationNotifications());
+
+  const gamificationDependencies = useMemo(
+    () => ({
+      supabaseClient,
+      store: gamificationStoreRef.current,
+      analytics: gamificationAnalyticsRef.current,
+      sounds: gamificationSoundsRef.current,
+      haptics: gamificationHapticsRef.current,
+      notifications: gamificationNotificationsRef.current,
+    }),
+    [supabaseClient],
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated || !gamificationDependencies.supabaseClient) {
+      setGamificationService((current) => {
+        if (current) {
+          current.dispose();
+        }
+        return null;
+      });
+      return;
+    }
+
+    if (gamificationService) {
+      return;
+    }
+
+    const service = new GamificationService(gamificationDependencies);
+    setGamificationService(service);
+
+    return () => {
+      setGamificationService((current) => {
+        if (current === service) {
+          current.dispose();
+          return null;
+        }
+        return current;
+      });
+    };
+  }, [
+    gamificationDependencies,
+    gamificationService,
+    isAuthenticated,
+    setGamificationService,
+  ]);
 
   useEffect(() => {
     const init = async () => {
@@ -1119,13 +1186,25 @@ export default function App(): React.JSX.Element {
   const [personalization, setPersonalization] = useState<PersonalizationContextValue>(
     () => ({ ...emptyPersonalizationState }),
   );
+  const [gamificationService, setGamificationService] = useState<GamificationService | null>(null);
 
   const contextValue = useMemo(() => personalization, [personalization]);
+  const gamificationContextValue = useMemo(
+    () => ({ service: gamificationService, setService: setGamificationService }),
+    [gamificationService],
+  );
 
   return (
     <ThemeProvider>
       <PersonalizationContext.Provider value={contextValue}>
-        <AppContent personalization={personalization} setPersonalization={setPersonalization} />
+        <GamificationServiceProvider value={gamificationContextValue}>
+          <AppContent
+            personalization={personalization}
+            setPersonalization={setPersonalization}
+            gamificationService={gamificationService}
+            setGamificationService={setGamificationService}
+          />
+        </GamificationServiceProvider>
       </PersonalizationContext.Provider>
     </ThemeProvider>
   );

--- a/src/services/gamification/GamificationService.ts
+++ b/src/services/gamification/GamificationService.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import SupabaseGamificationAdapter from './SupabaseGamificationAdapter';
+import type { GamificationOverview } from '../../types/gamification';
+import type { GamificationStore } from './GamificationStore';
+
+export interface GamificationAnalytics {
+  track(event: string, payload?: Record<string, unknown>): void;
+}
+
+export interface GamificationSoundPlayer {
+  play(effect: string): Promise<void> | void;
+  stop?(effect?: string): Promise<void> | void;
+}
+
+export interface GamificationHaptics {
+  impact(pattern: 'light' | 'medium' | 'heavy'): Promise<void> | void;
+  notify?(type: 'success' | 'warning' | 'error'): Promise<void> | void;
+}
+
+export interface GamificationNotifications {
+  trigger(event: string, payload?: Record<string, unknown>): Promise<void> | void;
+}
+
+export interface GamificationServiceDependencies {
+  supabaseClient: SupabaseClient | null;
+  store: GamificationStore;
+  analytics: GamificationAnalytics;
+  sounds: GamificationSoundPlayer;
+  haptics: GamificationHaptics;
+  notifications: GamificationNotifications;
+}
+
+export class GamificationService {
+  private readonly adapter: SupabaseGamificationAdapter | null;
+  private disposed = false;
+
+  constructor(private readonly dependencies: GamificationServiceDependencies) {
+    this.adapter = dependencies.supabaseClient
+      ? new SupabaseGamificationAdapter(dependencies.supabaseClient)
+      : null;
+  }
+
+  public getDeps(): GamificationServiceDependencies {
+    return this.dependencies;
+  }
+
+  public async refreshOverview(userId: string): Promise<GamificationOverview | null> {
+    if (this.disposed) {
+      return null;
+    }
+
+    const { store, analytics } = this.dependencies;
+    store.setState({ isLoading: true, error: null });
+
+    try {
+      if (!this.adapter) {
+        store.setState({ isLoading: false });
+        return null;
+      }
+
+      const overview = await this.adapter.fetchOverview(userId);
+      store.setState({
+        overview,
+        isLoading: false,
+        lastFetchedAt: new Date().toISOString(),
+      });
+      analytics.track('gamification_overview_refresh', { userId });
+      return overview;
+    } catch (error) {
+      console.warn('GamificationService.refreshOverview failed', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      store.setState({ error: message, isLoading: false });
+      return null;
+    }
+  }
+
+  public dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.dependencies.store.reset();
+  }
+}
+
+export default GamificationService;

--- a/src/services/gamification/GamificationServiceProvider.tsx
+++ b/src/services/gamification/GamificationServiceProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import type GamificationService from './GamificationService';
+
+export interface GamificationServiceContextValue {
+  service: GamificationService | null;
+  setService: React.Dispatch<React.SetStateAction<GamificationService | null>>;
+}
+
+const GamificationServiceContext = createContext<GamificationServiceContextValue | undefined>(undefined);
+
+export interface GamificationServiceProviderProps {
+  value: GamificationServiceContextValue;
+  children: React.ReactNode;
+}
+
+export const GamificationServiceProvider = ({ value, children }: GamificationServiceProviderProps): React.JSX.Element => {
+  const memoisedValue = useMemo(
+    () => ({ service: value.service, setService: value.setService }),
+    [value.service, value.setService],
+  );
+  return <GamificationServiceContext.Provider value={memoisedValue}>{children}</GamificationServiceContext.Provider>;
+};
+
+export const useGamificationServiceContext = (): GamificationServiceContextValue => {
+  const context = useContext(GamificationServiceContext);
+  if (!context) {
+    throw new Error('useGamificationServiceContext must be used within a GamificationServiceProvider');
+  }
+  return context;
+};
+
+export default GamificationServiceContext;

--- a/src/services/gamification/GamificationStore.ts
+++ b/src/services/gamification/GamificationStore.ts
@@ -1,0 +1,62 @@
+import type { GamificationOverview } from '../../types/gamification';
+
+export interface GamificationStoreState {
+  overview: GamificationOverview | null;
+  isLoading: boolean;
+  lastFetchedAt: string | null;
+  error: string | null;
+}
+
+const DEFAULT_STATE: GamificationStoreState = {
+  overview: null,
+  isLoading: false,
+  lastFetchedAt: null,
+  error: null,
+};
+
+export type GamificationStoreListener = (state: GamificationStoreState) => void;
+
+export interface GamificationStore {
+  getState(): GamificationStoreState;
+  setState(patch: Partial<GamificationStoreState>): void;
+  subscribe(listener: GamificationStoreListener): () => void;
+  reset(): void;
+}
+
+export const createGamificationStore = (
+  initialState: Partial<GamificationStoreState> = {},
+): GamificationStore => {
+  let state: GamificationStoreState = { ...DEFAULT_STATE, ...initialState };
+  const listeners = new Set<GamificationStoreListener>();
+
+  const notify = () => {
+    const snapshot = state;
+    listeners.forEach((listener) => {
+      try {
+        listener(snapshot);
+      } catch (error) {
+        console.warn('GamificationStore listener threw', error);
+      }
+    });
+  };
+
+  return {
+    getState() {
+      return state;
+    },
+    setState(patch) {
+      state = { ...state, ...patch };
+      notify();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    reset() {
+      state = { ...DEFAULT_STATE, ...initialState };
+      notify();
+    },
+  };
+};

--- a/src/services/gamification/dependencyFactories.ts
+++ b/src/services/gamification/dependencyFactories.ts
@@ -1,0 +1,36 @@
+import type {
+  GamificationAnalytics,
+  GamificationHaptics,
+  GamificationNotifications,
+  GamificationSoundPlayer,
+} from './GamificationService';
+
+export const createDefaultGamificationAnalytics = (): GamificationAnalytics => ({
+  track(event, payload) {
+    console.debug('[Gamification][Analytics]', event, payload ?? {});
+  },
+});
+
+export const createDefaultGamificationSoundPlayer = (): GamificationSoundPlayer => ({
+  async play(effect: string) {
+    console.debug('[Gamification][Sound] play', effect);
+  },
+  async stop(effect?: string) {
+    console.debug('[Gamification][Sound] stop', effect);
+  },
+});
+
+export const createDefaultGamificationHaptics = (): GamificationHaptics => ({
+  async impact(pattern) {
+    console.debug('[Gamification][Haptics] impact', pattern);
+  },
+  async notify(type) {
+    console.debug('[Gamification][Haptics] notify', type);
+  },
+});
+
+export const createDefaultGamificationNotifications = (): GamificationNotifications => ({
+  async trigger(event, payload) {
+    console.debug('[Gamification][Notifications] trigger', event, payload ?? {});
+  },
+});


### PR DESCRIPTION
## Summary
- add a dedicated gamification service, store and dependency factories to prepare orchestration hooks
- initialize the gamification service inside AppContent with Supabase, analytics, sound, haptic and notification dependencies
- wrap the UI with GamificationServiceProvider so the setter stays the single source of truth for the flow

## Testing
- npm test *(fails: jest not found in PATH without installed dependencies)*
- npm install *(fails: registry returned 403 for @invertase/react-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68cfad28b700832abbb6fd1c2256bdf9