### PR TITLE
Add XP engine and award brew log XP

### DIFF
--- a/src/services/gamification/GamificationService.ts
+++ b/src/services/gamification/GamificationService.ts
@@ -1,7 +1,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import SupabaseGamificationAdapter from './SupabaseGamificationAdapter';
-import type { GamificationOverview } from '../../types/gamification';
+import type { GamificationOverview, GamificationStateSnapshot } from '../../types/gamification';
 import type { GamificationStore } from './GamificationStore';
+import XpEngine, { type XpGrant, XpSource } from './XpEngine';
 
 export interface GamificationAnalytics {
   track(event: string, payload?: Record<string, unknown>): void;
@@ -32,6 +33,7 @@ export interface GamificationServiceDependencies {
 
 export class GamificationService {
   private readonly adapter: SupabaseGamificationAdapter | null;
+  private readonly xpEngine = new XpEngine();
   private disposed = false;
 
   constructor(private readonly dependencies: GamificationServiceDependencies) {
@@ -74,12 +76,110 @@ export class GamificationService {
     }
   }
 
+  public async addXp(grant: XpGrant): Promise<GamificationStateSnapshot | null> {
+    if (this.disposed) {
+      return null;
+    }
+
+    const { store, analytics, sounds, haptics, notifications } = this.dependencies;
+    const currentState = store.getState().overview?.state ?? null;
+    const outcome = this.xpEngine.applyXp(grant, currentState);
+
+    if (outcome.kind === 'rejected') {
+      analytics.track('gamification_xp_rejected', {
+        userId: grant.userId,
+        source: grant.source,
+        reason: outcome.reason,
+      });
+      return currentState;
+    }
+
+    analytics.track('gamification_xp_applied', {
+      userId: grant.userId,
+      source: grant.source,
+      baseAmount: outcome.baseAmount,
+      appliedXp: outcome.appliedXp,
+      doubleXpActive: outcome.doubleXpActive,
+      comboMultiplier: outcome.comboMultiplier,
+      comboCount: outcome.comboCount,
+      totalMultiplier: outcome.totalMultiplier,
+      skillPointsEarned: outcome.skillPointsEarned,
+    });
+
+    this.applyLocalSnapshot(outcome.state);
+
+    try {
+      await Promise.resolve(sounds.play('xp_gain'));
+    } catch (error) {
+      console.warn('GamificationService.addXp sound failed', error);
+    }
+
+    try {
+      await Promise.resolve(haptics.impact('light'));
+    } catch (error) {
+      console.warn('GamificationService.addXp haptics failed', error);
+    }
+
+    try {
+      await Promise.resolve(
+        notifications.trigger('xp_awarded', {
+          userId: grant.userId,
+          amount: outcome.appliedXp,
+          source: grant.source,
+        }),
+      );
+    } catch (error) {
+      console.warn('GamificationService.addXp notification failed', error);
+    }
+
+    if (!this.adapter) {
+      return outcome.state;
+    }
+
+    try {
+      const persisted = await this.adapter.upsertState(outcome.patch);
+      if (persisted) {
+        this.applyLocalSnapshot(persisted);
+        return persisted;
+      }
+    } catch (error) {
+      console.warn('GamificationService.addXp persistence failed', error);
+    }
+
+    return outcome.state;
+  }
+
+  public async handleBrewLogSaved(
+    userId: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<GamificationStateSnapshot | null> {
+    return this.addXp({
+      userId,
+      baseAmount: 35,
+      source: XpSource.BrewLogEntry,
+      metadata,
+    });
+  }
+
   public dispose(): void {
     if (this.disposed) {
       return;
     }
     this.disposed = true;
     this.dependencies.store.reset();
+    this.xpEngine.reset();
+  }
+
+  private applyLocalSnapshot(snapshot: GamificationStateSnapshot): void {
+    const { store } = this.dependencies;
+    const { overview } = store.getState();
+    const nextOverview: GamificationOverview = overview
+      ? { ...overview, state: snapshot }
+      : { state: snapshot, dailyQuests: [], achievements: [] };
+    store.setState({
+      overview: nextOverview,
+      lastFetchedAt: snapshot.lastUpdatedAt ?? new Date().toISOString(),
+    });
   }
 }
 

--- a/src/services/gamification/XpEngine.ts
+++ b/src/services/gamification/XpEngine.ts
@@ -1,0 +1,249 @@
+import type { GamificationStatePatch, GamificationStateSnapshot } from '../../types/gamification';
+
+export enum XpSource {
+  DailyQuest = 'daily_quest',
+  Achievement = 'achievement',
+  ManualGrant = 'manual_grant',
+  BrewLogEntry = 'brew_log_entry',
+}
+
+export interface XpGrant {
+  userId: string;
+  baseAmount: number;
+  source: XpSource;
+  timestamp?: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface XpApplicationSuccess {
+  kind: 'applied';
+  baseAmount: number;
+  appliedXp: number;
+  doubleXpActive: boolean;
+  comboMultiplier: number;
+  comboCount: number;
+  totalMultiplier: number;
+  skillPointsEarned: number;
+  patch: GamificationStatePatch;
+  state: GamificationStateSnapshot;
+  metadata: Record<string, unknown> | undefined;
+}
+
+export interface XpApplicationRejected {
+  kind: 'rejected';
+  reason: 'invalid' | 'rate_limit' | 'amount_limit';
+}
+
+export type XpApplicationOutcome = XpApplicationSuccess | XpApplicationRejected;
+
+interface ComboState {
+  count: number;
+  lastTimestamp: number;
+}
+
+interface AntiCheatRule {
+  windowMs: number;
+  maxEvents: number;
+  maxAmount?: number;
+}
+
+const COMBO_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_COMBO_COUNT = 5;
+const COMBO_STEP = 0.25;
+
+const createDefaultSnapshot = (
+  userId: string,
+  timestamp: Date,
+): GamificationStateSnapshot => ({
+  userId,
+  totalXp: 0,
+  level: 1,
+  xpToNextLevel: 100,
+  lifetimePoints: 0,
+  unclaimedPoints: 0,
+  streakCount: 0,
+  longestStreak: 0,
+  lastStreakResetAt: null,
+  seasonId: null,
+  seasonLevel: 1,
+  seasonXp: 0,
+  seasonPoints: 0,
+  seasonRank: null,
+  seasonTier: null,
+  seasonBonusMultiplier: 1,
+  seasonBonusExpiresAt: null,
+  seasonXpToNextLevel: 100,
+  boostMultiplier: 1,
+  boostExpiresAt: null,
+  lastUpdatedAt: timestamp.toISOString(),
+  metadata: undefined,
+});
+
+const calculateXpThreshold = (level: number): number => 100 + Math.floor(Math.max(0, level - 1) * 20);
+
+const extractNumber = (value: unknown, fallback = 0): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+export class XpEngine {
+  private readonly comboState = new Map<string, ComboState>();
+  private readonly history = new Map<string, number[]>();
+
+  private readonly antiCheatRules: Partial<Record<XpSource, AntiCheatRule>> = {
+    [XpSource.BrewLogEntry]: {
+      windowMs: 60 * 60 * 1000, // 1 hour
+      maxEvents: 8,
+      maxAmount: 150,
+    },
+  };
+
+  public reset(): void {
+    this.comboState.clear();
+    this.history.clear();
+  }
+
+  public applyXp(grant: XpGrant, state: GamificationStateSnapshot | null): XpApplicationOutcome {
+    const { userId, baseAmount, source } = grant;
+    if (!userId || baseAmount <= 0 || !Number.isFinite(baseAmount)) {
+      return { kind: 'rejected', reason: 'invalid' };
+    }
+
+    const timestamp = grant.timestamp ?? new Date();
+    const rule = this.antiCheatRules[source];
+    const historyKey = `${userId}:${source}`;
+
+    if (rule) {
+      const now = timestamp.getTime();
+      const entries = this.history.get(historyKey) ?? [];
+      const filtered = entries.filter((value) => value > now - rule.windowMs);
+
+      if (rule.maxAmount !== undefined && baseAmount > rule.maxAmount) {
+        this.history.set(historyKey, filtered);
+        return { kind: 'rejected', reason: 'amount_limit' };
+      }
+
+      if (filtered.length >= rule.maxEvents) {
+        this.history.set(historyKey, filtered);
+        return { kind: 'rejected', reason: 'rate_limit' };
+      }
+
+      filtered.push(now);
+      this.history.set(historyKey, filtered);
+    }
+
+    const doubleXpActive = this.isDoubleXpWeekend(timestamp);
+    const combo = this.getComboMultiplier(historyKey, timestamp.getTime());
+    const totalMultiplier = (doubleXpActive ? 2 : 1) * combo.multiplier;
+    const appliedXp = Math.max(1, Math.round(baseAmount * totalMultiplier));
+
+    const baseState = state ? { ...state } : createDefaultSnapshot(userId, timestamp);
+
+    const levelProgress = this.calculateLevelProgress(baseState.level, baseState.xpToNextLevel, appliedXp);
+    const seasonProgress = this.calculateLevelProgress(
+      baseState.seasonLevel ?? 1,
+      baseState.seasonXpToNextLevel ?? 100,
+      appliedXp,
+    );
+
+    const metadata: Record<string, unknown> = { ...(baseState.metadata ?? {}) };
+    const previousSkillPoints = extractNumber(metadata['skillPoints']);
+    const lastGrants = {
+      source,
+      baseAmount,
+      appliedXp,
+      timestamp: timestamp.toISOString(),
+      doubleXpActive,
+      comboMultiplier: combo.multiplier,
+      comboCount: combo.count,
+      metadata: grant.metadata ?? {},
+    };
+
+    metadata['skillPoints'] = previousSkillPoints + levelProgress.skillPointsEarned;
+    metadata['lastXpGrant'] = lastGrants;
+
+    const stateSnapshot: GamificationStateSnapshot = {
+      ...baseState,
+      totalXp: (baseState.totalXp ?? 0) + appliedXp,
+      level: levelProgress.level,
+      xpToNextLevel: levelProgress.xpToNextLevel,
+      seasonXp: (baseState.seasonXp ?? 0) + appliedXp,
+      seasonLevel: seasonProgress.level,
+      seasonXpToNextLevel: seasonProgress.xpToNextLevel,
+      unclaimedPoints: (baseState.unclaimedPoints ?? 0) + levelProgress.skillPointsEarned,
+      metadata: this.cleanMetadata(metadata),
+      lastUpdatedAt: timestamp.toISOString(),
+    };
+
+    const patch: GamificationStatePatch = {
+      userId,
+      totalXp: stateSnapshot.totalXp,
+      level: stateSnapshot.level,
+      xpToNextLevel: stateSnapshot.xpToNextLevel,
+      seasonXp: stateSnapshot.seasonXp,
+      seasonLevel: stateSnapshot.seasonLevel,
+      seasonXpToNextLevel: stateSnapshot.seasonXpToNextLevel,
+      unclaimedPoints: stateSnapshot.unclaimedPoints,
+      metadata: stateSnapshot.metadata,
+    };
+
+    return {
+      kind: 'applied',
+      baseAmount,
+      appliedXp,
+      doubleXpActive,
+      comboMultiplier: combo.multiplier,
+      comboCount: combo.count,
+      totalMultiplier,
+      skillPointsEarned: levelProgress.skillPointsEarned,
+      patch,
+      state: stateSnapshot,
+      metadata: stateSnapshot.metadata,
+    };
+  }
+
+  private calculateLevelProgress(initialLevel: number | undefined, xpToNextLevel: number | undefined, appliedXp: number) {
+    let level = initialLevel && initialLevel > 0 ? initialLevel : 1;
+    let xpRequired = xpToNextLevel && xpToNextLevel > 0 ? xpToNextLevel : calculateXpThreshold(level);
+    let remaining = appliedXp;
+    let skillPointsEarned = 0;
+
+    while (remaining >= xpRequired) {
+      remaining -= xpRequired;
+      level += 1;
+      skillPointsEarned += 1;
+      xpRequired = calculateXpThreshold(level);
+    }
+
+    const xpToNext = Math.max(10, xpRequired - remaining);
+
+    return {
+      level,
+      xpToNextLevel: xpToNext,
+      skillPointsEarned,
+    };
+  }
+
+  private getComboMultiplier(key: string, timestamp: number) {
+    const existing = this.comboState.get(key);
+    if (!existing || timestamp - existing.lastTimestamp > COMBO_WINDOW_MS) {
+      this.comboState.set(key, { count: 1, lastTimestamp: timestamp });
+      return { multiplier: 1, count: 1 };
+    }
+
+    const nextCount = Math.min(existing.count + 1, MAX_COMBO_COUNT);
+    const multiplier = 1 + (nextCount - 1) * COMBO_STEP;
+    this.comboState.set(key, { count: nextCount, lastTimestamp: timestamp });
+    return { multiplier, count: nextCount };
+  }
+
+  private isDoubleXpWeekend(date: Date): boolean {
+    const day = date.getDay();
+    return day === 0 || day === 6;
+  }
+
+  private cleanMetadata(metadata: Record<string, unknown>): Record<string, unknown> | undefined {
+    const entries = Object.entries(metadata).filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+}
+
+export default XpEngine;


### PR DESCRIPTION
## Summary
- add an XP engine that handles double XP weekends, combo multipliers, skill points and anti-cheat rules
- extend the gamification service with an `addXp` flow and brew-log specific handler that persists updates
- trigger the XP grant from the brew log form once a log is saved so the new source is exercised

## Testing
- `npm test -- --runTestsByPath __tests__/App.test.tsx` *(fails: jest not found; `npm install` blocked by 403 when fetching @invertase/react-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb101b250832abcbafae801441bde