### PR TITLE
Wire coffee rating and favorites to offline helpers

### DIFF
--- a/__tests__/CoffeeTasteScanner.test.tsx
+++ b/__tests__/CoffeeTasteScanner.test.tsx
@@ -38,9 +38,16 @@ jest.mock('../src/services/ocrServices.ts', () => ({
   })),
   fetchOCRHistory: jest.fn(() => Promise.resolve([])),
   deleteOCRRecord: jest.fn(),
-  rateOCRResult: jest.fn(),
   markCoffeePurchased: jest.fn(),
   extractCoffeeName: jest.fn(() => 'Test Coffee'),
+}));
+
+const saveCoffeeRating = jest.fn(() => Promise.resolve(true));
+const toggleFavorite = jest.fn(() => Promise.resolve(true));
+
+jest.mock('../src/services/homePagesService.ts', () => ({
+  saveCoffeeRating: (...args: any[]) => saveCoffeeRating(...args),
+  toggleFavorite: (...args: any[]) => toggleFavorite(...args),
 }));
 
 jest.mock('../src/services/offlineCache', () => ({
@@ -60,6 +67,8 @@ jest.mock('../src/services/coffeeServices.ts', () => ({
 describe('CoffeeTasteScanner', () => {
   beforeEach(() => {
     addRecentScan.mockClear();
+    saveCoffeeRating.mockClear();
+    toggleFavorite.mockClear();
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
@@ -77,6 +86,64 @@ describe('CoffeeTasteScanner', () => {
       await galleryButton.props.onPress();
     });
     expect(addRecentScan).toHaveBeenCalled();
+  });
+
+  it('calls saveCoffeeRating when rating star is pressed', async () => {
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<CoffeeTasteScanner />);
+    });
+
+    const buttons = instance.root.findAllByType(TouchableOpacity);
+    const galleryButton = buttons.find(btn =>
+      btn.findAllByType(Text).some(t => t.props.children === 'Vybrať z galérie')
+    );
+    expect(galleryButton).toBeTruthy();
+
+    await ReactTestRenderer.act(async () => {
+      await galleryButton.props.onPress();
+    });
+
+    const starButton = instance.root.findAllByType(TouchableOpacity).find(btn =>
+      btn.findAllByType(Text).some(t => t.props.children === '☆'),
+    );
+
+    expect(starButton).toBeTruthy();
+
+    await ReactTestRenderer.act(async () => {
+      await starButton!.props.onPress();
+    });
+
+    expect(saveCoffeeRating).toHaveBeenCalledWith(expect.any(String), 1, undefined);
+  });
+
+  it('calls toggleFavorite when favorite button is pressed', async () => {
+    let instance: any;
+    await ReactTestRenderer.act(async () => {
+      instance = ReactTestRenderer.create(<CoffeeTasteScanner />);
+    });
+
+    const buttons = instance.root.findAllByType(TouchableOpacity);
+    const galleryButton = buttons.find(btn =>
+      btn.findAllByType(Text).some(t => t.props.children === 'Vybrať z galérie')
+    );
+    expect(galleryButton).toBeTruthy();
+
+    await ReactTestRenderer.act(async () => {
+      await galleryButton.props.onPress();
+    });
+
+    const favoriteButton = instance.root.findAllByType(TouchableOpacity).find(btn =>
+      btn.findAllByType(Text).some(t => t.props.children === '♡ Obľúbené'),
+    );
+
+    expect(favoriteButton).toBeTruthy();
+
+    await ReactTestRenderer.act(async () => {
+      await favoriteButton!.props.onPress();
+    });
+
+    expect(toggleFavorite).toHaveBeenCalled();
   });
 });
 

--- a/__tests__/homePagesService.offline.test.ts
+++ b/__tests__/homePagesService.offline.test.ts
@@ -1,0 +1,52 @@
+import { saveCoffeeRating, toggleFavorite } from '../src/services/homePagesService';
+import { offlineSync } from '../src/offline';
+
+jest.mock('@react-native-firebase/auth', () => () => ({
+  currentUser: {
+    getIdToken: jest.fn(() => Promise.resolve('token')),
+  },
+}));
+
+jest.mock('../src/offline', () => {
+  const enqueue = jest.fn();
+  return {
+    coffeeOfflineManager: {},
+    offlineSync: { enqueue },
+  };
+});
+
+const enqueueMock = (offlineSync.enqueue as unknown) as jest.Mock;
+
+beforeAll(() => {
+  global.fetch = jest.fn();
+});
+
+beforeEach(() => {
+  enqueueMock.mockClear();
+  (global.fetch as jest.Mock).mockReset();
+});
+
+describe('homePagesService offline helpers', () => {
+  it('enqueues coffee rating when network request fails', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network request failed'));
+
+    const result = await saveCoffeeRating('coffee-123', 4, 'note');
+
+    expect(result).toBe(true);
+    expect(enqueueMock).toHaveBeenCalledWith('coffee:rate', {
+      coffeeId: 'coffee-123',
+      rating: 4,
+      notes: 'note',
+    });
+  });
+
+  it('enqueues favorite toggle on unauthorized response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const result = await toggleFavorite('coffee-abc');
+
+    expect(result).toBe(true);
+    expect(enqueueMock).toHaveBeenCalledWith('coffee:favorite', { coffeeId: 'coffee-abc' });
+  });
+});
+

--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -704,6 +704,31 @@ export const scannerStyles = (isDarkMode: boolean = false) => {
       fontSize: 20,
     },
 
+    favoriteButton: {
+      marginLeft: 12,
+      paddingHorizontal: 12,
+      paddingVertical: 6,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.background,
+    },
+
+    favoriteButtonActive: {
+      backgroundColor: colors.primary,
+      borderColor: colors.primary,
+    },
+
+    favoriteButtonText: {
+      fontSize: 13,
+      fontWeight: '600',
+      color: colors.textPrimary,
+    },
+
+    favoriteButtonTextActive: {
+      color: colors.textLight,
+    },
+
     // Brewing Methods
     brewingSection: {
       padding: 16,

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -501,6 +501,7 @@ export const fetchOCRHistory = async (limit: number = 10): Promise<OCRHistory[]>
       match_percentage: item.match_percentage,
       is_recommended: item.is_recommended,
       is_purchased: item.is_purchased,
+      is_favorite: item.is_favorite,
     }));
   } catch (error) {
     console.error('Error fetching OCR history:', error);


### PR DESCRIPTION
## Summary
- connect CoffeeTasteScanner rating stars and favorite toggle to saveCoffeeRating/toggleFavorite with offline queuing feedback
- add rating/favorite controls in CoffeeReceipeScanner backed by the shared helpers and connection tracking
- extend shared styles, propagate the is_favorite flag, and add tests covering helper calls plus offline enqueueing

## Testing
- npm test -- --runInBand *(fails: jest binary unavailable before dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68e22e8417e0832a80792b8b49691d2f