### PR TITLE
feat: add comprehensive gamification system

### DIFF
--- a/assets/sounds/README.md
+++ b/assets/sounds/README.md
@@ -1,0 +1,9 @@
+# Zvukové efekty
+
+Tieto súbory slúžia ako zástupné miesto pre zvukové efekty gamifikačného systému.
+
+- `level-up.mp3` – efekt pri zvýšení levelu
+- `xp-gain.mp3` – jemný efekt pri získaní XP
+- `quest-complete.mp3` – triumfálny efekt po splnení questov
+
+Nahraďte tieto placeholdery reálnymi zvukmi pri integrácii do produkcie.

--- a/db/create_gamification_system.sql
+++ b/db/create_gamification_system.sql
@@ -1,0 +1,129 @@
+-- Gamifikačný systém - tabuľky a triggery
+-- Komentáre v slovenčine podľa požiadavky
+
+create table if not exists public.user_levels (
+    user_id uuid primary key references auth.users(id) on delete cascade,
+    current_level integer not null default 1 check (current_level between 1 and 50),
+    current_xp integer not null default 0 check (current_xp >= 0),
+    skill_points integer not null default 0 check (skill_points >= 0),
+    skill_tree jsonb not null default '{}'::jsonb,
+    combo_multiplier numeric(5,2) not null default 1.0,
+    double_xp_until timestamptz,
+    streak_days integer not null default 0,
+    login_streak integer not null default 0,
+    brew_streak integer not null default 0,
+    perfect_week boolean not null default false,
+    freeze_tokens integer not null default 1,
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists public.achievements (
+    id uuid primary key default gen_random_uuid(),
+    code text not null unique,
+    name text not null,
+    description text not null,
+    category text not null check (category in ('beginner','skills','exploration','social','hidden','seasonal')),
+    rarity text not null check (rarity in ('common','rare','epic','legendary')),
+    thresholds integer[] not null default '{1}',
+    special_reward jsonb,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists public.user_achievements (
+    user_id uuid references auth.users(id) on delete cascade,
+    achievement_id uuid references public.achievements(id) on delete cascade,
+    progress integer not null default 0,
+    unlocked_at timestamptz,
+    featured boolean not null default false,
+    primary key (user_id, achievement_id)
+);
+
+create table if not exists public.daily_quests (
+    id uuid primary key default gen_random_uuid(),
+    template_id text,
+    title text not null,
+    description text not null,
+    difficulty text not null check (difficulty in ('easy','medium','hard','special')),
+    reward_xp integer not null,
+    reward_skill_points integer not null default 0,
+    requirements jsonb not null,
+    active_from timestamptz not null,
+    active_to timestamptz not null,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists public.user_daily_progress (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid references auth.users(id) on delete cascade,
+    daily_quest_id uuid references public.daily_quests(id) on delete cascade,
+    progress jsonb not null default '{}'::jsonb,
+    completed boolean not null default false,
+    claimed boolean not null default false,
+    updated_at timestamptz not null default now(),
+    unique (user_id, daily_quest_id)
+);
+
+create table if not exists public.seasonal_events (
+    id uuid primary key default gen_random_uuid(),
+    title text not null,
+    theme text not null,
+    starts_at timestamptz not null,
+    ends_at timestamptz not null,
+    bonus_multiplier numeric(4,2) not null default 1.0,
+    featured_methods text[] not null default '{}',
+    created_at timestamptz not null default now()
+);
+
+create table if not exists public.analytics_events (
+    id bigserial primary key,
+    name text not null,
+    timestamp timestamptz not null,
+    properties jsonb,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_levels_level on public.user_levels (current_level);
+create index if not exists idx_user_achievements_user on public.user_achievements (user_id);
+create index if not exists idx_daily_quests_window on public.daily_quests (active_from, active_to);
+create index if not exists idx_user_daily_progress_user on public.user_daily_progress (user_id);
+
+-- Trigger pre automatické aktualizácie timestampov
+create or replace function public.touch_user_level()
+returns trigger as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_touch_user_level
+  before update on public.user_levels
+  for each row execute function public.touch_user_level();
+
+-- Trigger pre výpočet kombo násobiteľa podľa streaku
+create or replace function public.recalculate_combo_multiplier()
+returns trigger as $$
+begin
+  if new.streak_days is distinct from old.streak_days then
+    new.combo_multiplier := least(3.0, 1.0 + (greatest(new.streak_days, 0) / 10.0));
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_recalculate_combo_multiplier
+  before update on public.user_levels
+  for each row execute function public.recalculate_combo_multiplier();
+
+-- Pomocná view pre leaderboards
+create or replace view public.gamification_leaderboard as
+select
+  ul.user_id,
+  ul.current_level,
+  ul.current_xp,
+  ul.skill_points,
+  ul.streak_days,
+  sum(case when ua.unlocked_at is not null then 1 else 0 end) as unlocked_achievements
+from public.user_levels ul
+left join public.user_achievements ua on ua.user_id = ul.user_id
+group by ul.user_id, ul.current_level, ul.current_xp, ul.skill_points, ul.streak_days;

--- a/src/components/gamification/AchievementShowcase.tsx
+++ b/src/components/gamification/AchievementShowcase.tsx
@@ -1,0 +1,132 @@
+/*
+ * Prezentácia odznakov s pseudo 3D efektom a žiarením podľa rarity.
+ */
+import React, {useEffect, useMemo} from 'react';
+import {Share, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import Animated, {useAnimatedStyle, useSharedValue, withRepeat, withTiming} from 'react-native-reanimated';
+import type {AchievementDefinition} from '../../types/gamification';
+
+interface Props {
+  achievement: AchievementDefinition;
+  onFeature?: (achievementId: string) => void;
+}
+
+const rarityColors = {
+  common: ['#94a3b8', '#cbd5f5'],
+  rare: ['#38bdf8', '#818cf8'],
+  epic: ['#a855f7', '#f472b6'],
+  legendary: ['#f59e0b', '#f97316'],
+};
+
+const AchievementShowcase: React.FC<Props> = ({achievement, onFeature}) => {
+  const glow = useSharedValue(0);
+
+  useEffect(() => {
+    glow.value = withRepeat(withTiming(1, {duration: 2000}), -1, true);
+  }, [glow]);
+
+  const glowStyle = useAnimatedStyle(() => ({
+    opacity: 0.6 + glow.value * 0.4,
+    transform: [{scale: 1 + glow.value * 0.05}],
+  }));
+
+  const gradient = useMemo(() => rarityColors[achievement.rarity], [achievement.rarity]);
+
+  const handleShare = () => {
+    void Share.share({
+      title: 'BrewMate Achievement',
+      message: `Práve som získal odznak ${achievement.name} v BrewMate! Pridaj sa ku mne.`,
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Animated.View style={[styles.glow, glowStyle]} />
+      <LinearGradient colors={gradient} style={styles.badge}>
+        <View style={styles.badgeFace}>
+          <Text style={styles.badgeTitle}>{achievement.name}</Text>
+          <Text style={styles.badgeDescription}>{achievement.description}</Text>
+          <Text style={styles.badgeCategory}>{achievement.category.toUpperCase()}</Text>
+        </View>
+      </LinearGradient>
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.button} onPress={() => onFeature?.(achievement.id)}>
+          <Text style={styles.buttonText}>🌟 Zvýrazniť</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={handleShare}>
+          <Text style={styles.buttonText}>📤 Zdieľať</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginVertical: 24,
+  },
+  glow: {
+    position: 'absolute',
+    width: 220,
+    height: 220,
+    borderRadius: 110,
+    backgroundColor: '#fde68a',
+    opacity: 0.5,
+  },
+  badge: {
+    width: 200,
+    height: 200,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    transform: [{rotateX: '12deg'}, {rotateY: '-8deg'}],
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 10},
+    shadowOpacity: 0.4,
+    shadowRadius: 20,
+    elevation: 16,
+  },
+  badgeFace: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  badgeTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#fff',
+    textAlign: 'center',
+  },
+  badgeDescription: {
+    fontSize: 12,
+    color: '#f1f5f9',
+    textAlign: 'center',
+    marginVertical: 8,
+  },
+  badgeCategory: {
+    fontSize: 10,
+    color: '#1f2937',
+    backgroundColor: '#fff',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  actions: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  button: {
+    backgroundColor: '#1f2937',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    marginHorizontal: 6,
+  },
+  buttonText: {
+    color: '#f8fafc',
+    fontWeight: '600',
+  },
+});
+
+export default AchievementShowcase;

--- a/src/components/gamification/DailyQuestCard.tsx
+++ b/src/components/gamification/DailyQuestCard.tsx
@@ -1,0 +1,179 @@
+/*
+ * Denná úloha so swipe interakciou, progres barom a animovaným claim efektom.
+ */
+import React, {useMemo} from 'react';
+import {StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {PanGestureHandler} from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import LinearGradient from 'react-native-linear-gradient';
+import type {DailyQuestInstance, DailyQuestProgress} from '../../types/gamification';
+
+interface Props {
+  quest: DailyQuestInstance;
+  progress?: DailyQuestProgress;
+  onClaim?: (questId: string) => void;
+}
+
+const DailyQuestCard: React.FC<Props> = ({quest, progress, onClaim}) => {
+  const translateX = useSharedValue(0);
+  const claimed = progress?.claimed ?? false;
+  const completed = progress?.completed ?? false;
+  const progressRatio = useMemo(() => {
+    if (!progress) {
+      return 0;
+    }
+    const values = Object.values(progress.progress);
+    if (values.length === 0) {
+      return completed ? 1 : 0;
+    }
+    const sum = values.reduce((total, value) => total + value, 0);
+    return Math.min(1, sum / values.length);
+  }, [progress, completed]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{translateX: translateX.value}],
+  }));
+
+  const gestureHandler = useAnimatedGestureHandler({
+    onActive: (event) => {
+      translateX.value = Math.max(0, event.translationX);
+    },
+    onEnd: () => {
+      if (translateX.value > 120 && completed && !claimed) {
+        translateX.value = withTiming(200, {duration: 200}, () => {
+          runOnJS(onClaim ?? (() => {}))(quest.id);
+        });
+      } else {
+        translateX.value = withTiming(0);
+      }
+    },
+  });
+
+  return (
+    <View style={styles.container}>
+      <PanGestureHandler onGestureEvent={gestureHandler}>
+        <Animated.View style={[styles.card, animatedStyle]}>
+          <LinearGradient colors={['#0f172a', '#1e1b4b']} style={styles.gradient}>
+            <View style={styles.header}>
+              <Text style={styles.title}>{quest.title}</Text>
+              <Text style={styles.difficulty}>{quest.difficulty.toUpperCase()}</Text>
+            </View>
+            <Text style={styles.description}>{quest.description}</Text>
+            <View style={styles.progressWrapper}>
+              <View style={styles.progressBar}>
+                <View style={[styles.progressFill, {width: `${progressRatio * 100}%`}]} />
+              </View>
+              <Text style={styles.progressText}>{Math.round(progressRatio * 100)}%</Text>
+            </View>
+            <View style={styles.footer}>
+              <Text style={styles.reward}>🎁 {quest.rewardXp} XP</Text>
+              {quest.rewardSkillPoints > 0 && <Text style={styles.reward}>⚙️ {quest.rewardSkillPoints} SP</Text>}
+            </View>
+            {completed && !claimed && <Text style={styles.swipeHint}>⬅️ Potiahni pre odmenu</Text>}
+            {claimed && <Text style={styles.claimed}>Odmena vyzdvihnutá!</Text>}
+            <TouchableOpacity style={styles.claimButton} disabled={!completed || claimed} onPress={() => onClaim?.(quest.id)}>
+              <Text style={styles.claimText}>{claimed ? 'Hotovo' : completed ? 'Získať odmenu' : 'Plním...'}</Text>
+            </TouchableOpacity>
+          </LinearGradient>
+        </Animated.View>
+      </PanGestureHandler>
+      <Text style={styles.timer}>⏱️ Koniec: {new Date(quest.activeTo).toLocaleTimeString()}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginVertical: 12,
+  },
+  card: {
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  gradient: {
+    padding: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  title: {
+    color: '#e0f2fe',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  difficulty: {
+    color: '#f97316',
+    fontWeight: '600',
+  },
+  description: {
+    color: '#cbd5f5',
+    fontSize: 14,
+  },
+  progressWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  progressBar: {
+    flex: 1,
+    height: 10,
+    backgroundColor: '#312e81',
+    borderRadius: 5,
+    overflow: 'hidden',
+    marginRight: 12,
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: '#fbbf24',
+  },
+  progressText: {
+    color: '#fef9c3',
+    fontWeight: '600',
+  },
+  footer: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  reward: {
+    color: '#f1f5f9',
+    fontWeight: '600',
+    marginRight: 16,
+  },
+  swipeHint: {
+    marginTop: 16,
+    color: '#a855f7',
+    fontStyle: 'italic',
+  },
+  claimed: {
+    marginTop: 16,
+    color: '#22c55e',
+    fontWeight: '700',
+  },
+  claimButton: {
+    marginTop: 16,
+    backgroundColor: '#2563eb',
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  claimText: {
+    color: '#f8fafc',
+    fontWeight: '700',
+  },
+  timer: {
+    marginTop: 8,
+    color: '#cbd5f5',
+    textAlign: 'right',
+  },
+});
+
+export default DailyQuestCard;

--- a/src/components/gamification/LevelProgressBar.tsx
+++ b/src/components/gamification/LevelProgressBar.tsx
@@ -1,0 +1,172 @@
+/*
+ * Animovaná kruhová lišta progresu s efektmi pre level-up.
+ */
+import React, {useEffect} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import Svg, {Circle, Defs, LinearGradient, Stop} from 'react-native-svg';
+import Animated, {
+  Easing,
+  useAnimatedProps,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
+interface Props {
+  progress: number;
+  level: number;
+  title: string;
+  xp: number;
+  xpToNext: number;
+  recentGain?: number;
+  leveledUp?: boolean;
+}
+
+const SIZE = 220;
+const STROKE = 16;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+const LevelProgressBar: React.FC<Props> = ({progress, level, title, xp, xpToNext, recentGain = 0, leveledUp}) => {
+  const animatedProgress = useSharedValue(progress);
+  const pulse = useSharedValue(0);
+  const floating = useSharedValue(0);
+
+  useEffect(() => {
+    animatedProgress.value = withTiming(progress, {duration: 800, easing: Easing.out(Easing.cubic)});
+  }, [progress, animatedProgress]);
+
+  useEffect(() => {
+    if (leveledUp) {
+      pulse.value = withSequence(withSpring(1, {damping: 8}), withTiming(0, {duration: 600}));
+    }
+  }, [leveledUp, pulse]);
+
+  useEffect(() => {
+    floating.value = withSequence(withTiming(1, {duration: 600}), withDelay(400, withTiming(0, {duration: 400})));
+  }, [recentGain, floating]);
+
+  const animatedProps = useAnimatedProps(() => ({
+    strokeDashoffset: CIRCUMFERENCE * (1 - animatedProgress.value),
+  }));
+
+  const pulseStyle = useAnimatedProps(() => ({
+    opacity: pulse.value,
+    strokeWidth: STROKE + pulse.value * 6,
+  }));
+
+  const floatingStyle = useAnimatedStyle(() => ({
+    opacity: floating.value,
+    transform: [{translateY: -40 * floating.value}],
+  }));
+
+  return (
+    <View style={styles.container}>
+      <Svg width={SIZE} height={SIZE}>
+        <Defs>
+          <LinearGradient id="progress" x1="0%" y1="0%" x2="100%" y2="100%">
+            <Stop offset="0%" stopColor="#fbbf24" />
+            <Stop offset="100%" stopColor="#ec4899" />
+          </LinearGradient>
+        </Defs>
+        <Circle cx={SIZE / 2} cy={SIZE / 2} r={RADIUS} stroke="#1f2937" strokeWidth={STROKE} fill="none" />
+        <AnimatedCircle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          stroke="url(#progress)"
+          strokeWidth={STROKE}
+          strokeDasharray={`${CIRCUMFERENCE}`}
+          animatedProps={animatedProps}
+          strokeLinecap="round"
+        />
+        <AnimatedCircle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS + 4}
+          stroke="#f472b6"
+          fill="none"
+          strokeDasharray={`${CIRCUMFERENCE}`}
+          animatedProps={pulseStyle}
+        />
+      </Svg>
+      <View style={styles.content}>
+        <Text style={styles.levelLabel}>Level {level}</Text>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.xp}>XP {xp}/{xpToNext}</Text>
+      </View>
+      {recentGain > 0 && <AnimatedText style={[styles.gain, floatingStyle]}>+{recentGain} XP</AnimatedText>}
+      <Animated.View style={styles.particles}>
+        {[...Array(12)].map((_, index) => (
+          <Animated.View
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            style={[
+              styles.particle,
+              {
+                transform: [
+                  {translateX: Math.cos((index / 12) * 2 * Math.PI) * (RADIUS + 10)},
+                  {translateY: Math.sin((index / 12) * 2 * Math.PI) * (RADIUS + 10)},
+                ],
+              },
+            ]}
+          />
+        ))}
+      </Animated.View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 24,
+  },
+  content: {
+    position: 'absolute',
+    alignItems: 'center',
+  },
+  levelLabel: {
+    color: '#f9fafb',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  title: {
+    color: '#c4b5fd',
+    fontSize: 14,
+    marginTop: 4,
+  },
+  xp: {
+    color: '#fde68a',
+    fontSize: 12,
+    marginTop: 8,
+  },
+  gain: {
+    position: 'absolute',
+    top: -10,
+    fontSize: 18,
+    color: '#fbbf24',
+    fontWeight: '700',
+  },
+  particles: {
+    position: 'absolute',
+    width: SIZE,
+    height: SIZE,
+  },
+  particle: {
+    position: 'absolute',
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#f472b6',
+  },
+});
+
+export default LevelProgressBar;

--- a/src/components/gamification/StatsRadarChart.tsx
+++ b/src/components/gamification/StatsRadarChart.tsx
@@ -1,0 +1,95 @@
+/*
+ * Radarový graf so štyrmi osami a animovaným porovnaním priemeru.
+ */
+import React, {useMemo} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import Svg, {G, Line, Polygon, Text as SvgText} from 'react-native-svg';
+import Animated, {useAnimatedProps, useSharedValue, withTiming} from 'react-native-reanimated';
+import type {RadarStats} from '../../types/gamification';
+
+interface Props {
+  stats: RadarStats;
+}
+
+const AnimatedPolygon = Animated.createAnimatedComponent(Polygon);
+const AnimatedLine = Animated.createAnimatedComponent(Line);
+
+const AXES = ['brewing', 'exploration', 'social', 'knowledge'] as const;
+
+const StatsRadarChart: React.FC<Props> = ({stats}) => {
+  const progress = useSharedValue(0);
+  progress.value = withTiming(1, {duration: 600});
+
+  const points = useMemo(() => calculatePoints(stats), [stats]);
+  const averagePoints = useMemo(() => calculatePoints({
+    brewing: stats.averageComparison ?? 0.5,
+    exploration: stats.averageComparison ?? 0.5,
+    social: stats.averageComparison ?? 0.5,
+    knowledge: stats.averageComparison ?? 0.5,
+  }), [stats.averageComparison]);
+
+  const animatedProps = useAnimatedProps(() => ({
+    points: points
+      .map((point) => `${point.x * progress.value},${point.y * progress.value}`)
+      .join(' '),
+  }));
+
+  const averageProps = useAnimatedProps(() => ({
+    points: averagePoints
+      .map((point) => `${point.x * progress.value},${point.y * progress.value}`)
+      .join(' '),
+  }));
+
+  return (
+    <View style={styles.container}>
+      <Svg width={240} height={240} viewBox="-120 -120 240 240">
+        <G>
+          {Array.from({length: 4}, (_, index) => (
+            <AnimatedLine
+              key={index}
+              x1={0}
+              y1={0}
+              x2={points[index].x}
+              y2={points[index].y}
+              stroke="#334155"
+              strokeWidth={1}
+            />
+          ))}
+          <AnimatedPolygon animatedProps={averageProps} fill="rgba(96,165,250,0.2)" stroke="#60a5fa" strokeWidth={1} />
+          <AnimatedPolygon animatedProps={animatedProps} fill="rgba(248,113,113,0.25)" stroke="#f87171" strokeWidth={2} />
+          {AXES.map((axis, index) => (
+            <SvgText key={axis} x={points[index].x * 1.1} y={points[index].y * 1.1} fill="#e2e8f0" fontSize={10} textAnchor="middle">
+              {axis.toUpperCase()}
+            </SvgText>
+          ))}
+        </G>
+      </Svg>
+      <Text style={styles.caption}>Porovnanie s komunitným priemerom</Text>
+    </View>
+  );
+};
+
+function calculatePoints(stats: RadarStats) {
+  const radius = 90;
+  return AXES.map((axis, index) => {
+    const value = Math.max(0, Math.min(1, stats[axis] ?? 0));
+    const angle = (Math.PI / 2) + (index * (2 * Math.PI)) / AXES.length;
+    return {
+      x: Math.cos(angle) * radius * value,
+      y: Math.sin(angle) * radius * value * -1,
+    };
+  });
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginVertical: 24,
+  },
+  caption: {
+    color: '#cbd5f5',
+    marginTop: 8,
+  },
+});
+
+export default StatsRadarChart;

--- a/src/config/supabaseClient.ts
+++ b/src/config/supabaseClient.ts
@@ -1,0 +1,20 @@
+/*
+ * Inicializácia Supabase klienta.
+ */
+import {createClient, SupabaseClient} from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'https://example.supabase.co';
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? 'public-anon-key';
+
+let client: SupabaseClient | undefined;
+
+export function getSupabaseClient() {
+  if (!client) {
+    client = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        persistSession: false,
+      },
+    });
+  }
+  return client;
+}

--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -1,0 +1,27 @@
+/*
+ * Pomocný hook pre prácu s gamifikačným úložiskom.
+ */
+import {useCallback} from 'react';
+import gamificationStore from '../store/gamificationStore';
+import GamificationEngine from '../services/gamification/GamificationEngine';
+import type {DailyQuestProgress, XpEvent} from '../types/gamification';
+
+export default function useGamification() {
+  const state = gamificationStore();
+
+  const handleXp = useCallback((event: XpEvent) => GamificationEngine.handleXpEvent(event), []);
+  const updateQuest = useCallback(
+    (progress: DailyQuestProgress & {userId: string}) => GamificationEngine.updateQuestProgress(progress),
+    []
+  );
+  const refreshQuests = useCallback(() => GamificationEngine.refreshDailyQuests(), []);
+  const useFreeze = useCallback(() => GamificationEngine.useFreeze(), []);
+
+  return {
+    state,
+    handleXp,
+    updateQuest,
+    refreshQuests,
+    useFreeze,
+  };
+}

--- a/src/screens/gamification/LeaderboardScreen.tsx
+++ b/src/screens/gamification/LeaderboardScreen.tsx
@@ -1,0 +1,144 @@
+/*
+ * Prehľad rebríčkov s animáciami a možnosťou prepínania rozsahu.
+ */
+import React, {useEffect, useState} from 'react';
+import {FlatList, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import Animated, {Layout, SlideInRight} from 'react-native-reanimated';
+import gamificationStore from '../../store/gamificationStore';
+import GamificationRepository from '../../services/gamification/GamificationRepository';
+import type {LeaderboardEntry} from '../../types/gamification';
+
+const repository = new GamificationRepository();
+
+type Scope = 'global' | 'friends' | 'local';
+
+const LeaderboardScreen: React.FC = () => {
+  const {leaderboard, userId} = gamificationStore((state) => ({
+    leaderboard: state.leaderboard,
+    userId: state.userId,
+  }));
+  const [scope, setScope] = useState<Scope>('global');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    repository
+      .fetchLeaderboard(scope)
+      .then((entries) => gamificationStore.setState({leaderboard: entries}))
+      .finally(() => setLoading(false));
+  }, [scope]);
+
+  const renderItem = ({item, index}: {item: LeaderboardEntry; index: number}) => (
+    <Animated.View entering={SlideInRight} layout={Layout.springify()} style={[styles.row, item.userId === userId && styles.highlight]}> 
+      <Text style={styles.rank}>{index + 1}</Text>
+      <View style={styles.info}>
+        <Text style={styles.name}>{item.displayName}</Text>
+        <Text style={styles.meta}>
+          Level {item.level} · {item.totalXp} XP · {item.streakDays} dní streak
+        </Text>
+      </View>
+      <Text style={styles.badges}>🏅 {item.achievementsUnlocked}</Text>
+    </Animated.View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.tabs}>
+        {(['global', 'friends', 'local'] as Scope[]).map((item) => (
+          <TouchableOpacity
+            key={item}
+            style={[styles.tab, scope === item && styles.tabActive]}
+            onPress={() => setScope(item)}
+          >
+            <Text style={[styles.tabText, scope === item && styles.tabTextActive]}>{item.toUpperCase()}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {loading ? (
+        <Text style={styles.loading}>Načítavam...</Text>
+      ) : (
+        <FlatList
+          data={leaderboard}
+          keyExtractor={(item) => item.userId}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#0f172a',
+  },
+  tabs: {
+    flexDirection: 'row',
+    marginBottom: 16,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#1e293b',
+    marginHorizontal: 4,
+  },
+  tabActive: {
+    backgroundColor: '#2563eb',
+  },
+  tabText: {
+    textAlign: 'center',
+    color: '#94a3b8',
+    fontWeight: '600',
+  },
+  tabTextActive: {
+    color: '#f8fafc',
+  },
+  list: {
+    paddingBottom: 80,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#1e1b4b',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 12,
+  },
+  highlight: {
+    borderWidth: 2,
+    borderColor: '#fbbf24',
+  },
+  rank: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#fef08a',
+    width: 40,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    color: '#f8fafc',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  meta: {
+    color: '#cbd5f5',
+    fontSize: 12,
+    marginTop: 4,
+  },
+  badges: {
+    color: '#fbbf24',
+    fontWeight: '700',
+  },
+  loading: {
+    color: '#f8fafc',
+    textAlign: 'center',
+    marginTop: 40,
+  },
+});
+
+export default LeaderboardScreen;

--- a/src/services/gamification/AchievementManager.ts
+++ b/src/services/gamification/AchievementManager.ts
@@ -1,0 +1,131 @@
+/*
+ * Manažér achievementov - logika pre vyhodnocovanie a odmeny.
+ */
+import gamificationStore from '../../store/gamificationStore';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  AnalyticsEvent,
+  XpEvent,
+} from '../../types/gamification';
+import AnalyticsService from './AnalyticsService';
+
+export default class AchievementManager {
+  constructor(private definitions: AchievementDefinition[]) {}
+
+  /**
+   * Paralelne skontroluje všetky dostupné achievementy.
+   */
+  async evaluate(event: XpEvent) {
+    const checks = this.definitions.map((definition) => this.evaluateAchievement(definition, event));
+    await Promise.all(checks);
+  }
+
+  /**
+   * Aktualizuje progres a zapisuje ho do úložiska.
+   */
+  private async evaluateAchievement(definition: AchievementDefinition, event: XpEvent) {
+    const current = gamificationStore.getState().achievementProgress[definition.id];
+    const progress = await this.resolveProgress(definition, event, current);
+    if (!progress) {
+      return;
+    }
+
+    gamificationStore.registerAchievementProgress(progress);
+
+    if (progress.unlockedAt) {
+      AnalyticsService.track({
+        name: 'achievement_unlocked',
+        timestamp: new Date().toISOString(),
+        properties: {achievement: definition.code, userId: event.userId},
+      } satisfies AnalyticsEvent);
+    }
+  }
+
+  /**
+   * Podľa kategórie vyhodnotí progres.
+   */
+  private async resolveProgress(
+    definition: AchievementDefinition,
+    event: XpEvent,
+    current?: AchievementProgress
+  ): Promise<AchievementProgress | undefined> {
+    const existingProgress = current?.progress ?? 0;
+    let nextProgress = existingProgress;
+
+    switch (definition.code) {
+      case 'first_brew':
+        if (event.source === 'brew') {
+          nextProgress = Math.max(existingProgress, 1);
+        }
+        break;
+      case 'week_streak':
+        if (event.metadata?.streak_days) {
+          nextProgress = Number(event.metadata.streak_days);
+        }
+        break;
+      case 'espresso_master':
+        if (event.source === 'perfect_brew' && event.metadata?.method === 'espresso') {
+          nextProgress = existingProgress + 1;
+        }
+        break;
+      case 'latte_artist':
+        if (event.metadata?.art_score) {
+          nextProgress = Math.max(existingProgress, Number(event.metadata.art_score));
+        }
+        break;
+      case 'bean_explorer':
+        if (event.metadata?.country) {
+          nextProgress = existingProgress + Number(event.metadata.country_new ? 1 : 0);
+        }
+        break;
+      case 'helpful_barista':
+        if (event.source === 'help_others') {
+          nextProgress = existingProgress + 1;
+        }
+        break;
+      case 'night_owl':
+        if (event.metadata?.brew_hour !== undefined && Number(event.metadata.brew_hour) >= 22) {
+          nextProgress = 1;
+        }
+        break;
+      case 'perfectionist':
+        if (event.source === 'perfect_brew') {
+          nextProgress = existingProgress + 1;
+        }
+        break;
+      default:
+        nextProgress = existingProgress + 1;
+    }
+
+    const unlocked = this.checkThreshold(definition.thresholds, nextProgress) && !current?.unlockedAt;
+    const progress: AchievementProgress = {
+      userId: event.userId,
+      achievementId: definition.id,
+      progress: nextProgress,
+      unlockedAt: unlocked ? new Date().toISOString() : current?.unlockedAt,
+      featured: current?.featured ?? false,
+    };
+
+    return progress;
+  }
+
+  /**
+   * Zistí či bol dosiahnutý nejaký míľnik.
+   */
+  private checkThreshold(thresholds: number[], value: number) {
+    return thresholds.some((threshold) => value >= threshold);
+  }
+
+  /**
+   * Nastaví featured odznak.
+   */
+  featureBadge(achievementId: string) {
+    const state = gamificationStore.getState();
+    const progress = state.achievementProgress[achievementId];
+    if (!progress || !progress.unlockedAt) {
+      return;
+    }
+    gamificationStore.registerAchievementProgress({...progress, featured: true});
+  }
+}

--- a/src/services/gamification/AnalyticsService.ts
+++ b/src/services/gamification/AnalyticsService.ts
@@ -1,0 +1,69 @@
+/*
+ * Ľahký analytický modul s možnosťou A/B testovania.
+ */
+import type {AbTestVariant, AnalyticsEvent} from '../../types/gamification';
+import {getSupabaseClient} from '../../config/supabaseClient';
+
+class AnalyticsService {
+  private queue: AnalyticsEvent[] = [];
+
+  private variants = new Map<string, AbTestVariant>();
+
+  private flushing = false;
+
+  constructor() {
+    setInterval(() => {
+      void this.flush();
+    }, 10_000);
+  }
+
+  track(event: AnalyticsEvent) {
+    this.queue.push(event);
+  }
+
+  async flush() {
+    if (this.flushing || this.queue.length === 0) {
+      return;
+    }
+    this.flushing = true;
+    const batch = [...this.queue];
+    this.queue = [];
+
+    try {
+      const client = getSupabaseClient();
+      const {error} = await client.from('analytics_events').insert(batch);
+      if (error) {
+        console.warn('[AnalyticsService] insert failed', error.message);
+        this.queue.unshift(...batch);
+      }
+    } catch (error) {
+      console.warn('[AnalyticsService] flush exception', error);
+      this.queue.unshift(...batch);
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  assignVariant(experiment: string, userId: string): AbTestVariant {
+    const existing = this.variants.get(userId + experiment);
+    if (existing) {
+      return existing;
+    }
+    const variants: AbTestVariant['variant'][] = ['A', 'B', 'C'];
+    const variant = variants[Math.floor(Math.random() * variants.length)];
+    const allocation: AbTestVariant = {
+      experiment,
+      variant,
+      allocatedAt: new Date().toISOString(),
+    };
+    this.variants.set(userId + experiment, allocation);
+    this.track({
+      name: 'ab_assignment',
+      timestamp: allocation.allocatedAt,
+      properties: {experiment, variant, userId},
+    });
+    return allocation;
+  }
+}
+
+export default new AnalyticsService();

--- a/src/services/gamification/DailyQuestGenerator.ts
+++ b/src/services/gamification/DailyQuestGenerator.ts
@@ -1,0 +1,199 @@
+/*
+ * Generátor denných úloh s personalizáciou podľa úrovne.
+ */
+import type {DailyQuestInstance, QuestTemplate} from '../../types/gamification';
+
+const QUEST_TEMPLATES: QuestTemplate[] = [
+  {
+    id: 'morning_brew',
+    title: 'Ranná káva',
+    description: 'Uvar si kávu medzi 5:00 a 11:00 a zdieľ tipy.',
+    difficulty: 'easy',
+    rewardXpRange: [20, 25],
+    rewardSkillPoints: 0,
+    requirements: [
+      {type: 'time_window', value: {start: '05:00', end: '11:00'}, progressKey: 'time_window'},
+      {type: 'streak', value: 1, progressKey: 'brew_count'},
+    ],
+    tags: ['morning', 'routine'],
+  },
+  {
+    id: 'trust_ai',
+    title: 'Dôveruj AI',
+    description: 'Vyskúšaj návrh BrewMate AI na dnešný nápoj.',
+    difficulty: 'easy',
+    rewardXpRange: [20, 25],
+    rewardSkillPoints: 0,
+    requirements: [{type: 'use_ai', value: true, progressKey: 'ai_used'}],
+    tags: ['ai', 'learning'],
+  },
+  {
+    id: 'coffee_photographer',
+    title: 'Fotograf',
+    description: 'Nahraj fotku a poznámky z dnešného experimentu.',
+    difficulty: 'easy',
+    rewardXpRange: [20, 25],
+    rewardSkillPoints: 0,
+    requirements: [
+      {type: 'upload_photo', value: true, progressKey: 'photo_uploaded'},
+      {type: 'auto_complete', value: true, progressKey: 'notes_added'},
+    ],
+    tags: ['social', 'creative'],
+  },
+  {
+    id: 'perfect_extraction',
+    title: 'Perfektná extrakcia',
+    description: 'Dosiahni hodnotenie 4+ hviezdy.',
+    difficulty: 'medium',
+    rewardXpRange: [35, 45],
+    rewardSkillPoints: 0,
+    requirements: [{type: 'rating', value: {min: 4}, progressKey: 'rating'}],
+    tags: ['quality'],
+  },
+  {
+    id: 'experimenter',
+    title: 'Experimentátor',
+    description: 'Vyskúšaj novú receptúru alebo metódu.',
+    difficulty: 'medium',
+    rewardXpRange: [35, 45],
+    rewardSkillPoints: 0,
+    requirements: [{type: 'new_recipe', value: true, progressKey: 'recipes'}],
+    tags: ['exploration'],
+  },
+  {
+    id: 'consistency',
+    title: 'Konzistencia',
+    description: 'Dvakrát za deň priprav rovnakú kávu.',
+    difficulty: 'medium',
+    rewardXpRange: [35, 45],
+    rewardSkillPoints: 0,
+    requirements: [{type: 'repeat_brew', value: 2, progressKey: 'repeats'}],
+    tags: ['discipline'],
+  },
+  {
+    id: 'master_challenge',
+    title: 'Majstrovská výzva',
+    description: 'Použi tri rôzne metódy s hodnotením 4+.',
+    difficulty: 'hard',
+    rewardXpRange: [80, 100],
+    rewardSkillPoints: 1,
+    requirements: [
+      {type: 'multi_method', value: {methods: 3, minRating: 4}, progressKey: 'methods'},
+    ],
+    tags: ['hardcore'],
+  },
+  {
+    id: 'mentor',
+    title: 'Mentor',
+    description: 'Pomôž dvom používateľom komunitnou spätnou väzbou.',
+    difficulty: 'hard',
+    rewardXpRange: [80, 100],
+    rewardSkillPoints: 1,
+    requirements: [{type: 'mentor_help', value: 2, progressKey: 'helped'}],
+    tags: ['social'],
+  },
+  {
+    id: 'weekend_warrior',
+    title: 'Weekend Warrior',
+    description: 'Počas víkendu priprav Chemex, V60 alebo Syphon.',
+    difficulty: 'special',
+    rewardXpRange: [150, 180],
+    rewardSkillPoints: 2,
+    requirements: [
+      {type: 'method_specific', value: ['Chemex', 'V60', 'Syphon'], progressKey: 'method'},
+      {type: 'time_window', value: {days: ['sat', 'sun']}, progressKey: 'weekend'},
+    ],
+    tags: ['weekend', 'event'],
+  },
+  {
+    id: 'monthly_event',
+    title: 'Mesačná výzva',
+    description: 'Splň všetky týždenné ciele v mesiaci.',
+    difficulty: 'special',
+    rewardXpRange: [180, 220],
+    rewardSkillPoints: 3,
+    requirements: [{type: 'streak', value: 30, progressKey: 'month'}],
+    tags: ['season'],
+  },
+];
+
+export default class DailyQuestGenerator {
+  private history = new Map<string, string[]>();
+
+  constructor(private seed = Date.now()) {}
+
+  /**
+   * Vytvorí sadu úloh podľa úrovne a preferencií.
+   */
+  generate(userId: string, level: number, preferences: string[]): DailyQuestInstance[] {
+    const available = this.filterByLevel(level);
+    const rotated = this.rotate(userId, available);
+    const personalized = this.applyPreferences(rotated, preferences);
+    return personalized.slice(0, 3).map((template, index) => this.instantiate(template, userId, index));
+  }
+
+  private filterByLevel(level: number) {
+    return QUEST_TEMPLATES.filter((template) => {
+      switch (template.difficulty) {
+        case 'easy':
+          return level >= 1;
+        case 'medium':
+          return level >= 5;
+        case 'hard':
+          return level >= 10;
+        case 'special':
+          return level >= 15;
+        default:
+          return true;
+      }
+    });
+  }
+
+  private rotate(userId: string, templates: QuestTemplate[]) {
+    const used = this.history.get(userId) ?? [];
+    const filtered = templates.filter((template) => !used.includes(template.id));
+    const result = filtered.length >= 3 ? filtered : templates;
+    this.history.set(userId, result.map((template) => template.id));
+    return result;
+  }
+
+  private applyPreferences(templates: QuestTemplate[], preferences: string[]) {
+    if (preferences.length === 0) {
+      return templates;
+    }
+    const scored = templates.map((template) => {
+      const overlap = template.tags.filter((tag) => preferences.includes(tag)).length;
+      return {template, score: overlap};
+    });
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.template);
+  }
+
+  private instantiate(template: QuestTemplate, userId: string, offset: number): DailyQuestInstance {
+    const rewardXp = this.randomInRange(template.rewardXpRange);
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(23, 59, 59, 999);
+
+    return {
+      id: `${template.id}-${userId}-${start.getTime()}-${offset}`,
+      templateId: template.id,
+      userId,
+      activeFrom: start.toISOString(),
+      activeTo: end.toISOString(),
+      rewardXp,
+      rewardSkillPoints: template.rewardSkillPoints,
+      requirements: template.requirements,
+    };
+  }
+
+  private randomInRange([min, max]: [number, number]) {
+    const random = Math.sin(this.seed++) * 10000;
+    const normalized = random - Math.floor(random);
+    return Math.round(min + normalized * (max - min));
+  }
+}
+
+export {QUEST_TEMPLATES};

--- a/src/services/gamification/GamificationEngine.ts
+++ b/src/services/gamification/GamificationEngine.ts
@@ -1,0 +1,162 @@
+/*
+ * Orchestrácia všetkých gamifikačných súčastí.
+ */
+import gamificationStore from '../../store/gamificationStore';
+import type {
+  DailyQuestProgress,
+  GamificationStateSnapshot,
+  XpEvent,
+} from '../../types/gamification';
+import AchievementManager from './AchievementManager';
+import DailyQuestGenerator from './DailyQuestGenerator';
+import GamificationRepository from './GamificationRepository';
+import QuestNotificationService from './QuestNotificationService';
+import XpSystem from './XpSystem';
+import HapticsService from './HapticsService';
+import SoundEffectService from './SoundEffectService';
+import AnalyticsService from './AnalyticsService';
+
+class GamificationEngine {
+  private xpSystem = new XpSystem();
+
+  private repository = new GamificationRepository();
+
+  private questGenerator = new DailyQuestGenerator();
+
+  private achievementManager?: AchievementManager;
+
+  useFreeze() {
+    const state = gamificationStore.getState();
+    if (state.freezeTokens <= 0) {
+      return false;
+    }
+    gamificationStore.updateStreaks({freezeUsed: true});
+    return true;
+  }
+
+  async initialize(userId: string, preferences: string[] = []) {
+    const [stateSnapshot, achievementDefinitions, seasonalEvent] = await Promise.all([
+      this.repository.fetchUserState(userId),
+      this.repository.fetchAchievements(),
+      this.repository.fetchSeasonalEvent(),
+    ]);
+
+    gamificationStore.init({
+      userId,
+      level: stateSnapshot?.level ?? 1,
+      xp: stateSnapshot?.xp ?? 0,
+      xpToNextLevel: stateSnapshot?.xpToNextLevel ?? this.xpSystem.getRequiredXp(1),
+      skillPoints: stateSnapshot?.skillPoints ?? 0,
+      streakDays: stateSnapshot?.streakDays ?? 0,
+      loginStreak: stateSnapshot?.loginStreak ?? 0,
+      brewStreak: stateSnapshot?.brewStreak ?? 0,
+      perfectWeek: stateSnapshot?.perfectWeek ?? false,
+      freezeTokens: stateSnapshot?.freezeTokens ?? 1,
+      comboMultiplier: stateSnapshot?.comboMultiplier ?? this.xpSystem.getComboMultiplier(0),
+      doubleXpUntil: stateSnapshot?.doubleXpActive ? new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString() : undefined,
+    });
+
+    if (this.xpSystem.isDoubleXpWeekend() && !stateSnapshot?.doubleXpActive) {
+      const weekendEnd = new Date();
+      weekendEnd.setUTCHours(23, 59, 59, 999);
+      gamificationStore.setState({doubleXpUntil: weekendEnd.toISOString()});
+    }
+
+    gamificationStore.setAchievements(achievementDefinitions);
+    gamificationStore.setSeasonalEvent(seasonalEvent);
+
+    this.achievementManager = new AchievementManager(achievementDefinitions);
+
+    const quests = this.questGenerator.generate(userId, gamificationStore.getState().level, preferences);
+    gamificationStore.setDailyQuests(quests);
+    QuestNotificationService.scheduleQuestReminders(quests);
+
+    AnalyticsService.assignVariant('gamification_onboarding', userId);
+    SoundEffectService.preload('level_up', 'assets/sounds/level-up.mp3');
+    SoundEffectService.preload('xp_gain', 'assets/sounds/xp-gain.mp3');
+    SoundEffectService.preload('quest_complete', 'assets/sounds/quest-complete.mp3');
+  }
+
+  async handleXpEvent(event: XpEvent) {
+    const state = gamificationStore.getState();
+    if (!state.initialized) {
+      throw new Error('Gamification engine not initialized');
+    }
+
+    const xpGain = this.xpSystem.calculateXpGain(event, {
+      comboMultiplier: state.comboMultiplier,
+      streakDays: state.streakDays,
+      doubleXpActive: state.doubleXpUntil ? new Date(state.doubleXpUntil).getTime() > Date.now() : this.xpSystem.isDoubleXpWeekend(),
+    });
+
+    const outcome = this.xpSystem.processXp(state.level, state.xp, xpGain);
+
+    gamificationStore.registerXp({...event, baseAmount: xpGain});
+    const metadata = (event.metadata ?? {}) as Record<string, unknown>;
+    if (event.source === 'brew' || event.source === 'perfect_brew') {
+      gamificationStore.updateStreaks({brew: true});
+    }
+    if (typeof metadata.login === 'boolean' && metadata.login) {
+      gamificationStore.updateStreaks({login: true});
+    }
+    if (typeof metadata.perfect_week === 'boolean' && metadata.perfect_week) {
+      gamificationStore.updateStreaks({perfectWeek: true});
+    }
+    const updated = gamificationStore.getState();
+
+    if (outcome.leveledUp) {
+      HapticsService.triggerImpact('heavy');
+      SoundEffectService.play('level_up');
+    } else {
+      HapticsService.triggerImpact('light');
+      SoundEffectService.play('xp_gain');
+    }
+
+    const snapshot: GamificationStateSnapshot = {
+      userId: event.userId,
+      level: outcome.level,
+      xp: outcome.xp,
+      xpToNextLevel: outcome.xpToNext,
+      streakDays: updated.streakDays,
+      loginStreak: updated.loginStreak,
+      brewStreak: updated.brewStreak,
+      perfectWeek: updated.perfectWeek,
+      freezeTokens: updated.freezeTokens,
+      comboMultiplier: updated.comboMultiplier,
+      doubleXpActive: updated.doubleXpUntil ? new Date(updated.doubleXpUntil).getTime() > Date.now() : false,
+      skillPoints: updated.skillPoints,
+      title: outcome.title,
+    };
+    await this.repository.upsertUserState(snapshot);
+
+    if (this.achievementManager) {
+      await this.achievementManager.evaluate(event);
+    }
+  }
+
+  async updateQuestProgress(progress: DailyQuestProgress & {userId: string}) {
+    gamificationStore.registerQuestProgress(progress);
+    await this.repository.syncQuestProgress(progress);
+    if (progress.completed && !progress.claimed) {
+      HapticsService.triggerImpact('medium');
+      SoundEffectService.play('quest_complete');
+      AnalyticsService.track({
+        name: 'quest_completed',
+        timestamp: new Date().toISOString(),
+        properties: {questId: progress.questId, userId: progress.userId},
+      });
+    }
+  }
+
+  async refreshDailyQuests(preferences: string[] = []) {
+    const state = gamificationStore.getState();
+    if (!state.userId) {
+      return;
+    }
+    const quests = this.questGenerator.generate(state.userId, state.level, preferences);
+    gamificationStore.setDailyQuests(quests);
+    QuestNotificationService.scheduleQuestReminders(quests);
+  }
+}
+
+export default new GamificationEngine();

--- a/src/services/gamification/GamificationRepository.ts
+++ b/src/services/gamification/GamificationRepository.ts
@@ -1,0 +1,173 @@
+/*
+ * Vrstvu komunikácie so Supabase držíme na jednom mieste.
+ */
+import {PostgrestError} from '@supabase/supabase-js';
+import {getSupabaseClient} from '../../config/supabaseClient';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  DailyQuestInstance,
+  DailyQuestProgress,
+  GamificationStateSnapshot,
+  LeaderboardEntry,
+  SeasonalEvent,
+} from '../../types/gamification';
+
+export default class GamificationRepository {
+  private client = getSupabaseClient();
+
+  /**
+   * Načíta profil gamifikácie pre používateľa.
+   */
+  async fetchUserState(userId: string) {
+    const {data, error} = await this.client
+      .from('user_levels')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    this.handleError(error);
+    if (!data) {
+      return null;
+    }
+    const xpToNextLevel = Math.round(100 * Math.pow(1.5, (data.current_level ?? 1) - 1));
+    const titleIndex = Math.min(8, Math.floor((data.current_level - 1) / Math.ceil(50 / 9)));
+    const titles = [
+      'Coffee Curious',
+      'Bean Apprentice',
+      'Flavor Explorer',
+      'Craft Connoisseur',
+      'Brew Virtuoso',
+      'Roast Strategist',
+      'Epic Roaster',
+      'Mythic Barista',
+      'Legendary Brewmaster',
+    ];
+
+    return {
+      userId: data.user_id,
+      level: data.current_level,
+      xp: data.current_xp,
+      xpToNextLevel,
+      streakDays: data.streak_days,
+      loginStreak: data.login_streak,
+      brewStreak: data.brew_streak,
+      perfectWeek: data.perfect_week,
+      freezeTokens: data.freeze_tokens,
+      comboMultiplier: Number(data.combo_multiplier),
+      doubleXpActive: Boolean(data.double_xp_until && new Date(data.double_xp_until).getTime() > Date.now()),
+      skillPoints: data.skill_points,
+      title: titles[titleIndex],
+    } satisfies GamificationStateSnapshot;
+  }
+
+  async upsertUserState(snapshot: GamificationStateSnapshot) {
+    const {error} = await this.client.from('user_levels').upsert(
+      {
+        user_id: snapshot.userId,
+        current_level: snapshot.level,
+        current_xp: snapshot.xp,
+        skill_points: snapshot.skillPoints,
+        combo_multiplier: snapshot.comboMultiplier,
+        streak_days: snapshot.streakDays,
+        login_streak: snapshot.loginStreak ?? 0,
+        brew_streak: snapshot.brewStreak ?? 0,
+        perfect_week: snapshot.perfectWeek ?? false,
+        freeze_tokens: snapshot.freezeTokens ?? 0,
+        double_xp_until: snapshot.doubleXpActive ? new Date().toISOString() : null,
+      },
+      {onConflict: 'user_id'}
+    );
+    this.handleError(error);
+  }
+
+  async fetchAchievements(): Promise<AchievementDefinition[]> {
+    const {data, error} = await this.client.from('achievements').select('*');
+    this.handleError(error);
+    return (data ?? []) as AchievementDefinition[];
+  }
+
+  async syncAchievementProgress(progress: AchievementProgress) {
+    const {error} = await this.client.from('user_achievements').upsert(
+      {
+        user_id: progress.userId,
+        achievement_id: progress.achievementId,
+        progress: progress.progress,
+        unlocked_at: progress.unlockedAt,
+        featured: progress.featured,
+      },
+      {onConflict: 'user_id,achievement_id'}
+    );
+    this.handleError(error);
+  }
+
+  async fetchDailyQuests(userId: string): Promise<DailyQuestInstance[]> {
+    const now = new Date().toISOString();
+    const {data, error} = await this.client
+      .from('daily_quests')
+      .select('*')
+      .lte('active_from', now)
+      .gte('active_to', now);
+    this.handleError(error);
+    const quests = (data ?? []).map((quest) => ({
+      id: quest.id,
+      templateId: quest.template_id ?? quest.id,
+      userId,
+      activeFrom: quest.active_from,
+      activeTo: quest.active_to,
+      rewardXp: quest.reward_xp,
+      rewardSkillPoints: quest.reward_skill_points,
+      requirements: quest.requirements ?? [],
+    }));
+    return quests as DailyQuestInstance[];
+  }
+
+  async syncQuestProgress(progress: DailyQuestProgress & {userId: string}) {
+    const {error} = await this.client.from('user_daily_progress').upsert(
+      {
+        user_id: progress.userId,
+        daily_quest_id: progress.questId,
+        progress: progress.progress,
+        completed: progress.completed,
+        claimed: progress.claimed,
+        updated_at: progress.updatedAt,
+      },
+      {onConflict: 'user_id,daily_quest_id'}
+    );
+    this.handleError(error);
+  }
+
+  async fetchLeaderboard(scope: 'global' | 'friends' | 'local'): Promise<LeaderboardEntry[]> {
+    const query = this.client.from('gamification_leaderboard').select('*').order('current_level', {ascending: false});
+    if (scope === 'local') {
+      query.limit(100);
+    }
+    const {data, error} = await query;
+    this.handleError(error);
+    return (data ?? []).map((entry) => ({
+      userId: entry.user_id,
+      displayName: entry.display_name ?? 'Unknown',
+      level: entry.current_level,
+      totalXp: entry.current_xp,
+      streakDays: entry.streak_days,
+      achievementsUnlocked: entry.unlocked_achievements,
+      region: entry.region,
+      avatarUrl: entry.avatar_url,
+    }));
+  }
+
+  async fetchSeasonalEvent(): Promise<SeasonalEvent | undefined> {
+    const {data, error} = await this.client.from('seasonal_events').select('*').gte('ends_at', new Date().toISOString()).limit(1).single();
+    if (error && error.code !== 'PGRST116') {
+      this.handleError(error);
+    }
+    return data as SeasonalEvent | undefined;
+  }
+
+  private handleError(error: PostgrestError | null) {
+    if (error) {
+      // V produkcii by sme chceli posielať chyby do logovania.
+      console.warn('[GamificationRepository] Supabase error', error.message);
+    }
+  }
+}

--- a/src/services/gamification/HapticsService.ts
+++ b/src/services/gamification/HapticsService.ts
@@ -1,0 +1,21 @@
+/*
+ * Jednoduchý modul pre haptickú odozvu využívajúci API Vibrácie.
+ */
+import {Platform, Vibration} from 'react-native';
+
+class HapticsService {
+  private pattern = [0, 40];
+
+  triggerImpact(type: 'light' | 'medium' | 'heavy' = 'medium') {
+    if (Platform.OS === 'ios') {
+      // Na iOS sa vibrácie mapujú na systémové haptické odozvy.
+      const duration = type === 'light' ? 20 : type === 'heavy' ? 80 : 40;
+      Vibration.vibrate(duration);
+    } else {
+      const multiplier = type === 'heavy' ? 3 : type === 'medium' ? 2 : 1;
+      Vibration.vibrate(this.pattern.map((value) => value * multiplier));
+    }
+  }
+}
+
+export default new HapticsService();

--- a/src/services/gamification/QuestNotificationService.ts
+++ b/src/services/gamification/QuestNotificationService.ts
@@ -1,0 +1,33 @@
+/*
+ * Pomocník pre plánovanie notifikácií na denné úlohy.
+ */
+import PushNotification from 'react-native-push-notification';
+import type {DailyQuestInstance} from '../../types/gamification';
+
+class QuestNotificationService {
+  scheduleQuestReminders(quests: DailyQuestInstance[]) {
+    quests.forEach((quest, index) => {
+      const remindAt = new Date(quest.activeFrom);
+      remindAt.setHours(9 + index * 3, 0, 0, 0);
+      if (remindAt.getTime() < Date.now()) {
+        remindAt.setHours(new Date().getHours() + 1);
+      }
+      PushNotification.localNotificationSchedule({
+        id: quest.id,
+        channelId: 'default-channel',
+        title: `🎯 Výzva: ${quest.title}`,
+        message: quest.description,
+        date: remindAt,
+        allowWhileIdle: true,
+      });
+    });
+  }
+
+  cancelQuestNotifications(quests: DailyQuestInstance[]) {
+    quests.forEach((quest) => {
+      PushNotification.cancelLocalNotification(quest.id);
+    });
+  }
+}
+
+export default new QuestNotificationService();

--- a/src/services/gamification/SoundEffectService.ts
+++ b/src/services/gamification/SoundEffectService.ts
@@ -1,0 +1,31 @@
+/*
+ * Obsluha zvukových efektov s fallbackom na konzolovú správu.
+ */
+import {NativeModules} from 'react-native';
+
+type SoundModule = {
+  preloadEffect: (name: string, resource: string) => void;
+  playEffect: (name: string) => void;
+};
+
+const moduleProxy = (NativeModules.SoundEffectModule ?? {}) as SoundModule;
+
+class SoundEffectService {
+  preload(name: string, resource: string) {
+    if (moduleProxy.preloadEffect) {
+      moduleProxy.preloadEffect(name, resource);
+    } else {
+      console.warn('[SoundEffectService] Missing native module, preload skipped');
+    }
+  }
+
+  play(name: string) {
+    if (moduleProxy.playEffect) {
+      moduleProxy.playEffect(name);
+    } else {
+      console.warn('[SoundEffectService] Missing native module, play skipped');
+    }
+  }
+}
+
+export default new SoundEffectService();

--- a/src/services/gamification/XpSystem.ts
+++ b/src/services/gamification/XpSystem.ts
@@ -1,0 +1,139 @@
+/*
+ * Trieda zodpovedná za výpočet skúseností, titulov a odmien.
+ */
+import type {
+  ComboMultiplierConfig,
+  GamificationTitle,
+  LevelDefinition,
+  XpEvent,
+  XpSource,
+} from '../../types/gamification';
+
+const TITLES: GamificationTitle[] = [
+  'Coffee Curious',
+  'Bean Apprentice',
+  'Flavor Explorer',
+  'Craft Connoisseur',
+  'Brew Virtuoso',
+  'Roast Strategist',
+  'Epic Roaster',
+  'Mythic Barista',
+  'Legendary Brewmaster',
+];
+
+const XP_PER_SOURCE: Record<XpSource, number> = {
+  brew: 10,
+  perfect_brew: 50,
+  help_others: 15,
+  bean_review: 12,
+  new_method: 25,
+  share_story: 8,
+  event_bonus: 30,
+};
+
+const MAX_LEVEL = 50;
+
+export default class XpSystem {
+  private comboConfig: ComboMultiplierConfig;
+
+  constructor(comboConfig?: Partial<ComboMultiplierConfig>) {
+    this.comboConfig = {
+      base: comboConfig?.base ?? 1,
+      max: comboConfig?.max ?? 3,
+      streakStep: comboConfig?.streakStep ?? 5,
+    };
+  }
+
+  /**
+   * Vypočíta potrebné XP pre daný level podľa exponenciálnej krivky.
+   */
+  getRequiredXp(level: number) {
+    return Math.round(100 * Math.pow(1.5, level - 1));
+  }
+
+  /**
+   * Vráti detaily levelov vrátane odmien.
+   */
+  getLevelDefinitions(): LevelDefinition[] {
+    return Array.from({length: MAX_LEVEL}, (_, index) => {
+      const level = index + 1;
+      const xpRequired = this.getRequiredXp(level);
+      const titleIndex = Math.min(TITLES.length - 1, Math.floor((level - 1) / Math.ceil(MAX_LEVEL / TITLES.length)));
+      return {
+        level,
+        xpRequired,
+        title: TITLES[titleIndex],
+        rewards: {
+          skillPoints: level % 5 === 0 ? 1 : 0,
+          perks: level % 10 === 0 ? ['seasonal_badge'] : [],
+        },
+      };
+    });
+  }
+
+  /**
+   * Vypočíta výsledné XP po aplikovaní násobiteľov.
+   */
+  calculateXpGain(event: XpEvent, options: {comboMultiplier: number; streakDays: number; doubleXpActive: boolean}) {
+    const base = XP_PER_SOURCE[event.source] ?? event.baseAmount;
+    const streakMultiplier = 1 + Math.min(2, options.streakDays / this.comboConfig.streakStep);
+    const doubleXp = options.doubleXpActive ? 2 : 1;
+    const combo = Math.min(options.comboMultiplier, this.comboConfig.max);
+    const total = base * streakMultiplier * doubleXp * combo;
+    return Math.round(total);
+  }
+
+  /**
+   * Zistí či aktuálny deň spadá do víkendu a teda poskytuje double XP.
+   */
+  isDoubleXpWeekend(date: Date = new Date()) {
+    const day = date.getUTCDay();
+    return day === 0 || day === 6;
+  }
+
+  /**
+   * Vypočíta nový kombo násobiteľ na základe počtu dní streaku.
+   */
+  getComboMultiplier(streakDays: number) {
+    const bonus = Math.floor(streakDays / this.comboConfig.streakStep) * 0.25;
+    return Math.min(this.comboConfig.max, this.comboConfig.base + bonus);
+  }
+
+  /**
+   * Nájde titul prislúchajúci levelu.
+   */
+  getTitleForLevel(level: number): GamificationTitle {
+    const titleIndex = Math.min(TITLES.length - 1, Math.floor((level - 1) / Math.ceil(MAX_LEVEL / TITLES.length)));
+    return TITLES[titleIndex];
+  }
+
+  /**
+   * Vyhodnotí, či hráč postúpil na vyšší level a koľko XP má zostať.
+   */
+  processXp(currentLevel: number, currentXp: number, xpGain: number) {
+    let xp = currentXp + xpGain;
+    let level = currentLevel;
+    let skillPoints = 0;
+    let leveledUp = false;
+
+    while (level < MAX_LEVEL && xp >= this.getRequiredXp(level)) {
+      xp -= this.getRequiredXp(level);
+      level += 1;
+      leveledUp = true;
+      if (level % 5 === 0) {
+        skillPoints += 1;
+      }
+    }
+
+    const xpToNext = level >= MAX_LEVEL ? 0 : this.getRequiredXp(level);
+
+    return {
+      level,
+      xp,
+      xpToNext,
+      skillPoints,
+      leveledUp,
+      title: this.getTitleForLevel(level),
+    };
+  }
+}

--- a/src/store/gamificationStore.ts
+++ b/src/store/gamificationStore.ts
@@ -1,0 +1,215 @@
+/*
+ * Centrálne úložisko gamifikácie využívajúce ľahkú implementáciu podobnú Zustandu.
+ */
+import {create} from '../utils/zustandLite';
+import type {
+  AchievementDefinition,
+  AchievementProgress,
+  DailyQuestInstance,
+  DailyQuestProgress,
+  GamificationStateSnapshot,
+  GamificationTitle,
+  LeaderboardEntry,
+  RadarStats,
+  SeasonalEvent,
+  XpEvent,
+} from '../types/gamification';
+
+interface GamificationState {
+  userId?: string;
+  level: number;
+  xp: number;
+  xpToNextLevel: number;
+  title: GamificationTitle;
+  skillPoints: number;
+  streakDays: number;
+  loginStreak: number;
+  brewStreak: number;
+  perfectWeek: boolean;
+  freezeTokens: number;
+  comboMultiplier: number;
+  doubleXpUntil?: string;
+  xpLog: XpEvent[];
+  achievements: AchievementDefinition[];
+  achievementProgress: Record<string, AchievementProgress>;
+  dailyQuests: DailyQuestInstance[];
+  questProgress: Record<string, DailyQuestProgress>;
+  leaderboard: LeaderboardEntry[];
+  radarStats?: RadarStats;
+  seasonalEvent?: SeasonalEvent;
+  lastInteraction?: string;
+  initialized: boolean;
+  init: (payload: Partial<GamificationState>) => void;
+  setAchievements: (definitions: AchievementDefinition[]) => void;
+  setDailyQuests: (quests: DailyQuestInstance[]) => void;
+  updateStreaks: (payload: {login?: boolean; brew?: boolean; perfectWeek?: boolean; freezeUsed?: boolean}) => void;
+  registerXp: (event: XpEvent) => {newLevel: number; leveledUp: boolean};
+  registerQuestProgress: (progress: DailyQuestProgress) => void;
+  registerAchievementProgress: (progress: AchievementProgress) => void;
+  setLeaderboard: (entries: LeaderboardEntry[]) => void;
+  setRadarStats: (stats: RadarStats) => void;
+  setSeasonalEvent: (event?: SeasonalEvent) => void;
+  consumeSkillPoints: (amount: number) => boolean;
+  getSnapshot: () => GamificationStateSnapshot | undefined;
+}
+
+const TITLES: GamificationTitle[] = [
+  'Coffee Curious',
+  'Bean Apprentice',
+  'Flavor Explorer',
+  'Craft Connoisseur',
+  'Brew Virtuoso',
+  'Roast Strategist',
+  'Epic Roaster',
+  'Mythic Barista',
+  'Legendary Brewmaster',
+];
+
+const MAX_LEVEL = 50;
+
+const computeXpForLevel = (level: number) => Math.round(100 * Math.pow(1.5, level - 1));
+
+const gamificationStore = create<GamificationState>((set, get) => ({
+  level: 1,
+  xp: 0,
+  xpToNextLevel: computeXpForLevel(1),
+  title: TITLES[0],
+  skillPoints: 0,
+  streakDays: 0,
+  loginStreak: 0,
+  brewStreak: 0,
+  perfectWeek: false,
+  freezeTokens: 1,
+  comboMultiplier: 1,
+  xpLog: [],
+  achievements: [],
+  achievementProgress: {},
+  dailyQuests: [],
+  questProgress: {},
+  leaderboard: [],
+  initialized: false,
+  init: (payload) => {
+    set({
+      ...payload,
+      initialized: true,
+      xpToNextLevel: computeXpForLevel(payload.level ?? 1),
+      title: TITLES[Math.min(TITLES.length - 1, Math.floor(((payload.level ?? 1) - 1) / Math.ceil(MAX_LEVEL / TITLES.length)))],
+      lastInteraction: new Date().toISOString(),
+    });
+  },
+  registerXp: (event) => {
+    const state = get();
+    const isDoubleXp = state.doubleXpUntil
+      ? new Date(state.doubleXpUntil).getTime() > new Date(event.timestamp).getTime()
+      : false;
+    const streakMultiplier = 1 + Math.min(2, state.streakDays / 7);
+    const seasonalMultiplier = state.seasonalEvent?.bonusMultiplier ?? 1;
+    const comboMultiplier = state.comboMultiplier;
+    const totalMultiplier = (isDoubleXp ? 2 : 1) * streakMultiplier * seasonalMultiplier * comboMultiplier;
+    const xpGain = Math.round(event.baseAmount * totalMultiplier);
+
+    let newXp = state.xp + xpGain;
+    let newLevel = state.level;
+    let leveledUp = false;
+    let skillPointsGain = 0;
+
+    while (newLevel < MAX_LEVEL && newXp >= computeXpForLevel(newLevel)) {
+      newXp -= computeXpForLevel(newLevel);
+      newLevel += 1;
+      leveledUp = true;
+      if (newLevel % 5 === 0) {
+        skillPointsGain += 1;
+      }
+    }
+
+    const snapshotLevel = newLevel;
+    const xpToNext = newLevel >= MAX_LEVEL ? 0 : computeXpForLevel(newLevel);
+
+    set({
+      level: snapshotLevel,
+      xp: newXp,
+      xpToNextLevel: xpToNext,
+      skillPoints: state.skillPoints + skillPointsGain,
+      xpLog: [...state.xpLog.slice(-49), event],
+      title: TITLES[Math.min(TITLES.length - 1, Math.floor((snapshotLevel - 1) / Math.ceil(MAX_LEVEL / TITLES.length)))],
+    });
+
+    return {newLevel: snapshotLevel, leveledUp};
+  },
+  registerQuestProgress: (progress) => {
+    set(({questProgress}) => ({
+      questProgress: {...questProgress, [progress.questId]: progress},
+      lastInteraction: new Date().toISOString(),
+    }));
+  },
+  registerAchievementProgress: (progress) => {
+    set(({achievementProgress}) => ({
+      achievementProgress: {...achievementProgress, [progress.achievementId]: progress},
+      lastInteraction: new Date().toISOString(),
+    }));
+  },
+  setAchievements: (definitions) => set({achievements: definitions}),
+  setDailyQuests: (quests) => set({dailyQuests: quests}),
+  updateStreaks: ({login, brew, perfectWeek, freezeUsed}) => {
+    set((state) => {
+      const consumeFreeze = freezeUsed && state.freezeTokens > 0;
+      const shouldResetLogin = login === false && !consumeFreeze;
+      const shouldResetBrew = brew === false && !consumeFreeze;
+      const nextLogin = login
+        ? state.loginStreak + 1
+        : shouldResetLogin
+          ? 0
+          : state.loginStreak;
+      const nextBrew = brew
+        ? state.brewStreak + 1
+        : shouldResetBrew
+          ? 0
+          : state.brewStreak;
+      const nextFreeze = consumeFreeze ? state.freezeTokens - 1 : state.freezeTokens;
+      const nextStreakDays = login || brew ? state.streakDays + 1 : state.streakDays;
+      const nextCombo = Math.min(3, 1 + nextStreakDays / 10);
+      return {
+        loginStreak: nextLogin,
+        brewStreak: nextBrew,
+        freezeTokens: nextFreeze,
+        streakDays: nextStreakDays,
+        comboMultiplier: nextCombo,
+        perfectWeek: perfectWeek ?? state.perfectWeek,
+      };
+    });
+  },
+  setLeaderboard: (entries) => set({leaderboard: entries}),
+  setRadarStats: (stats) => set({radarStats: stats}),
+  setSeasonalEvent: (event) => set({seasonalEvent: event}),
+  consumeSkillPoints: (amount) => {
+    const state = get();
+    if (state.skillPoints < amount) {
+      return false;
+    }
+    set({skillPoints: state.skillPoints - amount});
+    return true;
+  },
+  getSnapshot: () => {
+    const state = get();
+    if (!state.userId) {
+      return undefined;
+    }
+    return {
+      userId: state.userId,
+      level: state.level,
+      xp: state.xp,
+      xpToNextLevel: state.xpToNextLevel,
+      streakDays: state.streakDays,
+      loginStreak: state.loginStreak,
+      brewStreak: state.brewStreak,
+      perfectWeek: state.perfectWeek,
+      freezeTokens: state.freezeTokens,
+      comboMultiplier: state.comboMultiplier,
+      doubleXpActive: state.doubleXpUntil ? new Date(state.doubleXpUntil).getTime() > Date.now() : false,
+      skillPoints: state.skillPoints,
+      title: state.title,
+    };
+  },
+}));
+
+export default gamificationStore;

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -1,0 +1,186 @@
+/*
+ * Všetky typy pre gamifikačný systém.
+ * Komentáre sú v slovenčine podľa zadania.
+ */
+
+export type GamificationTitle =
+  | 'Coffee Curious'
+  | 'Bean Apprentice'
+  | 'Flavor Explorer'
+  | 'Craft Connoisseur'
+  | 'Brew Virtuoso'
+  | 'Roast Strategist'
+  | 'Epic Roaster'
+  | 'Mythic Barista'
+  | 'Legendary Brewmaster';
+
+export interface LevelDefinition {
+  level: number;
+  xpRequired: number;
+  title: GamificationTitle;
+  rewards: {
+    skillPoints: number;
+    perks: string[];
+  };
+}
+
+export type XpSource =
+  | 'brew'
+  | 'perfect_brew'
+  | 'help_others'
+  | 'bean_review'
+  | 'new_method'
+  | 'share_story'
+  | 'event_bonus';
+
+export interface XpEvent {
+  userId: string;
+  source: XpSource;
+  baseAmount: number;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type AchievementCategory =
+  | 'beginner'
+  | 'skills'
+  | 'exploration'
+  | 'social'
+  | 'hidden'
+  | 'seasonal';
+
+export type AchievementRarity = 'common' | 'rare' | 'epic' | 'legendary';
+
+export interface AchievementDefinition {
+  id: string;
+  code: string;
+  name: string;
+  description: string;
+  category: AchievementCategory;
+  rarity: AchievementRarity;
+  thresholds: number[];
+  specialReward?: {
+    type: 'feature_unlock' | 'badge' | 'cosmetic';
+    payload: Record<string, unknown>;
+  };
+}
+
+export interface AchievementProgress {
+  userId: string;
+  achievementId: string;
+  progress: number;
+  unlockedAt?: string;
+  featured: boolean;
+}
+
+export type QuestDifficulty = 'easy' | 'medium' | 'hard' | 'special';
+
+export interface QuestRequirement {
+  type:
+    | 'time_window'
+    | 'use_ai'
+    | 'upload_photo'
+    | 'rating'
+    | 'new_recipe'
+    | 'repeat_brew'
+    | 'multi_method'
+    | 'mentor_help'
+    | 'method_specific'
+    | 'streak'
+    | 'auto_complete';
+  value: unknown;
+  progressKey: string;
+}
+
+export interface QuestTemplate {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: QuestDifficulty;
+  rewardXpRange: [number, number];
+  rewardSkillPoints: number;
+  requirements: QuestRequirement[];
+  tags: string[];
+}
+
+export interface DailyQuestInstance {
+  id: string;
+  templateId: string;
+  userId: string;
+  activeFrom: string;
+  activeTo: string;
+  rewardXp: number;
+  rewardSkillPoints: number;
+  requirements: QuestRequirement[];
+}
+
+export interface DailyQuestProgress {
+  questId: string;
+  progress: Record<string, number>;
+  completed: boolean;
+  claimed: boolean;
+  updatedAt: string;
+}
+
+export interface LeaderboardEntry {
+  userId: string;
+  displayName: string;
+  level: number;
+  totalXp: number;
+  streakDays: number;
+  achievementsUnlocked: number;
+  region?: string;
+  avatarUrl?: string;
+}
+
+export interface RadarStats {
+  brewing: number;
+  exploration: number;
+  social: number;
+  knowledge: number;
+  averageComparison?: number;
+}
+
+export interface SeasonalEvent {
+  id: string;
+  title: string;
+  theme: string;
+  startsAt: string;
+  endsAt: string;
+  bonusMultiplier: number;
+  featuredMethods: string[];
+}
+
+export interface AbTestVariant {
+  experiment: string;
+  variant: 'A' | 'B' | 'C';
+  allocatedAt: string;
+}
+
+export interface AnalyticsEvent {
+  name: string;
+  timestamp: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface ComboMultiplierConfig {
+  base: number;
+  max: number;
+  streakStep: number;
+}
+
+export interface GamificationStateSnapshot {
+  userId: string;
+  level: number;
+  xp: number;
+  xpToNextLevel: number;
+  streakDays: number;
+  loginStreak?: number;
+  brewStreak?: number;
+  perfectWeek?: boolean;
+  freezeTokens?: number;
+  comboMultiplier: number;
+  doubleXpActive: boolean;
+  skillPoints: number;
+  title: GamificationTitle;
+}

--- a/src/utils/zustandLite.ts
+++ b/src/utils/zustandLite.ts
@@ -1,0 +1,70 @@
+/*
+ * Ľahká implementácia rozhrania podobného knižnici Zustand.
+ * V prípade budúcej migrácie na originálnu knižnicu stačí nahradiť tento súbor importom.
+ */
+import {MutableRefObject, useCallback, useRef, useSyncExternalStore} from 'react';
+
+type StateCreator<T> = (
+  setState: (updater: Partial<T> | ((state: T) => Partial<T>), replace?: boolean) => void,
+  getState: () => T
+) => T;
+
+type Listener<T> = (state: T) => void;
+
+export interface StoreApi<T> {
+  getState: () => T;
+  setState: (updater: Partial<T> | ((state: T) => Partial<T>), replace?: boolean) => void;
+  subscribe: (listener: Listener<T>) => () => void;
+}
+
+/**
+ * Funkcia `create` vracia hook použiteľný rovnako ako `useStore` zo Zustandu.
+ */
+export function create<TState extends object>(initializer: StateCreator<TState>) {
+  const listeners = new Set<Listener<TState>>();
+  let state = {} as TState;
+
+  const getState = () => state;
+
+  const setState: StoreApi<TState>['setState'] = (updater, replace = false) => {
+    const previous = state;
+    const partial = typeof updater === 'function' ? (updater as (state: TState) => Partial<TState>)(previous) : updater;
+    state = replace ? (partial as TState) : {...previous, ...partial};
+    listeners.forEach((listener) => listener(state));
+  };
+
+  state = initializer(setState, getState);
+
+  const subscribe: StoreApi<TState>['subscribe'] = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+
+  function useStore(): TState;
+  function useStore<TSlice>(selector: (state: TState) => TSlice): TSlice;
+  function useStore<TSlice>(selector?: (state: TState) => TSlice): TState | TSlice {
+    const selectorRef: MutableRefObject<(state: TState) => TSlice | TState> = useRef(
+      (selector as (state: TState) => TSlice | TState) ?? ((s: TState) => s)
+    );
+
+    const subscribeWithSelector = useCallback(
+      (callback: Listener<TSlice | TState>) =>
+        subscribe((nextState) => {
+          callback(selectorRef.current(nextState));
+        }),
+      []
+    );
+
+    return useSyncExternalStore(
+      subscribeWithSelector,
+      () => selectorRef.current(state),
+      () => selectorRef.current(state)
+    );
+  }
+
+  useStore.getState = getState;
+  useStore.setState = setState;
+  useStore.subscribe = subscribe;
+
+  return useStore as typeof useStore & StoreApi<TState>;
+}


### PR DESCRIPTION
## Summary
- add Supabase schema for user levels, achievements, quests, analytics and seasonal events
- implement gamification domain services including XP curve, achievements, quests, analytics and notifications
- create reusable React Native components and screens for level progress, achievements, quests, leaderboards and radar stats with animated feedback

## Testing
- npm run lint *(fails: ESLint requires migration to eslint.config.js in upstream project)*

------
https://chatgpt.com/codex/tasks/task_e_68d30849648c832aaecf96c10956ad1d