### PR TITLE
Add brew diary navigation and tests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 // App.tsx
 import React, { useState, useEffect, useMemo, createContext, useCallback } from 'react';
 import {
+  Alert,
   StyleSheet,
   Text,
   View,
@@ -25,6 +26,8 @@ import OnboardingScreen from './src/components/OnboardingScreen';
 import PersonalizationDashboard from './src/components/personalization/PersonalizationDashboard';
 import FlavorJourneyMap from './src/components/personalization/FlavorJourneyMap';
 import AICoachChat from './src/components/personalization/AICoachChat';
+import BrewHistoryScreen from './src/components/BrewHistoryScreen';
+import BrewLogForm from './src/components/BrewLogForm';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
 import ResponsiveWrapper from './src/components/ResponsiveWrapper';
@@ -82,7 +85,9 @@ type ScreenName =
   | 'inventory'
   | 'gamification'
   | 'taste-quiz'
-  | 'personalization';
+  | 'personalization'
+  | 'brew-history'
+  | 'brew-log';
 
 const MORNING_RITUAL_CHANNEL_ID = 'brewmate-morning-ritual';
 const WEATHER_CACHE_KEY = 'brewmate:ritual:last_weather';
@@ -1100,6 +1105,14 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     setCurrentScreen('personalization');
   };
 
+  const handleBrewHistoryPress = () => {
+    setCurrentScreen('brew-history');
+  };
+
+  const handleBrewLogPress = () => {
+    setCurrentScreen('brew-log');
+  };
+
   const handleBackPress = () => {
     setCurrentScreen('home');
   };
@@ -1475,6 +1488,86 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     );
   }
 
+  if (currentScreen === 'brew-history') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <ConnectionStatusBar />
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.backButton, { backgroundColor: colors.primary }]}
+            onPress={handleBackPress}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+          <View style={styles.headerActionsGroup}>
+            <TouchableOpacity
+              style={[styles.headerActionButton, { backgroundColor: colors.accent }]}
+              onPress={handleBrewLogPress}
+              testID="open-brew-log-form">
+              <Text style={styles.headerActionButtonText}>+ Nový záznam</Text>
+            </TouchableOpacity>
+            <QueueStatusBadge />
+          </View>
+        </View>
+        <BrewHistoryScreen onAddLog={handleBrewLogPress} />
+        <BottomNav
+          active="home"
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+        <SyncProgressIndicator progress={syncProgress} visible={indicatorVisible} />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'brew-log') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <ConnectionStatusBar />
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.backButton, { backgroundColor: colors.primary }]}
+            onPress={handleBackPress}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+          <QueueStatusBadge />
+        </View>
+        <BrewLogForm
+          onSaved={() => {
+            Alert.alert('Záznam uložený', 'Tvoj záznam bol pridaný do histórie.', [
+              {
+                text: 'OK',
+                onPress: () => setCurrentScreen('brew-history'),
+              },
+            ]);
+          }}
+          onError={() => {
+            Alert.alert('Chyba', 'Nepodarilo sa uložiť záznam. Skúste to znova neskôr.');
+          }}
+        />
+        <BottomNav
+          active="home"
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+        <SyncProgressIndicator progress={syncProgress} visible={indicatorVisible} />
+      </ResponsiveWrapper>
+    );
+  }
+
   if (currentScreen === 'personalization') {
     return (
       <ResponsiveWrapper
@@ -1563,6 +1656,8 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
         onHomePress={handleBackPress}
         onScanPress={handleScannerPress}
         onBrewPress={handleBrewPress}
+        onBrewHistoryPress={handleBrewHistoryPress}
+        onLogBrewPress={handleBrewLogPress}
         onProfilePress={handleProfilePress}
         onDiscoverPress={handleDiscoverPress}
         onRecipesPress={handleRecipesPress}
@@ -1582,6 +1677,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: scale(20),
     paddingVertical: scale(10),
+  },
+  headerActionsGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: scale(12),
+  },
+  headerActionButton: {
+    paddingHorizontal: scale(16),
+    paddingVertical: scale(8),
+    borderRadius: scale(14),
+  },
+  headerActionButtonText: {
+    color: 'white',
+    fontWeight: '600',
+    fontSize: scale(14),
   },
   backButton: {
     paddingHorizontal: scale(15),

--- a/__tests__/BrewLogForm.test.tsx
+++ b/__tests__/BrewLogForm.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { Button, TextInput } from 'react-native';
+
+import BrewLogForm from '../src/components/BrewLogForm';
+import { saveBrewLog } from '../src/services/brewLogService';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+
+jest.mock('../src/services/brewLogService', () => ({
+  saveBrewLog: jest.fn(() => Promise.resolve()),
+}));
+
+describe('BrewLogForm', () => {
+  beforeEach(() => {
+    (saveBrewLog as jest.Mock).mockClear();
+  });
+
+  it('saves a valid brew log and notifies listeners', async () => {
+    const handleSaved = jest.fn();
+    let component!: ReactTestRenderer;
+
+    await act(async () => {
+      component = renderer.create(<BrewLogForm onSaved={handleSaved} />);
+    });
+
+    const inputs = component.root.findAllByType(TextInput);
+
+    act(() => {
+      inputs[0].props.onChangeText('92');
+      inputs[1].props.onChangeText('18');
+      inputs[2].props.onChangeText('15');
+      inputs[3].props.onChangeText('02:30');
+      inputs[4].props.onChangeText('Skvelá chuť');
+    });
+
+    const saveButton = component.root.findByType(Button);
+
+    await act(async () => {
+      await saveButton.props.onPress();
+    });
+
+    expect(saveBrewLog).toHaveBeenCalledTimes(1);
+    const [savedLog, options] = (saveBrewLog as jest.Mock).mock.calls[0];
+    expect(savedLog).toMatchObject({
+      waterTemp: 92,
+      coffeeDose: 18,
+      waterVolume: 270,
+      brewTime: '02:30',
+      notes: 'Skvelá chuť',
+    });
+    expect(options).toEqual({ showFeedback: false });
+    expect(handleSaved).toHaveBeenCalledWith(savedLog);
+
+    const updatedInputs = component.root.findAllByType(TextInput);
+    expect(updatedInputs[0].props.value).toBe('');
+    expect(updatedInputs[1].props.value).toBe('');
+    expect(updatedInputs[2].props.value).toBe('');
+  });
+
+  it('calls onError when saving fails', async () => {
+    const error = new Error('failed');
+    (saveBrewLog as jest.Mock).mockRejectedValueOnce(error);
+    const handleError = jest.fn();
+    let component!: ReactTestRenderer;
+
+    await act(async () => {
+      component = renderer.create(<BrewLogForm onError={handleError} />);
+    });
+
+    const inputs = component.root.findAllByType(TextInput);
+
+    act(() => {
+      inputs[0].props.onChangeText('92');
+      inputs[1].props.onChangeText('18');
+      inputs[2].props.onChangeText('15');
+    });
+
+    const saveButton = component.root.findByType(Button);
+
+    await act(async () => {
+      await saveButton.props.onPress();
+    });
+
+    expect(handleError).toHaveBeenCalledWith(error);
+  });
+});

--- a/__tests__/HomeScreen.brewDiary.test.tsx
+++ b/__tests__/HomeScreen.brewDiary.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { TouchableOpacity } from 'react-native';
+
+import HomeScreen from '../src/components/HomeScreen';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+
+jest.mock('../src/services/homePagesService.ts', () => ({
+  fetchCoffees: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../src/services/contentServices', () => ({
+  fetchDailyTip: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../src/services/coffeeServices.ts', () => ({
+  fetchRecentScans: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../src/hooks/usePersonalization', () => ({
+  usePersonalization: () => ({ morningRitualManager: null }),
+}));
+
+describe('HomeScreen brew diary actions', () => {
+  it('invokes callbacks when brew diary CTAs are pressed', async () => {
+    const props = {
+      onHomePress: jest.fn(),
+      onScanPress: jest.fn(),
+      onBrewPress: jest.fn(),
+      onBrewHistoryPress: jest.fn(),
+      onLogBrewPress: jest.fn(),
+      onProfilePress: jest.fn(),
+      onDiscoverPress: jest.fn(),
+      onRecipesPress: jest.fn(),
+      onFavoritesPress: jest.fn(),
+      onInventoryPress: jest.fn(),
+      onPersonalizationPress: jest.fn(),
+      userName: 'Tester',
+    };
+
+    let component!: ReactTestRenderer;
+
+    await act(async () => {
+      component = renderer.create(<HomeScreen {...props} />);
+    });
+
+    const buttons = component.root.findAllByType(TouchableOpacity);
+    const historyButton = buttons.find((btn) => btn.props.testID === 'brew-history-cta');
+    const logButton = buttons.find((btn) => btn.props.testID === 'brew-log-cta');
+
+    expect(historyButton).toBeDefined();
+    expect(logButton).toBeDefined();
+
+    act(() => {
+      historyButton?.props.onPress();
+      logButton?.props.onPress();
+    });
+
+    expect(props.onBrewHistoryPress).toHaveBeenCalled();
+    expect(props.onLogBrewPress).toHaveBeenCalled();
+  });
+});

--- a/src/components/BrewHistoryScreen.tsx
+++ b/src/components/BrewHistoryScreen.tsx
@@ -5,7 +5,11 @@ import { BrewLog } from '../types/BrewLog';
 import { BREW_DEVICES } from '../types/Recipe';
 import { getBrewLogs } from '../services/brewLogService';
 
-const BrewHistoryScreen: React.FC = () => {
+interface BrewHistoryScreenProps {
+  onAddLog?: () => void;
+}
+
+const BrewHistoryScreen: React.FC<BrewHistoryScreenProps> = ({ onAddLog }) => {
   const [logs, setLogs] = useState<BrewLog[]>([]);
   const [deviceFilter, setDeviceFilter] = useState<string>('all');
   const [dateFilter, setDateFilter] = useState('');
@@ -39,6 +43,13 @@ const BrewHistoryScreen: React.FC = () => {
 
   return (
     <View style={styles.container}>
+      {onAddLog ? (
+        <View style={styles.actionsRow}>
+          <TouchableOpacity style={styles.addButton} onPress={onAddLog} testID="history-add-log">
+            <Text style={styles.addButtonText}>Pridať záznam</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
       <View style={styles.filters}>
         <Picker
           selectedValue={deviceFilter}
@@ -64,6 +75,17 @@ const BrewHistoryScreen: React.FC = () => {
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
+  actionsRow: {
+    marginBottom: 12,
+    alignItems: 'flex-end',
+  },
+  addButton: {
+    backgroundColor: '#6B4423',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+  },
+  addButtonText: { color: 'white', fontWeight: '600' },
   filters: { flexDirection: 'row', marginBottom: 12 },
   devicePicker: { flex: 1 },
   dateInput: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginLeft: 8, flex: 1 },

--- a/src/components/BrewLogForm.tsx
+++ b/src/components/BrewLogForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { BrewLog } from '../types/BrewLog';
 import { BrewDevice, BREW_DEVICES } from '../types/Recipe';
@@ -8,9 +8,11 @@ import { saveBrewLog } from '../services/brewLogService';
 interface Props {
   recipeId?: string;
   initialDevice?: BrewDevice;
+  onSaved?: (log: BrewLog) => void;
+  onError?: (error: unknown) => void;
 }
 
-const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice }) => {
+const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice, onSaved, onError }) => {
   const [waterTemp, setWaterTemp] = useState('');
   const [coffeeDose, setCoffeeDose] = useState('');
   const [ratio, setRatio] = useState('');
@@ -47,12 +49,22 @@ const BrewLogForm: React.FC<Props> = ({ recipeId, initialDevice }) => {
       notes,
       brewDevice,
     };
-    await saveBrewLog(log);
-    setWaterTemp('');
-    setCoffeeDose('');
-    setRatio('');
-    setBrewTime('');
-    setNotes('');
+    try {
+      await saveBrewLog(log, { showFeedback: false });
+      setWaterTemp('');
+      setCoffeeDose('');
+      setRatio('');
+      setBrewTime('');
+      setNotes('');
+      onSaved?.(log);
+    } catch (error) {
+      console.error('BrewLogForm: failed to save log', error);
+      if (onError) {
+        onError(error);
+      } else {
+        Alert.alert('Chyba', 'Záznam sa nepodarilo uložiť. Skúste to prosím znova.');
+      }
+    }
   };
 
   return (

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -36,6 +36,8 @@ interface HomeScreenProps {
   onHomePress: () => void;
   onScanPress: () => void;
   onBrewPress: () => void;
+  onBrewHistoryPress: () => void;
+  onLogBrewPress: () => void;
   onProfilePress: () => void;
   onDiscoverPress: () => void;
   onRecipesPress: () => void;
@@ -49,6 +51,8 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                                                  onHomePress,
                                                  onScanPress,
                                                  onBrewPress,
+                                                 onBrewHistoryPress,
+                                                 onLogBrewPress,
                                                  onProfilePress,
                                                  onDiscoverPress,
                                                  onRecipesPress,
@@ -355,6 +359,28 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
             <Text style={styles.actionTitle}>Personalizácia</Text>
             <Text style={styles.actionDesc}>Pozri svoje odporúčania</Text>
           </TouchableOpacity>
+        </View>
+
+        <View style={styles.brewDiarySection}>
+          <Text style={styles.sectionTitle}>Denník varenia</Text>
+          <View style={styles.brewDiaryActions}>
+            <TouchableOpacity
+              style={[styles.brewDiaryButton, styles.brewDiaryPrimary]}
+              onPress={onLogBrewPress}
+              activeOpacity={0.85}
+              testID="brew-log-cta"
+            >
+              <Text style={styles.brewDiaryButtonText}>Pridať záznam</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.brewDiaryButton}
+              onPress={onBrewHistoryPress}
+              activeOpacity={0.85}
+              testID="brew-history-cta"
+            >
+              <Text style={styles.brewDiaryButtonSecondaryText}>História varení</Text>
+            </TouchableOpacity>
+          </View>
         </View>
 
         {/* Coffee Inventory */}

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -315,6 +315,47 @@ export const homeStyles = () => {
       color: 'white',
     },
 
+    brewDiarySection: {
+      marginHorizontal: 16,
+      marginBottom: 20,
+      padding: 20,
+      backgroundColor: 'white',
+      borderRadius: 20,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.08,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    brewDiaryActions: {
+      flexDirection: 'row',
+      gap: 12,
+      marginTop: 12,
+    },
+    brewDiaryButton: {
+      flex: 1,
+      paddingVertical: 14,
+      borderRadius: 14,
+      borderWidth: 1,
+      borderColor: colors.borderLight,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    brewDiaryPrimary: {
+      backgroundColor: colors.primary,
+      borderColor: colors.primary,
+    },
+    brewDiaryButtonText: {
+      color: 'white',
+      fontWeight: '600',
+      fontSize: 14,
+    },
+    brewDiaryButtonSecondaryText: {
+      color: colors.textPrimary,
+      fontWeight: '600',
+      fontSize: 14,
+    },
+
     // Coffee Inventory
     coffeeInventory: {
       marginHorizontal: 16,

--- a/src/services/brewLogService.ts
+++ b/src/services/brewLogService.ts
@@ -4,15 +4,21 @@ import { Platform, ToastAndroid, Alert } from 'react-native';
 
 const STORAGE_KEY = 'brewLogs';
 
-export const saveBrewLog = async (log: BrewLog): Promise<void> => {
+interface SaveOptions {
+  showFeedback?: boolean;
+}
+
+export const saveBrewLog = async (log: BrewLog, options: SaveOptions = {}): Promise<void> => {
   const raw = await AsyncStorage.getItem(STORAGE_KEY);
   const logs: BrewLog[] = raw ? JSON.parse(raw) : [];
   logs.push(log);
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
-  if (Platform.OS === 'android') {
-    ToastAndroid.show('Záznam uložený', ToastAndroid.SHORT);
-  } else {
-    Alert.alert('Záznam uložený');
+  if (options.showFeedback !== false) {
+    if (Platform.OS === 'android') {
+      ToastAndroid.show('Záznam uložený', ToastAndroid.SHORT);
+    } else {
+      Alert.alert('Záznam uložený');
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add dedicated `brew-history` and `brew-log` routes with navigation hooks in `App.tsx`
- surface brew diary calls-to-action on the home screen and allow history screen to open the form
- extend brew log form save handling with callbacks plus targeted unit tests for the new flows

## Testing
- npm test -- BrewLogForm.test.tsx HomeScreen.brewDiary.test.tsx *(fails: jest binary unavailable before dependency install; npm install blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e1544f23ec832a9a328839915b518b