### PR TITLE
Integrate smart diary insights refresh into personalization context

### DIFF
--- a/src/components/personalization/PersonalizationDashboard.tsx
+++ b/src/components/personalization/PersonalizationDashboard.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TasteQuizResult } from '../../types/PersonalizationAI';
 import { FlavorJourneyMilestone } from '../../types/PersonalizationAI';
-import { SmartDiaryInsight } from '../../services/SmartDiaryService';
 import { UserTasteProfile } from '../../types/Personalization';
+import { usePersonalization } from '../../hooks/usePersonalization';
 
 interface PersonalizationDashboardProps {
   quizResult?: TasteQuizResult;
@@ -12,7 +12,6 @@ interface PersonalizationDashboardProps {
   onToggleExperiment: (enabled: boolean) => void;
   experimentsEnabled: boolean;
   journey?: FlavorJourneyMilestone[];
-  insights?: SmartDiaryInsight[];
   profile?: UserTasteProfile | null;
 }
 
@@ -23,9 +22,20 @@ export const PersonalizationDashboard: React.FC<PersonalizationDashboardProps> =
   onToggleExperiment,
   experimentsEnabled,
   journey,
-  insights,
   profile,
 }) => {
+  const { insights, refreshInsights, ready } = usePersonalization();
+
+  useEffect(() => {
+    if (!refreshInsights || !ready) {
+      return;
+    }
+
+    refreshInsights().catch((error) => {
+      console.warn('PersonalizationDashboard: failed to refresh smart diary insights', error);
+    });
+  }, [ready, refreshInsights]);
+
   return (
     <ScrollView style={styles.container}>
       <Text style={styles.title}>Personalizačné učenie</Text>

--- a/src/services/personalizationGateway.ts
+++ b/src/services/personalizationGateway.ts
@@ -4,6 +4,9 @@ import { formatISO } from 'date-fns';
 import { CoffeeDiary } from './CoffeeDiary';
 import { PreferenceLearningEngine } from './PreferenceLearningEngine';
 import { PrivacyManager, LearningEventProvider } from './PrivacyManager';
+import { FlavorEmbeddingService } from './flavor/FlavorEmbeddingService';
+import { FlavorJourneyRepository } from './flavor/FlavorJourneyRepository';
+import { SmartDiaryService } from './SmartDiaryService';
 import {
   BrewContext,
   BrewHistoryEntry,
@@ -341,8 +344,15 @@ export const privacyManager = new PrivacyManager({
   eventProvider: eventsStorageProvider,
 });
 
+const flavorJourneyRepository = new FlavorJourneyRepository();
+const flavorEmbeddingService = new FlavorEmbeddingService(flavorJourneyRepository);
+const gatewaySmartDiary = new SmartDiaryService(preferenceEngine.getEngine(), flavorEmbeddingService);
+
 export const coffeeDiary = new CoffeeDiary({
   storage: diaryStorage,
   learningEngine: preferenceEngine.getEngine(),
+  smartDiary: gatewaySmartDiary,
 });
+
+export const smartDiary = gatewaySmartDiary;
 


### PR DESCRIPTION
## Summary
- extend the personalization context with a smart diary refresh callback and wire it up during service bootstrap
- update personalization UI to pull insights from context and refresh them when the dashboard mounts
- switch coffee scanners to the context-aware diary so new entries trigger smart diary insights, and bootstrap the gateway with a SmartDiaryService

## Testing
- npm run lint *(fails: ESLint v9 requires eslint.config.js migration)*

------
https://chatgpt.com/codex/tasks/task_e_68d71364473c832a8d374893b79d4916