### PR TITLE
Add personalization dashboard navigation and live data

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -41,6 +41,7 @@ interface HomeScreenProps {
   onRecipesPress: () => void;
   onFavoritesPress: () => void;
   onInventoryPress: () => void;
+  onPersonalizationPress: () => void;
   userName?: string;
 }
 
@@ -53,6 +54,7 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                                                  onRecipesPress,
                                                  onFavoritesPress,
                                                  onInventoryPress,
+                                                 onPersonalizationPress,
                                                userName = 'Martin',
                                              }) => {
   const [refreshing, setRefreshing] = useState(false);
@@ -340,6 +342,18 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
             </View>
             <Text style={styles.actionTitle}>Pripraviť drink</Text>
             <Text style={styles.actionDesc}>Návod krok po kroku</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.actionCard}
+            onPress={onPersonalizationPress}
+            activeOpacity={0.8}
+          >
+            <View style={styles.actionIcon}>
+              <Text style={styles.actionEmoji}>🧠</Text>
+            </View>
+            <Text style={styles.actionTitle}>Personalizácia</Text>
+            <Text style={styles.actionDesc}>Pozri svoje odporúčania</Text>
           </TouchableOpacity>
         </View>
 


### PR DESCRIPTION
## Summary
- extend the app screen map and personalization context with quiz results, journey data, mood signals, and a chat responder
- surface a new personalization dashboard screen that renders live confidence, journey, and AI coach information from personalization services
- add a quick action on the home screen to let users jump directly to the personalization experience

## Testing
- not run (react-native project)

------
https://chatgpt.com/codex/tasks/task_e_68d6f57c63ec832a9d8be3ad68df9b66