### PR TITLE
Add navigation for community recipes and saved tips screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,8 @@ import TasteProfileQuizScreen from './src/screens/TasteProfileQuizScreen';
 import BottomNav from './src/components/BottomNav';
 import { scheduleLowStockCheck } from './src/utils/reminders';
 import InventoryScreen from './src/screens/InventoryScreen';
+import CommunityRecipesScreen from './src/screens/CommunityRecipesScreen';
+import SavedTipsScreen from './src/screens/SavedTipsScreen';
 import { coffeeOfflineManager, offlineSync } from './src/offline';
 import {
   ConnectionStatusBar,
@@ -91,7 +93,9 @@ type ScreenName =
   | 'taste-quiz'
   | 'personalization'
   | 'brew-history'
-  | 'brew-log';
+  | 'brew-log'
+  | 'community-recipes'
+  | 'saved-tips';
 
 const MORNING_RITUAL_CHANNEL_ID = 'brewmate-morning-ritual';
 const WEATHER_CACHE_KEY = 'brewmate:ritual:last_weather';
@@ -1323,6 +1327,14 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     setCurrentScreen('brew-log');
   };
 
+  const handleCommunityRecipesPress = () => {
+    setCurrentScreen('community-recipes');
+  };
+
+  const handleSavedTipsPress = () => {
+    setCurrentScreen('saved-tips');
+  };
+
   const handleBackPress = () => {
     setCurrentScreen('home');
   };
@@ -1664,6 +1676,36 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     );
   }
 
+  if (currentScreen === 'community-recipes') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.primary}
+      >
+        <ConnectionStatusBar />
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.backButton, { backgroundColor: colors.primary }]}
+            onPress={handleBackPress}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+          <QueueStatusBadge />
+        </View>
+        <CommunityRecipesScreen />
+        <BottomNav
+          active="recipes"
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+        <SyncProgressIndicator progress={syncProgress} visible={indicatorVisible} />
+      </ResponsiveWrapper>
+    );
+  }
+
   if (currentScreen === 'favorites') {
     return (
       <ResponsiveWrapper
@@ -1677,6 +1719,36 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
         </View>
         <AllCoffeesScreen
           onBack={handleBackPress}
+          onHomePress={handleBackPress}
+          onDiscoverPress={handleDiscoverPress}
+          onRecipesPress={handleRecipesPress}
+          onFavoritesPress={handleFavoritesPress}
+          onProfilePress={handleProfilePress}
+        />
+        <SyncProgressIndicator progress={syncProgress} visible={indicatorVisible} />
+      </ResponsiveWrapper>
+    );
+  }
+
+  if (currentScreen === 'saved-tips') {
+    return (
+      <ResponsiveWrapper
+        backgroundColor={colors.background}
+        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
+        statusBarBackground={colors.background}
+      >
+        <ConnectionStatusBar />
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.backButton, { backgroundColor: colors.primary }]}
+            onPress={handleBackPress}>
+            <Text style={styles.backButtonText}>← Späť</Text>
+          </TouchableOpacity>
+          <QueueStatusBadge />
+        </View>
+        <SavedTipsScreen />
+        <BottomNav
+          active="home"
           onHomePress={handleBackPress}
           onDiscoverPress={handleDiscoverPress}
           onRecipesPress={handleRecipesPress}
@@ -1894,6 +1966,8 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
         onFavoritesPress={handleFavoritesPress}
         onInventoryPress={handleInventoryPress}
         onPersonalizationPress={handlePersonalizationPress}
+        onCommunityRecipesPress={handleCommunityRecipesPress}
+        onSavedTipsPress={handleSavedTipsPress}
       />
       <SyncProgressIndicator progress={syncProgress} visible={indicatorVisible} />
     </ResponsiveWrapper>

--- a/__tests__/CommunityRecipesScreen.test.tsx
+++ b/__tests__/CommunityRecipesScreen.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import CommunityRecipesScreen from '../src/screens/CommunityRecipesScreen';
+import { fetchRecipes } from '../src/services/recipeServices';
+
+jest.mock('../src/services/recipeServices', () => ({
+  fetchRecipes: jest.fn(),
+}));
+
+describe('CommunityRecipesScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading indicator while fetching recipes', async () => {
+    let resolveFetch: (value: any) => void = () => {};
+    (fetchRecipes as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<CommunityRecipesScreen />);
+    });
+
+    const loading = component.root.findByProps({ testID: 'community-recipes-loading' });
+    expect(loading).toBeDefined();
+
+    await act(async () => {
+      resolveFetch([]);
+    });
+
+    expect(component.root.findAllByProps({ testID: 'community-recipes-loading' })).toHaveLength(0);
+  });
+
+  it('renders recipes after successful fetch', async () => {
+    (fetchRecipes as jest.Mock).mockResolvedValue([
+      { id: '1', title: 'Filtrovaná káva', brewDevice: 'V60' },
+    ]);
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<CommunityRecipesScreen />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const texts = component.root.findAllByType(Text);
+    const hasTitle = texts.some((node) => node.props.children === 'Filtrovaná káva');
+    const hasDevice = texts.some((node) => node.props.children === 'V60');
+    expect(hasTitle).toBe(true);
+    expect(hasDevice).toBe(true);
+  });
+
+  it('shows error state when fetch fails', async () => {
+    (fetchRecipes as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<CommunityRecipesScreen />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const error = component.root.findByProps({ testID: 'community-recipes-error' });
+    expect(error).toBeDefined();
+  });
+});

--- a/__tests__/HomeScreen.brewDiary.test.tsx
+++ b/__tests__/HomeScreen.brewDiary.test.tsx
@@ -37,6 +37,8 @@ describe('HomeScreen brew diary actions', () => {
       onFavoritesPress: jest.fn(),
       onInventoryPress: jest.fn(),
       onPersonalizationPress: jest.fn(),
+      onCommunityRecipesPress: jest.fn(),
+      onSavedTipsPress: jest.fn(),
       userName: 'Tester',
     };
 
@@ -53,12 +55,19 @@ describe('HomeScreen brew diary actions', () => {
     expect(historyButton).toBeDefined();
     expect(logButton).toBeDefined();
 
+    const savedTipsButton = component.root.findByProps({ testID: 'saved-tips-cta' });
+    const communityButton = component.root.findByProps({ testID: 'community-recipes-cta' });
+
     act(() => {
       historyButton?.props.onPress();
       logButton?.props.onPress();
+      savedTipsButton.props.onPress();
+      communityButton.props.onPress();
     });
 
     expect(props.onBrewHistoryPress).toHaveBeenCalled();
     expect(props.onLogBrewPress).toHaveBeenCalled();
+    expect(props.onSavedTipsPress).toHaveBeenCalled();
+    expect(props.onCommunityRecipesPress).toHaveBeenCalled();
   });
 });

--- a/__tests__/SavedTipsScreen.test.tsx
+++ b/__tests__/SavedTipsScreen.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import SavedTipsScreen from '../src/screens/SavedTipsScreen';
+
+const mockStorage: Record<string, string | null> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) => Promise.resolve(mockStorage[key] ?? null)),
+    setItem: jest.fn((key: string, value: string) => {
+      mockStorage[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+describe('SavedTipsScreen', () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+
+  beforeEach(() => {
+    Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+  });
+
+  it('shows loading state while tips are being read', async () => {
+    let resolveGet: (value: string | null) => void = () => {};
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        }),
+    );
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<SavedTipsScreen />);
+    });
+
+    const loading = component.root.findByProps({ testID: 'saved-tips-loading' });
+    expect(loading).toBeDefined();
+
+    await act(async () => {
+      resolveGet(null);
+    });
+  });
+
+  it('renders stored tips after loading', async () => {
+    const tip = { id: 1, date: '2024-01-01', text: 'Skvelý tip' };
+    mockStorage.SavedTips = JSON.stringify([tip]);
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<SavedTipsScreen />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const texts = component.root.findAllByType(Text);
+    const hasTip = texts.some((node) => node.props.children === tip.text);
+    expect(hasTip).toBe(true);
+  });
+
+  it('shows error state when reading tips fails', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('Read failed'));
+
+    let component!: ReactTestRenderer;
+    await act(async () => {
+      component = renderer.create(<SavedTipsScreen />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const error = component.root.findByProps({ testID: 'saved-tips-error' });
+    expect(error).toBeDefined();
+  });
+});

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -264,9 +264,51 @@ export const homeStyles = () => {
       lineHeight: 20,
     },
 
+    tipFeedback: {
+      backgroundColor: colors.cardLight,
+      borderRadius: 16,
+      padding: 16,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 12,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.08,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    tipFeedbackText: {
+      color: colors.textPrimary,
+      fontSize: 14,
+      textAlign: 'center',
+      lineHeight: 20,
+    },
+    tipRetry: {
+      backgroundColor: colors.primary,
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 12,
+    },
+    tipRetryText: {
+      color: 'white',
+      fontWeight: '600',
+      fontSize: 14,
+    },
+    savedTipsLink: {
+      marginTop: 12,
+      alignSelf: 'center',
+    },
+    savedTipsLinkText: {
+      color: colors.primary,
+      fontWeight: '600',
+      fontSize: 14,
+      textDecorationLine: 'underline',
+    },
+
     // Quick Actions
     quickActions: {
       flexDirection: 'row',
+      flexWrap: 'wrap',
       marginHorizontal: 16,
       marginBottom: 20,
       gap: 12,

--- a/src/screens/CommunityRecipesScreen.tsx
+++ b/src/screens/CommunityRecipesScreen.tsx
@@ -1,5 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  ActivityIndicator,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { Recipe, BrewDevice, BREW_DEVICES } from '../types/Recipe';
 import { fetchRecipes } from '../services/recipeServices';
@@ -7,35 +14,126 @@ import { fetchRecipes } from '../services/recipeServices';
 const CommunityRecipesScreen: React.FC = () => {
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [device, setDevice] = useState<'All' | BrewDevice>('All');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRecipes = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const fetched = await fetchRecipes();
+      setRecipes(fetched);
+    } catch (err) {
+      console.error('CommunityRecipesScreen: failed to load recipes', err);
+      setError('Nepodarilo sa načítať recepty. Skúste to znova.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    fetchRecipes().then(setRecipes);
-  }, []);
+    loadRecipes();
+  }, [loadRecipes]);
 
   const filtered = recipes.filter(
     (r) => r.brewDevice === device || device === 'All'
   );
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={styles.container}>
       <Picker selectedValue={device} onValueChange={(v) => setDevice(v as any)}>
         <Picker.Item label="All" value="All" />
         {BREW_DEVICES.map((d) => (
           <Picker.Item key={d} label={d} value={d} />
         ))}
       </Picker>
-      <FlatList
-        data={filtered}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#eee' }}>
-            <Text style={{ fontWeight: 'bold' }}>{item.title}</Text>
-            <Text>{item.brewDevice}</Text>
-          </View>
-        )}
-      />
+      {loading ? (
+        <View style={styles.stateContainer} testID="community-recipes-loading">
+          <ActivityIndicator color="#6B4423" />
+          <Text style={styles.stateText}>Načítavam recepty...</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.stateContainer} testID="community-recipes-error">
+          <Text style={styles.stateText}>{error}</Text>
+          <TouchableOpacity
+            style={styles.retryButton}
+            onPress={loadRecipes}
+            activeOpacity={0.85}
+            testID="community-recipes-retry"
+          >
+            <Text style={styles.retryText}>Skúsiť znova</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={filtered.length === 0 ? styles.emptyContainer : undefined}
+          renderItem={({ item }) => (
+            <View style={styles.recipeItem}>
+              <Text style={styles.recipeTitle}>{item.title}</Text>
+              <Text style={styles.recipeDevice}>{item.brewDevice}</Text>
+            </View>
+          )}
+          ListEmptyComponent={
+            <Text style={styles.emptyText}>Pre zvolený filter nemáme recepty.</Text>
+          }
+        />
+      )}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  stateContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  stateText: {
+    fontSize: 14,
+    textAlign: 'center',
+    color: '#2C2C2C',
+  },
+  retryButton: {
+    backgroundColor: '#6B4423',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  recipeItem: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  recipeTitle: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  recipeDevice: {
+    color: '#666',
+  },
+  emptyContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    color: '#666',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+});
 
 export default CommunityRecipesScreen;

--- a/src/screens/SavedTipsScreen.tsx
+++ b/src/screens/SavedTipsScreen.tsx
@@ -1,5 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Tip } from '../services/contentServices';
 
@@ -7,37 +14,136 @@ const SAVED_TIPS_KEY = 'SavedTips';
 
 const SavedTipsScreen: React.FC = () => {
   const [tips, setTips] = useState<Tip[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const loadTips = async () => {
-    const raw = await AsyncStorage.getItem(SAVED_TIPS_KEY);
-    setTips(raw ? JSON.parse(raw) : []);
-  };
+  const loadTips = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const raw = await AsyncStorage.getItem(SAVED_TIPS_KEY);
+      setTips(raw ? JSON.parse(raw) : []);
+    } catch (err) {
+      console.error('SavedTipsScreen: failed to load tips', err);
+      setTips([]);
+      setError('Nepodarilo sa načítať tipy. Skúste to znova.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     loadTips();
-  }, []);
+  }, [loadTips]);
 
   const removeTip = async (id: number, date: string) => {
     const updated = tips.filter((t) => !(t.id === id && t.date === date));
     setTips(updated);
-    await AsyncStorage.setItem(SAVED_TIPS_KEY, JSON.stringify(updated));
+    try {
+      await AsyncStorage.setItem(SAVED_TIPS_KEY, JSON.stringify(updated));
+    } catch (err) {
+      console.error('SavedTipsScreen: failed to persist tips', err);
+      setError('Nepodarilo sa uložiť zmeny. Skúste to znova.');
+      await loadTips();
+    }
   };
 
   const renderItem = ({ item }: { item: Tip }) => (
-    <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#ccc' }}>
-      <Text style={{ fontWeight: 'bold' }}>{item.date}</Text>
-      <Text>{item.text}</Text>
-      <TouchableOpacity onPress={() => removeTip(item.id, item.date)}>
-        <Text style={{ color: 'red' }}>Odstrániť</Text>
+    <View style={styles.tipCard}>
+      <Text style={styles.tipDate}>{item.date}</Text>
+      <Text style={styles.tipText}>{item.text}</Text>
+      <TouchableOpacity onPress={() => removeTip(item.id, item.date)} style={styles.removeButton}>
+        <Text style={styles.removeButtonText}>Odstrániť</Text>
       </TouchableOpacity>
     </View>
   );
 
   return (
-    <View style={{ flex: 1 }}>
-      <FlatList data={tips} keyExtractor={(item) => `${item.id}-${item.date}`} renderItem={renderItem} />
+    <View style={styles.container}>
+      {loading ? (
+        <View style={styles.stateContainer} testID="saved-tips-loading">
+          <ActivityIndicator color="#6B4423" />
+          <Text style={styles.stateText}>Načítavam tipy...</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.stateContainer} testID="saved-tips-error">
+          <Text style={styles.stateText}>{error}</Text>
+          <TouchableOpacity
+            style={styles.retryButton}
+            onPress={loadTips}
+            activeOpacity={0.85}
+            testID="saved-tips-retry"
+          >
+            <Text style={styles.retryText}>Skúsiť znova</Text>
+          </TouchableOpacity>
+        </View>
+      ) : tips.length === 0 ? (
+        <View style={styles.stateContainer} testID="saved-tips-empty">
+          <Text style={styles.stateText}>Nemáš uložené žiadne tipy.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={tips}
+          keyExtractor={(item) => `${item.id}-${item.date}`}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+        />
+      )}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  stateContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  stateText: {
+    fontSize: 14,
+    textAlign: 'center',
+    color: '#2C2C2C',
+  },
+  retryButton: {
+    backgroundColor: '#6B4423',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  retryText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  listContent: {
+    paddingVertical: 8,
+  },
+  tipCard: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderColor: '#ccc',
+    backgroundColor: '#fff',
+  },
+  tipDate: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  tipText: {
+    fontSize: 14,
+    color: '#333',
+    marginBottom: 12,
+  },
+  removeButton: {
+    alignSelf: 'flex-start',
+  },
+  removeButtonText: {
+    color: '#EF5350',
+    fontWeight: '600',
+  },
+});
 
 export default SavedTipsScreen;


### PR DESCRIPTION
## Summary
- add `community-recipes` and `saved-tips` routes with corresponding screen layouts and bottom navigation wiring
- extend the home dashboard with CTA buttons for the new screens and resilient daily tip loading feedback
- implement loading and error states for community recipes and saved tips plus new Jest coverage for both views

## Testing
- npm test -- --runTestsByPath __tests__/HomeScreen.brewDiary.test.tsx __tests__/CommunityRecipesScreen.test.tsx __tests__/SavedTipsScreen.test.tsx *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e172d38958832a82b967ceff3905f4