### PR TITLE
Refactor daily tip persistence and widget scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+
+## Widget refresh scheduling
+
+The BrewMate home screen widget reuses the same daily tip helper that powers the app UI. After every fetch, the helper schedules the next refresh at the upcoming local midnight using `scheduleDailyTipRefresh`. This keeps both the widget and app aligned on the same persistence keys and prevents multiple timers from stacking because the helper clears any existing timeout before creating a new one. If the widget needs to inspect the delay directly it can call `getWidgetRefreshDelay` from `src/utils/widgets.ts`.

--- a/__tests__/contentServices.test.ts
+++ b/__tests__/contentServices.test.ts
@@ -1,32 +1,94 @@
-import { fetchDailyTip, Tip } from '../src/services/contentServices';
+import {
+  TIP_OFFLINE_CACHE_KEY_PREFIX,
+  TIP_STORAGE_KEY,
+  fetchDailyTip,
+  getNextRefreshDelay,
+  scheduleDailyTipRefresh,
+} from '../src/services/contentServices';
+import type { Tip } from '../src/services/contentServices';
 
 jest.useFakeTimers();
 
-const store: Record<string, string> = {};
+const asyncStore: Record<string, string> = {};
+const offlineStore: Record<string, Tip> = {};
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
   default: {
-    getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+    getItem: jest.fn((key: string) => Promise.resolve(asyncStore[key] ?? null)),
     setItem: jest.fn((key: string, value: string) => {
-      store[key] = value;
+      asyncStore[key] = value;
       return Promise.resolve();
     }),
   },
 }));
 
-describe('fetchDailyTip', () => {
+jest.mock('../src/offline', () => ({
+  coffeeOfflineManager: {
+    getItem: jest.fn((key: string) => Promise.resolve(offlineStore[key] ?? null)),
+    setItem: jest.fn((key: string, value: Tip) => {
+      offlineStore[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+describe('daily tip service', () => {
+  beforeEach(() => {
+    jest.setSystemTime(new Date('2024-01-01T10:00:00.000Z'));
+    Object.keys(asyncStore).forEach(key => delete asyncStore[key]);
+    Object.keys(offlineStore).forEach(key => delete offlineStore[key]);
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
   it('returns same tip within a day and different on next day', async () => {
-    jest.setSystemTime(new Date('2024-01-01'));
-    const tip1 = await fetchDailyTip();
-    const tipStored: Tip = JSON.parse(store['lastTip']);
-    expect(tipStored.id).toBe(tip1.id);
+    const firstTip = await fetchDailyTip();
+    expect(firstTip.date).toBe('2024-01-01');
+    const storedTip: Tip = JSON.parse(asyncStore[TIP_STORAGE_KEY]);
+    expect(storedTip.id).toBe(firstTip.id);
 
-    const tip2 = await fetchDailyTip();
-    expect(tip2.id).toBe(tip1.id);
+    const secondTip = await fetchDailyTip();
+    expect(secondTip.id).toBe(firstTip.id);
 
-    jest.setSystemTime(new Date('2024-01-02'));
-    const tip3 = await fetchDailyTip();
-    expect(tip3.id).not.toBe(tip1.id);
+    jest.setSystemTime(new Date('2024-01-02T09:00:00.000Z'));
+    const thirdTip = await fetchDailyTip();
+    expect(thirdTip.id).not.toBe(firstTip.id);
+  });
+
+  it('prefers offline cache over async storage', async () => {
+    const offlineKey = `${TIP_OFFLINE_CACHE_KEY_PREFIX}:2024-01-01`;
+    const offlineTip: Tip = { id: 99, text: 'from offline', date: '2024-01-01' };
+    offlineStore[offlineKey] = offlineTip;
+
+    const fetched = await fetchDailyTip();
+    expect(fetched).toEqual(offlineTip);
+  });
+
+  it('hydrates offline cache from async storage when needed', async () => {
+    const storedTip: Tip = { id: 42, text: 'stored', date: '2024-01-01' };
+    asyncStore[TIP_STORAGE_KEY] = JSON.stringify(storedTip);
+
+    const fetched = await fetchDailyTip();
+
+    expect(fetched).toEqual(storedTip);
+    const offlineKey = `${TIP_OFFLINE_CACHE_KEY_PREFIX}:2024-01-01`;
+    expect(offlineStore[offlineKey]).toEqual(storedTip);
+  });
+
+  it('schedules refresh at midnight', () => {
+    const now = new Date('2024-01-01T20:00:00.000Z');
+    const expectedDelay = getNextRefreshDelay(now);
+    const refreshSpy = jest.fn();
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
+
+    scheduleDailyTipRefresh(refreshSpy, now);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedDelay);
+
+    jest.advanceTimersByTime(expectedDelay);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    timeoutSpy.mockRestore();
   });
 });

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -13,8 +13,7 @@ import { homeStyles } from './styles/HomeScreen.styles.ts';
 import { fetchCoffees, fetchDashboardData, fetchUserStats } from '../services/homePagesService.ts';
 import DailyTipCard from './DailyTipCard';
 import DailyRitualCard, { DailyRitualCardProps } from './DailyRitualCard';
-import { fetchDailyTip, Tip } from '../services/contentServices';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { fetchDailyTip, getTipFromCache, Tip } from '../services/contentServices';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
 import RecentScansCarousel from './RecentScansCarousel';
 import { fetchRecentScans, RecentScan } from '../services/coffeeServices.ts';
@@ -179,22 +178,17 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
     try {
       const tip = await fetchDailyTip();
       setDailyTip(tip);
-      try {
-        await AsyncStorage.setItem('lastTip', JSON.stringify(tip));
-      } catch (storageError) {
-        console.warn('HomeScreen: failed to persist last tip', storageError);
-      }
     } catch (e) {
       console.warn('HomeScreen: failed to fetch daily tip', e);
       setTipError('Nepodarilo sa načítať tip. Skúste to znova.');
       try {
-        const stored = await AsyncStorage.getItem('lastTip');
-        if (stored) {
-          setDailyTip(JSON.parse(stored));
+        const cached = await getTipFromCache(new Date().toISOString().slice(0, 10));
+        if (cached) {
+          setDailyTip(cached);
           setTipError(null);
         }
-      } catch (storageError) {
-        console.warn('HomeScreen: failed to read cached tip', storageError);
+      } catch (cacheError) {
+        console.warn('HomeScreen: failed to read cached tip', cacheError);
       }
     } finally {
       setTipLoading(false);

--- a/src/services/contentServices.ts
+++ b/src/services/contentServices.ts
@@ -1,65 +1,14 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { coffeeOfflineManager } from '../offline';
-const tips = require('../../content/dailyTips.json');
-
-export interface Tip {
-  id: number;
-  text: string;
-  date: string;
-}
-
-const LAST_TIP_KEY = 'lastTip';
-const OFFLINE_TIP_KEY = 'ai:dailyTip';
-const AI_CACHE_TTL = 24;
-
-export const fetchDailyTip = async (): Promise<Tip> => {
-  const today = new Date().toISOString().slice(0, 10);
-
-  try {
-    const offlineCached = await coffeeOfflineManager.getItem<Tip>(`${OFFLINE_TIP_KEY}:${today}`);
-    if (offlineCached) {
-      return offlineCached;
-    }
-
-    const stored = await AsyncStorage.getItem(LAST_TIP_KEY);
-    if (stored) {
-      const parsed: Tip = JSON.parse(stored);
-      if (parsed.date === today) {
-        await coffeeOfflineManager.setItem(
-          `${OFFLINE_TIP_KEY}:${today}`,
-          parsed,
-          AI_CACHE_TTL,
-          4,
-        );
-        return parsed;
-      }
-    }
-  } catch (error) {
-    console.error('Error reading last tip:', error);
-  }
-
-  const list: Tip[] = tips as Tip[];
-  const matched = list.find((t) => t.date === today);
-  const index = new Date(today).getDate() % list.length;
-  const chosen = matched || list[index];
-  const tip: Tip = { ...chosen, date: today };
-
-  try {
-    await AsyncStorage.setItem(LAST_TIP_KEY, JSON.stringify(tip));
-  } catch (error) {
-    console.error('Error saving last tip:', error);
-  }
-
-  try {
-    await coffeeOfflineManager.setItem(
-      `${OFFLINE_TIP_KEY}:${today}`,
-      tip,
-      AI_CACHE_TTL,
-      4,
-    );
-  } catch (error) {
-    console.error('Error caching daily tip:', error);
-  }
-
-  return tip;
-};
+export {
+  Tip,
+  TIP_CACHE_TTL_HOURS,
+  TIP_OFFLINE_CACHE_KEY_PREFIX,
+  TIP_STORAGE_KEY,
+  clearScheduledDailyTipRefresh,
+  fetchDailyTip,
+  getNextRefreshDelay,
+  getScheduledDailyTipRefreshHandle,
+  getTipFromCache,
+  persistTip,
+  pickTipForDate,
+  scheduleDailyTipRefresh,
+} from './dailyTipService';

--- a/src/services/dailyTipService.ts
+++ b/src/services/dailyTipService.ts
@@ -1,0 +1,132 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { coffeeOfflineManager } from '../offline';
+const tipsData = require('../../content/dailyTips.json');
+
+export interface Tip {
+  id: number;
+  text: string;
+  date: string;
+}
+
+export const TIP_STORAGE_KEY = 'ai:dailyTip:last';
+export const TIP_OFFLINE_CACHE_KEY_PREFIX = 'ai:dailyTip';
+export const TIP_CACHE_TTL_HOURS = 24;
+
+let scheduledRefreshHandle: ReturnType<typeof setTimeout> | null = null;
+
+const tipList: Tip[] = tipsData as Tip[];
+
+const buildOfflineCacheKey = (date: string) => `${TIP_OFFLINE_CACHE_KEY_PREFIX}:${date}`;
+
+export const getTipFromCache = async (date: string): Promise<Tip | null> => {
+  try {
+    const offlineKey = buildOfflineCacheKey(date);
+    const offlineCached = await coffeeOfflineManager.getItem<Tip>(offlineKey);
+    if (offlineCached) {
+      return offlineCached;
+    }
+
+    const stored = await AsyncStorage.getItem(TIP_STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    const parsed: Tip = JSON.parse(stored);
+    if (parsed.date === date) {
+      try {
+        await coffeeOfflineManager.setItem(offlineKey, parsed, TIP_CACHE_TTL_HOURS, 4);
+      } catch (error) {
+        console.error('Error caching tip offline:', error);
+      }
+      return parsed;
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error reading cached tip:', error);
+    return null;
+  }
+};
+
+export const persistTip = async (tip: Tip): Promise<void> => {
+  const offlineKey = buildOfflineCacheKey(tip.date);
+  try {
+    await AsyncStorage.setItem(TIP_STORAGE_KEY, JSON.stringify(tip));
+  } catch (error) {
+    console.error('Error saving last tip:', error);
+  }
+
+  try {
+    await coffeeOfflineManager.setItem(offlineKey, tip, TIP_CACHE_TTL_HOURS, 4);
+  } catch (error) {
+    console.error('Error caching daily tip:', error);
+  }
+};
+
+export const pickTipForDate = (date: string): Tip => {
+  if (!tipList.length) {
+    return {
+      id: 0,
+      text: 'Enjoy your brew!',
+      date,
+    };
+  }
+
+  const matched = tipList.find(tip => tip.date === date);
+  if (matched) {
+    return { ...matched, date };
+  }
+
+  const day = new Date(date).getDate();
+  const fallback = tipList[day % tipList.length];
+  return { ...fallback, date };
+};
+
+export const fetchDailyTip = async (now: Date = new Date()): Promise<Tip> => {
+  const today = now.toISOString().slice(0, 10);
+  const cached = await getTipFromCache(today);
+  if (cached) {
+    return cached;
+  }
+
+  const tip = pickTipForDate(today);
+  await persistTip(tip);
+  return tip;
+};
+
+export const getNextRefreshDelay = (now: Date = new Date()): number => {
+  const midnight = new Date(now);
+  midnight.setHours(24, 0, 0, 0);
+  return Math.max(midnight.getTime() - now.getTime(), 0);
+};
+
+export const scheduleDailyTipRefresh = (
+  refresh: () => Promise<unknown> | unknown,
+  now: Date = new Date(),
+): ReturnType<typeof setTimeout> => {
+  const delay = getNextRefreshDelay(now);
+
+  if (scheduledRefreshHandle) {
+    clearTimeout(scheduledRefreshHandle);
+  }
+
+  scheduledRefreshHandle = setTimeout(() => {
+    scheduledRefreshHandle = null;
+    Promise.resolve()
+      .then(() => refresh())
+      .catch(error => {
+        console.error('Error running scheduled daily tip refresh:', error);
+      });
+  }, delay);
+
+  return scheduledRefreshHandle;
+};
+
+export const clearScheduledDailyTipRefresh = () => {
+  if (scheduledRefreshHandle) {
+    clearTimeout(scheduledRefreshHandle);
+    scheduledRefreshHandle = null;
+  }
+};
+
+export const getScheduledDailyTipRefreshHandle = () => scheduledRefreshHandle;

--- a/src/utils/widgets.ts
+++ b/src/utils/widgets.ts
@@ -1,40 +1,15 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import tips from '../../content/dailyTips.json';
-
-const TIP_KEY = 'dailyTip';
+import {
+  fetchDailyTip as fetchDailyTipFromService,
+  getNextRefreshDelay,
+  scheduleDailyTipRefresh,
+} from '../services/contentServices';
 
 export async function fetchDailyTip(): Promise<string> {
-  const today = new Date().toDateString();
-  try {
-    const cachedRaw = await AsyncStorage.getItem(TIP_KEY);
-    if (cachedRaw) {
-      const cached = JSON.parse(cachedRaw);
-      if (cached.date === today && cached.tip) {
-        return cached.tip;
-      }
-    }
-  } catch (e) {
-    // ignore parsing errors
-  }
-
-  let tip = tips[Math.floor(Math.random() * tips.length)];
-  // TODO: Optionally fetch from remote API here
-
-  try {
-    await AsyncStorage.setItem(TIP_KEY, JSON.stringify({ date: today, tip }));
-  } catch (e) {
-    // ignore write errors
-  }
-  scheduleNextUpdate();
-  return tip;
+  const tip = await fetchDailyTipFromService();
+  scheduleDailyTipRefresh(() => fetchDailyTipFromService());
+  return tip.text;
 }
 
-function scheduleNextUpdate() {
-  const now = new Date();
-  const midnight = new Date(now);
-  midnight.setHours(24, 0, 0, 0);
-  const timeout = midnight.getTime() - now.getTime();
-  setTimeout(fetchDailyTip, timeout);
-}
+export { getNextRefreshDelay as getWidgetRefreshDelay };
 
 export default fetchDailyTip;


### PR DESCRIPTION
## Summary
- centralize daily tip persistence and scheduling in `dailyTipService` so the app and widget share one helper
- update home screen, daily tip card, and widget utility to pull from the shared logic
- expand unit coverage and document how widget refresh scheduling works

## Testing
- npm test -- __tests__/contentServices.test.ts *(fails: jest not installed because dependency install is blocked by npm registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b61a4a60832a812e42ba9a79cdac