### PR TITLE
Use vertical scaling for vertical spacing across key screens

### DIFF
--- a/src/components/EditPreferences.tsx
+++ b/src/components/EditPreferences.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
 import { getColors, Colors } from '../theme/colors';
-import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
+import { getSafeAreaTop, getSafeAreaBottom, scale, verticalScale } from './utils/safeArea';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { CONFIG } from '../config/config';
 
@@ -369,12 +369,12 @@ const createStyles = (colors: Colors) =>
       justifyContent: 'space-between',
       alignItems: 'center',
       paddingHorizontal: scale(16),
-      paddingVertical: scale(12),
-      paddingTop: Platform.OS === 'ios' ? scale(12) : scale(16) + getSafeAreaTop(),
+      paddingVertical: verticalScale(12),
+      paddingTop: Platform.OS === 'ios' ? verticalScale(12) : verticalScale(16) + getSafeAreaTop(),
     },
     headerButton: {
       width: scale(36),
-      height: scale(36),
+      height: verticalScale(36),
       backgroundColor: 'rgba(255,255,255,0.2)',
       borderRadius: scale(18),
       justifyContent: 'center',
@@ -403,21 +403,21 @@ const createStyles = (colors: Colors) =>
     },
     scrollContent: {
       padding: scale(16),
-      paddingBottom: getSafeAreaBottom() + scale(30),
+      paddingBottom: getSafeAreaBottom() + verticalScale(30),
     },
     section: {
-      marginBottom: scale(20),
+      marginBottom: verticalScale(20),
     },
     label: {
       fontSize: scale(16),
       fontWeight: '600',
       color: colors.text,
-      marginBottom: scale(8),
+      marginBottom: verticalScale(8),
     },
     helperText: {
       fontSize: scale(13),
       color: colors.textSecondary,
-      marginBottom: scale(10),
+      marginBottom: verticalScale(10),
       fontStyle: 'italic',
     },
     currentRecommendation: {
@@ -431,12 +431,12 @@ const createStyles = (colors: Colors) =>
       fontSize: scale(16),
       fontWeight: '600',
       color: colors.text,
-      marginBottom: scale(8),
+      marginBottom: verticalScale(8),
     },
     recommendationText: {
       color: colors.text,
       fontSize: scale(14),
-      lineHeight: scale(20),
+      lineHeight: verticalScale(20),
     },
     input: {
       borderWidth: 1,
@@ -448,7 +448,7 @@ const createStyles = (colors: Colors) =>
       fontSize: scale(14),
     },
     multiline: {
-      height: scale(100),
+      height: verticalScale(100),
       textAlignVertical: 'top',
     },
     historyBox: {
@@ -457,25 +457,25 @@ const createStyles = (colors: Colors) =>
       borderRadius: scale(12),
       borderWidth: 1,
       borderColor: colors.border,
-      maxHeight: scale(120),
+      maxHeight: verticalScale(120),
     },
     historyScroll: {
-      maxHeight: scale(100),
+      maxHeight: verticalScale(100),
     },
     historyText: {
       color: colors.textSecondary,
       fontSize: scale(12),
-      lineHeight: scale(18),
+      lineHeight: verticalScale(18),
     },
     buttonsContainer: {
-      marginTop: scale(10),
+      marginTop: verticalScale(10),
     },
     saveButton: {
       backgroundColor: colors.primary,
       padding: scale(15),
       borderRadius: scale(20),
       alignItems: 'center',
-      marginBottom: scale(10),
+      marginBottom: verticalScale(10),
     },
     disabledButton: {
       opacity: 0.6,

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -14,7 +14,7 @@ import {
   Platform,
 } from 'react-native';
 import auth from '@react-native-firebase/auth';
-import { getSafeAreaTop, getSafeAreaBottom, scale } from './utils/safeArea';
+import { getSafeAreaTop, getSafeAreaBottom, scale, verticalScale } from './utils/safeArea';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { unifiedStyles } from '../theme/unifiedStyles';
 import BottomNav, { BOTTOM_NAV_HEIGHT } from './BottomNav';
@@ -642,12 +642,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     paddingHorizontal: scale(16),
-    paddingVertical: scale(12),
-    paddingTop: Platform.OS === 'ios' ? scale(12) : scale(16) + getSafeAreaTop(),
+    paddingVertical: verticalScale(12),
+    paddingTop: Platform.OS === 'ios' ? verticalScale(12) : verticalScale(16) + getSafeAreaTop(),
   },
   headerButton: {
     width: scale(36),
-    height: scale(36),
+    height: verticalScale(36),
     backgroundColor: 'rgba(255,255,255,0.2)',
     borderRadius: scale(18),
     justifyContent: 'center',
@@ -673,7 +673,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingBottom: getSafeAreaBottom() + BOTTOM_NAV_HEIGHT + scale(20),
+    paddingBottom: getSafeAreaBottom() + BOTTOM_NAV_HEIGHT + verticalScale(20),
   },
   centerContainer: {
     flex: 1,
@@ -693,7 +693,7 @@ const styles = StyleSheet.create({
     elevation: 5,
   },
   loadingText: {
-    marginTop: scale(15),
+    marginTop: verticalScale(15),
     fontSize: scale(16),
     color: '#666666',
   },
@@ -710,18 +710,18 @@ const styles = StyleSheet.create({
   },
   errorEmoji: {
     fontSize: scale(50),
-    marginBottom: scale(15),
+    marginBottom: verticalScale(15),
   },
   errorText: {
     fontSize: scale(16),
     color: '#2C2C2C',
-    marginBottom: scale(20),
+    marginBottom: verticalScale(20),
     textAlign: 'center',
   },
   retryButton: {
     backgroundColor: '#6B4423',
     paddingHorizontal: scale(25),
-    paddingVertical: scale(12),
+    paddingVertical: verticalScale(12),
     borderRadius: scale(20),
   },
   retryButtonText: {
@@ -743,11 +743,11 @@ const styles = StyleSheet.create({
   },
   avatar: {
     width: scale(80),
-    height: scale(80),
+    height: verticalScale(80),
     borderRadius: scale(40),
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: scale(12),
+    marginBottom: verticalScale(12),
   },
   avatarText: {
     fontSize: scale(30),
@@ -758,16 +758,16 @@ const styles = StyleSheet.create({
     fontSize: scale(20),
     fontWeight: '700',
     color: '#2C2C2C',
-    marginBottom: scale(4),
+    marginBottom: verticalScale(4),
   },
   profileEmail: {
     fontSize: scale(14),
     color: '#666666',
-    marginBottom: scale(12),
+    marginBottom: verticalScale(12),
   },
   levelBadge: {
     paddingHorizontal: scale(16),
-    paddingVertical: scale(8),
+    paddingVertical: verticalScale(8),
     borderRadius: scale(20),
   },
   levelBadgeText: {
@@ -777,14 +777,14 @@ const styles = StyleSheet.create({
   },
   tasteProfileWrapper: {
     width: '100%',
-    marginTop: scale(16),
+    marginTop: verticalScale(16),
     alignItems: 'center',
   },
   quickActions: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginHorizontal: scale(16),
-    marginBottom: scale(16),
+    marginBottom: verticalScale(16),
     gap: scale(10),
   },
   actionButton: {
@@ -803,12 +803,12 @@ const styles = StyleSheet.create({
   },
   actionIcon: {
     width: scale(40),
-    height: scale(40),
+    height: verticalScale(40),
     backgroundColor: 'rgba(107, 68, 35, 0.1)',
     borderRadius: scale(12),
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: scale(8),
+    marginBottom: verticalScale(8),
   },
   actionIconPrimary: {
     backgroundColor: 'rgba(255,255,255,0.2)',
@@ -826,7 +826,7 @@ const styles = StyleSheet.create({
   },
   section: {
     marginHorizontal: scale(16),
-    marginBottom: scale(16),
+    marginBottom: verticalScale(16),
   },
   sectionCard: {
     backgroundColor: 'white',
@@ -842,12 +842,12 @@ const styles = StyleSheet.create({
     fontSize: scale(16),
     fontWeight: '700',
     color: '#2C2C2C',
-    marginBottom: scale(12),
+    marginBottom: verticalScale(12),
   },
   sectionDescription: {
     fontSize: scale(12),
     color: '#6B6B6B',
-    marginBottom: scale(12),
+    marginBottom: verticalScale(12),
   },
   statsGrid: {
     flexDirection: 'row',
@@ -863,13 +863,13 @@ const styles = StyleSheet.create({
   },
   statEmoji: {
     fontSize: scale(20),
-    marginBottom: scale(4),
+    marginBottom: verticalScale(4),
   },
   statValue: {
     fontSize: scale(14),
     fontWeight: '700',
     color: '#6B4423',
-    marginBottom: scale(2),
+    marginBottom: verticalScale(2),
   },
   statLabel: {
     fontSize: scale(10),
@@ -883,7 +883,7 @@ const styles = StyleSheet.create({
   },
   refreshButton: {
     width: scale(30),
-    height: scale(30),
+    height: verticalScale(30),
     backgroundColor: colors.background,
     borderRadius: scale(15),
     justifyContent: 'center',
@@ -900,9 +900,9 @@ const styles = StyleSheet.create({
   dataButton: {
     backgroundColor: '#6B4423',
     borderRadius: scale(12),
-    paddingVertical: scale(12),
+    paddingVertical: verticalScale(12),
     alignItems: 'center',
-    marginBottom: scale(10),
+    marginBottom: verticalScale(10),
   },
   deleteButton: {
     backgroundColor: '#C62828',
@@ -918,18 +918,18 @@ const styles = StyleSheet.create({
   dataConsentHint: {
     fontSize: scale(11),
     color: '#8A8A8A',
-    marginTop: scale(8),
+    marginTop: verticalScale(8),
   },
   tipText: {
     fontSize: scale(13),
-    lineHeight: scale(18),
+    lineHeight: verticalScale(18),
     color: 'white',
-    marginTop: scale(8),
+    marginTop: verticalScale(8),
   },
   footer: {
     alignItems: 'center',
-    paddingVertical: scale(16),
-    marginBottom: scale(20),
+    paddingVertical: verticalScale(16),
+    marginBottom: verticalScale(20),
   },
   footerText: {
     fontSize: scale(12),

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -1,5 +1,6 @@
 // HomeScreen.styles.ts
 import { StyleSheet, Platform } from 'react-native';
+import { scale, verticalScale } from '../../theme/responsive';
 
 const colors = {
   primary: '#6B4423',
@@ -31,9 +32,9 @@ export const homeStyles = () => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      paddingHorizontal: 20,
-      paddingVertical: 8,
-      paddingTop: Platform.OS === 'ios' ? 44 : 8,
+      paddingHorizontal: scale(20),
+      paddingVertical: verticalScale(8),
+      paddingTop: Platform.OS === 'ios' ? verticalScale(44) : verticalScale(8),
     },
     statusTime: {
       color: 'white',
@@ -51,8 +52,8 @@ export const homeStyles = () => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      paddingHorizontal: 20,
-      paddingVertical: 16,
+      paddingHorizontal: scale(20),
+      paddingVertical: verticalScale(16),
       shadowColor: '#000',
       shadowOffset: { width: 0, height: 2 },
       shadowOpacity: 0.1,
@@ -100,7 +101,7 @@ export const homeStyles = () => {
     },
     notificationBadge: {
       position: 'absolute',
-      top: -2,
+      top: verticalScale(-2),
       right: -2,
       width: 18,
       height: 18,
@@ -154,13 +155,13 @@ export const homeStyles = () => {
       color: 'white',
       fontSize: 14,
       opacity: 0.9,
-      marginBottom: 4,
+      marginBottom: verticalScale(4),
     },
     welcomeName: {
       color: 'white',
       fontSize: 24,
       fontWeight: '700',
-      marginBottom: 8,
+      marginBottom: verticalScale(8),
     },
     coffeeStatus: {
       flexDirection: 'row',
@@ -183,7 +184,7 @@ export const homeStyles = () => {
 
     statsSection: {
       marginHorizontal: 16,
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
       padding: 20,
       backgroundColor: colors.cardLight,
       borderRadius: 18,
@@ -194,12 +195,12 @@ export const homeStyles = () => {
       elevation: 5,
     },
     statsHeader: {
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
     },
     statsSubtitle: {
       color: colors.textSecondary,
       fontSize: 13,
-      marginTop: 4,
+      marginTop: verticalScale(4),
     },
     statsGrid: {
       flexDirection: 'row',
@@ -209,7 +210,7 @@ export const homeStyles = () => {
       flex: 1,
       backgroundColor: '#F3E4D7',
       borderRadius: 14,
-      paddingVertical: 16,
+      paddingVertical: verticalScale(16),
       paddingHorizontal: 12,
       justifyContent: 'center',
     },
@@ -219,7 +220,7 @@ export const homeStyles = () => {
       letterSpacing: 0.2,
     },
     statValue: {
-      marginTop: 8,
+      marginTop: verticalScale(8),
       fontSize: 22,
       fontWeight: '700',
       color: colors.primaryDark,
@@ -237,13 +238,13 @@ export const homeStyles = () => {
     statsErrorText: {
       color: colors.danger,
       fontSize: 13,
-      marginBottom: 12,
+      marginBottom: verticalScale(12),
     },
 
     // Weather Widget
     weatherWidget: {
       marginHorizontal: 16,
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
       padding: 16,
       backgroundColor: 'white',
       borderRadius: 16,
@@ -279,7 +280,7 @@ export const homeStyles = () => {
       fontSize: 12,
       color: colors.textSecondary,
       fontWeight: '500',
-      marginBottom: 2,
+      marginBottom: verticalScale(2),
     },
     weatherTemp: {
       fontSize: 16,
@@ -292,7 +293,7 @@ export const homeStyles = () => {
     suggestionLabel: {
       fontSize: 11,
       color: colors.textSecondary,
-      marginBottom: 4,
+      marginBottom: verticalScale(4),
     },
     suggestionName: {
       flexDirection: 'row',
@@ -307,7 +308,7 @@ export const homeStyles = () => {
 
     coffeeTip: {
       marginHorizontal: 16,
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
       padding: 16,
       backgroundColor: 'white',
       borderRadius: 16,
@@ -345,7 +346,7 @@ export const homeStyles = () => {
     tipRetry: {
       backgroundColor: colors.primary,
       paddingHorizontal: 16,
-      paddingVertical: 10,
+      paddingVertical: verticalScale(10),
       borderRadius: 12,
     },
     tipRetryText: {
@@ -354,7 +355,7 @@ export const homeStyles = () => {
       fontSize: 14,
     },
     savedTipsLink: {
-      marginTop: 12,
+      marginTop: verticalScale(12),
       alignSelf: 'center',
     },
     savedTipsLinkText: {
@@ -369,7 +370,7 @@ export const homeStyles = () => {
       flexDirection: 'row',
       flexWrap: 'wrap',
       marginHorizontal: 16,
-      marginBottom: 20,
+      marginBottom: verticalScale(20),
       gap: 12,
     },
     actionCard: {
@@ -394,7 +395,7 @@ export const homeStyles = () => {
       borderRadius: 16,
       justifyContent: 'center',
       alignItems: 'center',
-      marginBottom: 12,
+      marginBottom: verticalScale(12),
     },
     actionEmoji: {
       fontSize: 28,
@@ -403,7 +404,7 @@ export const homeStyles = () => {
       fontSize: 16,
       fontWeight: '600',
       color: colors.textPrimary,
-      marginBottom: 4,
+      marginBottom: verticalScale(4),
       textAlign: 'center',
     },
     actionDesc: {
@@ -418,7 +419,7 @@ export const homeStyles = () => {
 
     brewDiarySection: {
       marginHorizontal: 16,
-      marginBottom: 20,
+      marginBottom: verticalScale(20),
       padding: 20,
       backgroundColor: 'white',
       borderRadius: 20,
@@ -431,11 +432,11 @@ export const homeStyles = () => {
     brewDiaryActions: {
       flexDirection: 'row',
       gap: 12,
-      marginTop: 12,
+      marginTop: verticalScale(12),
     },
     brewDiaryButton: {
       flex: 1,
-      paddingVertical: 14,
+      paddingVertical: verticalScale(14),
       borderRadius: 14,
       borderWidth: 1,
       borderColor: colors.borderLight,
@@ -460,7 +461,7 @@ export const homeStyles = () => {
     // Coffee Inventory
     coffeeInventory: {
       marginHorizontal: 16,
-      marginBottom: 20,
+      marginBottom: verticalScale(20),
       padding: 20,
       backgroundColor: 'white',
       borderRadius: 20,
@@ -475,7 +476,7 @@ export const homeStyles = () => {
       fontSize: 16,
       fontWeight: '600',
       color: colors.textPrimary,
-      marginBottom: 8,
+      marginBottom: verticalScale(8),
     },
     inventoryCount: {
       fontSize: 32,
@@ -486,7 +487,7 @@ export const homeStyles = () => {
     // Taste Profile
     tasteProfile: {
       marginHorizontal: 16,
-      marginBottom: 20,
+      marginBottom: verticalScale(20),
       padding: 20,
       backgroundColor: 'white',
       borderRadius: 20,
@@ -500,7 +501,7 @@ export const homeStyles = () => {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
     },
     profileTitle: {
       fontSize: 16,
@@ -509,7 +510,7 @@ export const homeStyles = () => {
     },
     editBtn: {
       paddingHorizontal: 8,
-      paddingVertical: 4,
+      paddingVertical: verticalScale(4),
       backgroundColor: 'rgba(107, 68, 35, 0.1)',
       borderRadius: 8,
     },
@@ -524,12 +525,12 @@ export const homeStyles = () => {
     },
     tasteTag: {
       paddingHorizontal: 14,
-      paddingVertical: 8,
+      paddingVertical: verticalScale(8),
       backgroundColor: colors.bgLight,
       borderRadius: 20,
       borderWidth: 1,
       borderColor: colors.borderLight,
-      marginBottom: 8,
+      marginBottom: verticalScale(8),
       marginRight: 8,
     },
     tasteTagActive: {
@@ -547,17 +548,17 @@ export const homeStyles = () => {
     // Recommendations
     recommendations: {
       marginHorizontal: 16,
-      marginBottom: 100,
+      marginBottom: verticalScale(100),
     },
     recentScans: {
       marginHorizontal: 16,
-      marginBottom: 24,
+      marginBottom: verticalScale(24),
     },
     sectionHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      marginBottom: 16,
+      marginBottom: verticalScale(16),
     },
     sectionTitle: {
       fontSize: 18,
@@ -578,7 +579,7 @@ export const homeStyles = () => {
       color: colors.primary,
     },
     coffeeCards: {
-      paddingBottom: 8,
+      paddingBottom: verticalScale(8),
     },
     coffeeCard: {
       width: 150,
@@ -594,7 +595,7 @@ export const homeStyles = () => {
     },
     coffeeBadge: {
       position: 'absolute',
-      top: 8,
+      top: verticalScale(8),
       right: 8,
       width: 24,
       height: 24,
@@ -617,7 +618,7 @@ export const homeStyles = () => {
       justifyContent: 'center',
       alignItems: 'center',
       alignSelf: 'center',
-      marginBottom: 12,
+      marginBottom: verticalScale(12),
     },
     coffeeEmoji: {
       fontSize: 36,
@@ -626,20 +627,20 @@ export const homeStyles = () => {
       fontSize: 14,
       fontWeight: '600',
       color: colors.textPrimary,
-      marginBottom: 4,
+      marginBottom: verticalScale(4),
       textAlign: 'center',
     },
     coffeeOrigin: {
       fontSize: 11,
       color: colors.textSecondary,
       textAlign: 'center',
-      marginBottom: 8,
+      marginBottom: verticalScale(8),
     },
     coffeeMatch: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
-      paddingTop: 8,
+      paddingTop: verticalScale(8),
       borderTopWidth: 1,
       borderTopColor: colors.borderLight,
     },

--- a/src/components/styles/UserProfile.styles.ts
+++ b/src/components/styles/UserProfile.styles.ts
@@ -1,5 +1,8 @@
 // UserProfile.styles.ts
-import { StyleSheet, Platform } from 'react-native';
+import { StyleSheet, Platform, Dimensions } from 'react-native';
+import { scale, verticalScale } from '../../theme/responsive';
+
+const { width } = Dimensions.get('window');
 
 const colors = {
     primary: '#6B4423',
@@ -31,9 +34,9 @@ export const userProfileStyles = () => {
             flexDirection: 'row',
             justifyContent: 'space-between',
             alignItems: 'center',
-            paddingHorizontal: 20,
-            paddingVertical: 16,
-            paddingTop: Platform.OS === 'ios' ? 50 : 16,
+            paddingHorizontal: scale(20),
+            paddingVertical: verticalScale(16),
+            paddingTop: Platform.OS === 'ios' ? verticalScale(50) : verticalScale(16),
             shadowColor: '#000',
             shadowOffset: { width: 0, height: 2 },
             shadowOpacity: 0.1,
@@ -84,7 +87,7 @@ export const userProfileStyles = () => {
             width: width * 0.8,
         },
         loadingText: {
-            marginTop: 15,
+            marginTop: verticalScale(15),
             fontSize: 16,
             color: colors.textSecondary,
             fontWeight: '500',
@@ -110,19 +113,19 @@ export const userProfileStyles = () => {
         },
         errorEmoji: {
             fontSize: 60,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
         },
         errorText: {
             fontSize: 18,
             color: colors.textPrimary,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
             textAlign: 'center',
             fontWeight: '600',
         },
         retryButton: {
             backgroundColor: colors.primary,
             paddingHorizontal: 30,
-            paddingVertical: 14,
+            paddingVertical: verticalScale(14),
             borderRadius: 25,
             shadowColor: colors.primary,
             shadowOffset: { width: 0, height: 4 },
@@ -160,7 +163,7 @@ export const userProfileStyles = () => {
             borderRadius: 50,
             justifyContent: 'center',
             alignItems: 'center',
-            marginBottom: 16,
+            marginBottom: verticalScale(16),
             shadowColor: '#000',
             shadowOffset: { width: 0, height: 4 },
             shadowOpacity: 0.2,
@@ -176,18 +179,18 @@ export const userProfileStyles = () => {
             fontSize: 24,
             fontWeight: '700',
             color: colors.textPrimary,
-            marginBottom: 6,
+            marginBottom: verticalScale(6),
             textAlign: 'center',
         },
         profileEmail: {
             fontSize: 16,
             color: colors.textSecondary,
-            marginBottom: 16,
+            marginBottom: verticalScale(16),
             textAlign: 'center',
         },
         levelBadge: {
             paddingHorizontal: 20,
-            paddingVertical: 10,
+            paddingVertical: verticalScale(10),
             borderRadius: 25,
             shadowColor: '#000',
             shadowOffset: { width: 0, height: 2 },
@@ -206,7 +209,7 @@ export const userProfileStyles = () => {
         quickActions: {
             flexDirection: 'row',
             marginHorizontal: 16,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
             gap: 12,
         },
         actionButton: {
@@ -236,7 +239,7 @@ export const userProfileStyles = () => {
             borderRadius: 16,
             justifyContent: 'center',
             alignItems: 'center',
-            marginBottom: 12,
+            marginBottom: verticalScale(12),
         },
         actionIconPrimary: {
             backgroundColor: 'rgba(255,255,255,0.2)',
@@ -257,7 +260,7 @@ export const userProfileStyles = () => {
         // Stats Section
         statsSection: {
             marginHorizontal: 16,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
         },
         sectionCard: {
             backgroundColor: 'white',
@@ -273,7 +276,7 @@ export const userProfileStyles = () => {
             fontSize: 18,
             fontWeight: '700',
             color: colors.textPrimary,
-            marginBottom: 16,
+            marginBottom: verticalScale(16),
         },
         statsGrid: {
             flexDirection: 'row',
@@ -293,13 +296,13 @@ export const userProfileStyles = () => {
         },
         statEmoji: {
             fontSize: 24,
-            marginBottom: 8,
+            marginBottom: verticalScale(8),
         },
         statValue: {
             fontSize: 16,
             fontWeight: '700',
             color: colors.primary,
-            marginBottom: 4,
+            marginBottom: verticalScale(4),
             textAlign: 'center',
         },
         statLabel: {
@@ -312,13 +315,13 @@ export const userProfileStyles = () => {
         // Recommendation Section
         recommendationSection: {
             marginHorizontal: 16,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
         },
         recommendationHeader: {
             flexDirection: 'row',
             justifyContent: 'space-between',
             alignItems: 'center',
-            marginBottom: 16,
+            marginBottom: verticalScale(16),
         },
         refreshButton: {
             width: 36,
@@ -354,7 +357,7 @@ export const userProfileStyles = () => {
         // Tips Section
         tipsSection: {
             marginHorizontal: 16,
-            marginBottom: 20,
+            marginBottom: verticalScale(20),
         },
         tipCard: {
             backgroundColor: colors.accent,
@@ -376,8 +379,8 @@ export const userProfileStyles = () => {
         // Footer
         footer: {
             marginHorizontal: 16,
-            marginBottom: 30,
-            paddingVertical: 20,
+            marginBottom: verticalScale(30),
+            paddingVertical: verticalScale(20),
             alignItems: 'center',
         },
         footerText: {

--- a/src/components/utils/safeArea.ts
+++ b/src/components/utils/safeArea.ts
@@ -54,3 +54,15 @@ export const scale = (size: number) => {
   const finalScale = Math.min(Math.max(scaleFactor, minScale), maxScale);
   return Math.round(size * finalScale);
 };
+
+export const verticalScale = (size: number) => {
+  const { height } = Dimensions.get('window');
+  const baseHeight = 812; // Reference height (iPhone 11 Pro)
+  const scaleFactor = height / baseHeight;
+
+  const maxScale = 1.3;
+  const minScale = 0.85;
+
+  const finalScale = Math.min(Math.max(scaleFactor, minScale), maxScale);
+  return Math.round(size * finalScale);
+};


### PR DESCRIPTION
## Summary
- import `verticalScale` alongside `scale` in the HomeScreen and UserProfile style modules and shift vertical paddings/margins to the height-aware helper
- expose a shared `verticalScale` helper in the safe area utilities and consume it from EditPreferences styles for consistent vertical spacing
- update inline UserProfile styles to respect screen height via `verticalScale` for headers, cards, and buttons

## Testing
- npm test -- --runInBand *(fails: jest not available before dependency install)*
- npm install *(fails: registry returned 403 for @invertase/react-native-apple-authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c8d1f398832a83df523cf79f9cdc