### PR TITLE
Use notification service helper for inventory reminder cancellations

### DIFF
--- a/__tests__/InventoryScreen.test.tsx
+++ b/__tests__/InventoryScreen.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import InventoryScreen from '../src/screens/InventoryScreen';
+
+const mockReminders = [
+  {
+    id: '123',
+    message: 'Test reminder',
+  },
+];
+
+const cancelLocalNotificationMock = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('react-native-add-calendar-event', () => ({
+  presentEventCreatingDialog: jest.fn(),
+}));
+
+jest.mock('react-native-push-notification', () => ({
+  __esModule: true,
+  default: {
+    getScheduledLocalNotifications: jest.fn((callback: (reminders: any[]) => void) => {
+      callback(mockReminders);
+    }),
+  },
+}));
+
+jest.mock('../src/utils/reminders', () => ({
+  scheduleReminder: jest.fn(),
+  cancelLocalNotification: cancelLocalNotificationMock,
+}));
+
+describe('InventoryScreen', () => {
+  beforeEach(() => {
+    cancelLocalNotificationMock.mockClear();
+  });
+
+  it('routes reminder cancellation through the service helper', async () => {
+    type Renderer = ReturnType<typeof TestRenderer.create>;
+    let renderer: Renderer;
+
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<InventoryScreen />);
+      await Promise.resolve();
+    });
+
+    const cancelButton = renderer!.root.findByProps({title: 'Zrušiť'});
+
+    await TestRenderer.act(async () => {
+      cancelButton.props.onPress();
+    });
+
+    expect(cancelLocalNotificationMock).toHaveBeenCalledWith('123');
+  });
+});

--- a/src/screens/InventoryScreen.tsx
+++ b/src/screens/InventoryScreen.tsx
@@ -3,8 +3,8 @@ import {View, Text, Button, TextInput, FlatList} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import PushNotification from 'react-native-push-notification';
 import AddCalendarEvent from 'react-native-add-calendar-event';
-import {InventoryItem} from '../types/InventoryItem';
-import {scheduleReminder} from '../utils/reminders';
+import { InventoryItem } from '../types/InventoryItem';
+import { cancelLocalNotification, scheduleReminder } from '../utils/reminders';
 
 const InventoryScreen = (): React.JSX.Element => {
   const [items, setItems] = useState<InventoryItem[]>([]);
@@ -53,7 +53,7 @@ const InventoryScreen = (): React.JSX.Element => {
   };
 
   const cancelReminder = (id: string) => {
-    PushNotification.cancelLocalNotification(id);
+    cancelLocalNotification(id);
     loadReminders();
   };
 

--- a/src/utils/reminders.ts
+++ b/src/utils/reminders.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import PushNotification from 'react-native-push-notification';
+import { cancelLocalNotification as cancelLocalNotificationService } from '../services/NotificationService';
 import { InventoryItem } from '../types/InventoryItem';
 
 export const scheduleReminder = (date: Date, message: string): string => {
@@ -29,5 +30,9 @@ export const scheduleLowStockCheck = async (): Promise<void> => {
       }
     }
   });
+};
+
+export const cancelLocalNotification = (id: string): void => {
+  cancelLocalNotificationService(id);
 };
 


### PR DESCRIPTION
## Summary
- update InventoryScreen to call the cancelLocalNotification helper instead of PushNotification directly
- expose the cancelLocalNotification helper from the reminders utility to centralize notification cleanup
- add a unit test to verify reminder cancellation flows through the helper

## Testing
- npm test -- InventoryScreen *(fails: Jest unavailable because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b3b30dc8832ab13a97440ea8e1df