### PR TITLE
Add Expo widget handler for daily tip refresh

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "src/services",
     "__tests__",
     "index.js",
-    "server.js"
+    "server.js",
+    "widgets"
   ]
 }

--- a/widgets/dailyTipWidget.ts
+++ b/widgets/dailyTipWidget.ts
@@ -1,0 +1,74 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { registerWidgetTaskHandler } from 'expo-widget';
+
+import { fetchDailyTip, getWidgetRefreshDelay } from '../src/utils/widgets';
+
+const WIDGET_LAST_TIP_KEY = 'widget:dailyTip:last';
+const DEFAULT_TIP = 'Enjoy your brew!';
+
+async function persistLastTip(tip: string) {
+  try {
+    await AsyncStorage.setItem(WIDGET_LAST_TIP_KEY, tip);
+  } catch (error) {
+    console.warn('[dailyTipWidget] Unable to persist last tip for offline use', error);
+  }
+}
+
+async function readCachedTip(): Promise<string> {
+  try {
+    const cached = await AsyncStorage.getItem(WIDGET_LAST_TIP_KEY);
+    if (cached) {
+      return cached;
+    }
+  } catch (error) {
+    console.warn('[dailyTipWidget] Unable to read cached tip', error);
+  }
+
+  return DEFAULT_TIP;
+}
+
+type DailyTipWidgetData = {
+  tip: string;
+};
+
+type DailyTipWidgetTimelineEntry = {
+  date: Date;
+  data: DailyTipWidgetData;
+};
+
+type DailyTipWidgetResult = {
+  timeline: DailyTipWidgetTimelineEntry[];
+  nextRefresh?: number;
+};
+
+registerWidgetTaskHandler(async (): Promise<DailyTipWidgetResult> => {
+  const nextRefresh = Date.now() + getWidgetRefreshDelay();
+
+  try {
+    const tip = await fetchDailyTip();
+    await persistLastTip(tip);
+
+    return {
+      timeline: [
+        {
+          date: new Date(),
+          data: { tip },
+        },
+      ],
+      nextRefresh,
+    };
+  } catch (error) {
+    console.warn('[dailyTipWidget] Falling back to cached tip', error);
+    const tip = await readCachedTip();
+
+    return {
+      timeline: [
+        {
+          date: new Date(),
+          data: { tip },
+        },
+      ],
+      nextRefresh,
+    };
+  }
+});

--- a/widgets/index.ts
+++ b/widgets/index.ts
@@ -1,0 +1,1 @@
+import './dailyTipWidget';


### PR DESCRIPTION
## Summary
- add a daily tip widget task handler that uses the shared helpers to fetch content and plan the next refresh
- persist the last successful tip so offline refreshes can reuse cached data
- include the widgets directory in the TypeScript project configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c18680c8832ab9ea2fd20dadc81d