### PR TITLE
Add AI-driven taste radar to home screen

### DIFF
--- a/src/components/CoffeePreferenceForm.tsx
+++ b/src/components/CoffeePreferenceForm.tsx
@@ -479,6 +479,7 @@ Píš jednoducho, zrozumiteľne a priateľsky v slovenčine.
     const preferences: any = {
       intensity,
       sweetness,
+      sugar: sweetness,
       milk,
       temperature,
     };

--- a/src/components/TasteProfileRadarCard.tsx
+++ b/src/components/TasteProfileRadarCard.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo } from 'react';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import Svg, { Circle, Defs, Line, LinearGradient, Polygon, Stop, Text as SvgText } from 'react-native-svg';
+import { homeStyles } from './styles/HomeScreen.styles';
+import { TasteRadarScores } from '../utils/tasteProfile';
+
+interface TasteProfileRadarCardProps {
+  scores: TasteRadarScores | null;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  onEdit: () => void;
+}
+
+type AxisKey = keyof TasteRadarScores;
+
+const axes: { key: AxisKey; label: string }[] = [
+  { key: 'acidity', label: 'Acidity' },
+  { key: 'sweetness', label: 'Sweet' },
+  { key: 'body', label: 'Body' },
+  { key: 'bitterness', label: 'Bitter' },
+  { key: 'aroma', label: 'Aroma' },
+  { key: 'fruitiness', label: 'Fruity' },
+];
+
+const size = 220;
+const center = size / 2;
+const radius = size / 2 - 18;
+
+const TasteProfileRadarCard: React.FC<TasteProfileRadarCardProps> = ({
+  scores,
+  loading = false,
+  error,
+  onRetry,
+  onEdit,
+}) => {
+  const styles = homeStyles();
+
+  const gridPolygons = useMemo(() => {
+    return [2, 4, 6, 8, 10].map((level) => buildPolygonPoints(level / 10));
+  }, []);
+
+  const dataPolygon = useMemo(() => {
+    if (!scores) {
+      return '';
+    }
+    return buildPolygonPointsFromScores(scores);
+  }, [scores]);
+
+  const dataDots = useMemo(() => {
+    if (!scores) {
+      return [];
+    }
+    return axes.map((axis, index) => ({
+      key: axis.key,
+      position: pointForValue(scores[axis.key], index, axes.length),
+      value: scores[axis.key],
+    }));
+  }, [scores]);
+
+  return (
+    <View style={styles.tasteProfileCard}>
+      <View style={styles.tasteProfileHeader}>
+        <View>
+          <Text style={styles.tasteProfileTitle}>Tvoj chuťový profil</Text>
+          <Text style={styles.tasteProfileSubtitle}>AI vyhodnotenie na základe tvojich preferencií</Text>
+        </View>
+        <TouchableOpacity style={styles.tasteProfileEditButton} onPress={onEdit} activeOpacity={0.85}>
+          <Text style={styles.tasteProfileEditButtonText}>Upraviť</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <View style={styles.tasteProfileLoading}>
+          <ActivityIndicator color="#D97706" />
+          <Text style={styles.tasteProfileLoadingText}>Načítavam chuťový profil...</Text>
+        </View>
+      ) : error && !scores ? (
+        <View style={styles.tasteProfileError}>
+          <Text style={styles.tasteProfileErrorText}>{error}</Text>
+          {onRetry && (
+            <TouchableOpacity style={styles.tasteProfileRetryButton} onPress={onRetry} activeOpacity={0.85}>
+              <Text style={styles.tasteProfileRetryText}>Skúsiť znova</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      ) : !scores ? (
+        <View style={styles.tasteProfileEmpty}>
+          <Text style={styles.tasteProfileEmptyTitle}>Zatiaľ nemáme dáta</Text>
+          <Text style={styles.tasteProfileEmptyText}>
+            Vyplň dotazník preferencií a získaj personalizovaný chuťový profil.
+          </Text>
+          <TouchableOpacity style={styles.tasteProfileRetryButton} onPress={onEdit} activeOpacity={0.85}>
+            <Text style={styles.tasteProfileRetryText}>Vyplniť dotazník</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <View style={styles.tasteProfileChartContainer}>
+          <Svg width={size} height={size}>
+            <Defs>
+              <LinearGradient id="radar-bg" x1="0%" y1="0%" x2="0%" y2="100%">
+                <Stop offset="0%" stopColor="rgba(255, 215, 170, 0.35)" />
+                <Stop offset="100%" stopColor="rgba(255, 175, 110, 0.1)" />
+              </LinearGradient>
+              <LinearGradient id="radar-fill" x1="0%" y1="0%" x2="100%" y2="100%">
+                <Stop offset="0%" stopColor="rgba(234, 88, 12, 0.7)" />
+                <Stop offset="100%" stopColor="rgba(249, 115, 22, 0.45)" />
+              </LinearGradient>
+            </Defs>
+
+            <Polygon points={buildPolygonPoints(1)} fill="url(#radar-bg)" />
+
+            {gridPolygons.map((points, index) => (
+              <Polygon key={`grid-${index}`} points={points} fill="none" stroke="rgba(217, 119, 6, 0.18)" strokeWidth={1} />
+            ))}
+
+            {axes.map((axis, index) => {
+              const { x, y } = pointForValue(10, index, axes.length, radius);
+              const labelPosition = pointForValue(10.8, index, axes.length, radius);
+              return (
+                <React.Fragment key={axis.key}>
+                  <Line x1={center} y1={center} x2={x} y2={y} stroke="rgba(217, 119, 6, 0.25)" strokeWidth={1} />
+                  <SvgText
+                    x={labelPosition.x}
+                    y={labelPosition.y}
+                    fill="#8B5E34"
+                    fontSize={12}
+                    textAnchor="middle"
+                  >
+                    {axis.label}
+                  </SvgText>
+                </React.Fragment>
+              );
+            })}
+
+            <Polygon points={dataPolygon} fill="url(#radar-fill)" stroke="rgba(234, 88, 12, 0.85)" strokeWidth={2.5} />
+
+            {dataDots.map((dot) => (
+              <Circle key={dot.key} cx={dot.position.x} cy={dot.position.y} r={4.5} fill="#EA580C" stroke="#fff7ed" strokeWidth={2} />
+            ))}
+          </Svg>
+        </View>
+      )}
+    </View>
+  );
+};
+
+function buildPolygonPoints(scaleFactor: number): string {
+  return axes
+    .map((axis, index) => {
+      const { x, y } = pointForValue(10 * scaleFactor, index, axes.length);
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+function buildPolygonPointsFromScores(scores: TasteRadarScores): string {
+  return axes
+    .map((axis, index) => {
+      const value = scores[axis.key];
+      const { x, y } = pointForValue(value, index, axes.length);
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+function pointForValue(value: number, index: number, total: number, customRadius?: number) {
+  const angle = (Math.PI * 2 * index) / total - Math.PI / 2;
+  const r = (typeof customRadius === 'number' ? customRadius : radius) * (value / 10);
+  return {
+    x: center + r * Math.cos(angle),
+    y: center + r * Math.sin(angle),
+  };
+}
+
+export default TasteProfileRadarCard;

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -485,64 +485,94 @@ export const homeStyles = () => {
     },
 
     // Taste Profile
-    tasteProfile: {
+    tasteProfileCard: {
       marginHorizontal: 16,
       marginBottom: verticalScale(20),
       padding: 20,
-      backgroundColor: 'white',
-      borderRadius: 20,
+      backgroundColor: '#FFF7ED',
+      borderRadius: 22,
       shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
+      shadowOffset: { width: 0, height: 3 },
       shadowOpacity: 0.08,
-      shadowRadius: 8,
-      elevation: 4,
+      shadowRadius: 12,
+      elevation: 6,
     },
-    profileHeader: {
+    tasteProfileHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
       marginBottom: verticalScale(16),
     },
-    profileTitle: {
-      fontSize: 16,
+    tasteProfileTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: colors.textPrimary,
+      marginBottom: 4,
+    },
+    tasteProfileSubtitle: {
+      fontSize: 13,
+      color: '#9A6B3A',
+    },
+    tasteProfileEditButton: {
+      paddingHorizontal: 14,
+      paddingVertical: verticalScale(6),
+      backgroundColor: '#FDE5C3',
+      borderRadius: 18,
+    },
+    tasteProfileEditButtonText: {
+      color: '#B45309',
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    tasteProfileLoading: {
+      alignItems: 'center',
+      paddingVertical: verticalScale(24),
+      gap: 12,
+    },
+    tasteProfileLoadingText: {
+      color: '#9A6B3A',
+      fontSize: 13,
+    },
+    tasteProfileError: {
+      alignItems: 'center',
+      gap: 12,
+      paddingVertical: verticalScale(20),
+    },
+    tasteProfileErrorText: {
+      color: colors.danger,
+      textAlign: 'center',
+      fontSize: 13,
+    },
+    tasteProfileRetryButton: {
+      paddingHorizontal: 16,
+      paddingVertical: verticalScale(8),
+      backgroundColor: '#FDE5C3',
+      borderRadius: 18,
+    },
+    tasteProfileRetryText: {
+      color: '#B45309',
+      fontWeight: '600',
+      fontSize: 13,
+    },
+    tasteProfileEmpty: {
+      alignItems: 'center',
+      gap: 10,
+      paddingVertical: verticalScale(20),
+    },
+    tasteProfileEmptyTitle: {
+      fontSize: 15,
       fontWeight: '600',
       color: colors.textPrimary,
     },
-    editBtn: {
-      paddingHorizontal: 8,
-      paddingVertical: verticalScale(4),
-      backgroundColor: 'rgba(107, 68, 35, 0.1)',
-      borderRadius: 8,
-    },
-    editBtnText: {
-      fontSize: 12,
-      color: colors.primary,
-    },
-    tasteTags: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: 8,
-    },
-    tasteTag: {
-      paddingHorizontal: 14,
-      paddingVertical: verticalScale(8),
-      backgroundColor: colors.bgLight,
-      borderRadius: 20,
-      borderWidth: 1,
-      borderColor: colors.borderLight,
-      marginBottom: verticalScale(8),
-      marginRight: 8,
-    },
-    tasteTagActive: {
-      backgroundColor: colors.primary,
-      borderColor: colors.primary,
-    },
-    tasteTagText: {
+    tasteProfileEmptyText: {
       fontSize: 13,
-      color: colors.textPrimary,
+      color: '#9A6B3A',
+      textAlign: 'center',
+      lineHeight: 18,
     },
-    tasteTagTextActive: {
-      color: 'white',
+    tasteProfileChartContainer: {
+      alignItems: 'center',
+      justifyContent: 'center',
     },
 
     // Recommendations

--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -1,0 +1,373 @@
+import { UserTasteProfile } from '../types/Personalization';
+
+export interface CoffeePreferenceSnapshot {
+  intensity?: string | null;
+  roast?: string | null;
+  temperature?: string | null;
+  milk?: boolean | null;
+  sugar?: string | number | null;
+  acidity?: string | null;
+  body?: string | null;
+  preferredDrinks: string[];
+  flavorNotes: string[];
+  experienceLevel?: string | null;
+}
+
+export interface TasteRadarScores {
+  acidity: number;
+  sweetness: number;
+  body: number;
+  bitterness: number;
+  aroma: number;
+  fruitiness: number;
+}
+
+interface TasteRadarSources {
+  profile?: UserTasteProfile | null;
+  preferences?: CoffeePreferenceSnapshot | null;
+}
+
+const DEFAULT_SCORE = 5;
+
+const fruitKeywords = ['fruit', 'fruity', 'berry', 'berries', 'citrus', 'orange', 'lemon', 'lime', 'apple', 'pear', 'peach', 'stone', 'wine'];
+const warmAromaKeywords = ['chocolate', 'cocoa', 'nut', 'nutty', 'caramel', 'spice', 'spicy', 'vanilla', 'floral', 'flower'];
+
+function clamp(value: number, min = 0, max = 10): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function safeNumber(value: unknown, fallback: number = DEFAULT_SCORE): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return clamp(value);
+  }
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return clamp(parsed);
+  }
+  return fallback;
+}
+
+function blend(current: number, incoming: number | null, weight: number = 1): number {
+  if (incoming === null) {
+    return clamp(current);
+  }
+  const mixed = (current * weight + incoming) / (weight + 1);
+  return clamp(Number(mixed.toFixed(1)));
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map(String);
+      }
+    } catch (error) {
+      // ignore JSON parse error, fallback to splitting by comma
+    }
+    return trimmed
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>);
+  }
+  return [];
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return null;
+    }
+    if (['true', '1', 'yes', 'áno', 'ano'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'nie'].includes(normalized)) {
+      return false;
+    }
+  }
+  return null;
+}
+
+export function normalizeCoffeePreferenceSnapshot(raw: any): CoffeePreferenceSnapshot | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const snapshot: CoffeePreferenceSnapshot = {
+    intensity: typeof raw.intensity === 'string' ? raw.intensity : typeof raw.strength === 'string' ? raw.strength : null,
+    roast: typeof raw.roast === 'string' ? raw.roast : null,
+    temperature: typeof raw.temperature === 'string' ? raw.temperature : null,
+    milk: parseBoolean(raw.milk),
+    sugar: raw.sugar ?? raw.sweetness ?? null,
+    acidity: typeof raw.acidity === 'string' ? raw.acidity : typeof raw.acidity_preference === 'string' ? raw.acidity_preference : null,
+    body: typeof raw.body === 'string' ? raw.body : typeof raw.body_preference === 'string' ? raw.body_preference : null,
+    preferredDrinks: parseStringArray(raw.preferred_drinks ?? raw.preferredDrinks),
+    flavorNotes: parseStringArray(raw.flavor_notes ?? raw.flavorNotes),
+    experienceLevel: typeof raw.experience_level === 'string' ? raw.experience_level : typeof raw.experienceLevel === 'string' ? raw.experienceLevel : null,
+  };
+
+  return snapshot;
+}
+
+function mapSweetness(input: CoffeePreferenceSnapshot['sugar']): number | null {
+  if (input === null || input === undefined) {
+    return null;
+  }
+
+  if (typeof input === 'number') {
+    return clamp(input);
+  }
+
+  const normalized = input.trim().toLowerCase();
+  switch (normalized) {
+    case 'none':
+    case 'bez':
+    case 'zero':
+      return 1.5;
+    case 'little':
+    case 'low':
+    case 'malo':
+    case 'málo':
+      return 3.5;
+    case 'medium':
+    case 'stredne':
+    case 'stredná':
+    case 'balanced':
+      return 5.8;
+    case 'sweet':
+    case 'high':
+    case 'vela':
+    case 'veľa':
+      return 8.4;
+    default:
+      return null;
+  }
+}
+
+function mapAcidity(preferences: CoffeePreferenceSnapshot): number | null {
+  if (preferences.acidity) {
+    switch (preferences.acidity) {
+      case 'low':
+      case 'nízka':
+        return 3.5;
+      case 'medium':
+      case 'stredná':
+        return 5.5;
+      case 'high':
+      case 'vysoká':
+        return 7.8;
+      default:
+        break;
+    }
+  }
+
+  if (preferences.roast) {
+    switch (preferences.roast) {
+      case 'light':
+        return 7.2;
+      case 'medium':
+        return 5.4;
+      case 'dark':
+        return 3.6;
+      default:
+        break;
+    }
+  }
+
+  return null;
+}
+
+function mapBody(preferences: CoffeePreferenceSnapshot): number | null {
+  if (preferences.body) {
+    switch (preferences.body) {
+      case 'light':
+        return 4.2;
+      case 'medium':
+        return 6;
+      case 'full':
+        return 8.2;
+      default:
+        break;
+    }
+  }
+
+  if (preferences.intensity) {
+    switch (preferences.intensity) {
+      case 'light':
+        return 4.5;
+      case 'medium':
+        return 6.2;
+      case 'strong':
+        return 8;
+      default:
+        break;
+    }
+  }
+
+  return null;
+}
+
+function mapBitterness(preferences: CoffeePreferenceSnapshot): number | null {
+  let base: number | null = null;
+
+  if (preferences.roast) {
+    switch (preferences.roast) {
+      case 'light':
+        base = 4.2;
+        break;
+      case 'medium':
+        base = 5.8;
+        break;
+      case 'dark':
+        base = 7.6;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (preferences.intensity) {
+    const intensityBoost = preferences.intensity === 'strong' ? 1.4 : preferences.intensity === 'medium' ? 0.6 : -0.4;
+    base = (base ?? DEFAULT_SCORE) + intensityBoost;
+  }
+
+  const sweetnessImpact = mapSweetness(preferences.sugar);
+  if (sweetnessImpact !== null) {
+    base = (base ?? DEFAULT_SCORE) - (sweetnessImpact - DEFAULT_SCORE) * 0.5;
+  }
+
+  if (preferences.milk === true) {
+    base = (base ?? DEFAULT_SCORE) - 0.8;
+  }
+
+  return base === null ? null : clamp(Number(base.toFixed(1)));
+}
+
+function evaluateFlavorNotes(notes: string[]): { aroma: number | null; fruitiness: number | null } {
+  if (!notes.length) {
+    return { aroma: null, fruitiness: null };
+  }
+
+  const unique = Array.from(new Set(notes.map(note => note.toLowerCase())));
+  const aromaticCount = unique.filter(note => warmAromaKeywords.some(keyword => note.includes(keyword))).length;
+  const fruityCount = unique.filter(note => fruitKeywords.some(keyword => note.includes(keyword))).length;
+
+  const aromaScore = aromaticCount > 0 ? clamp(4.5 + aromaticCount * 1.2) : clamp(4 + unique.length * 0.8);
+  const fruitScore = fruityCount > 0 ? clamp(4.8 + fruityCount * 1.6) : fruityCount === 0 ? null : clamp(4 + fruityCount * 1.2);
+
+  return {
+    aroma: Number(aromaScore.toFixed(1)),
+    fruitiness: fruitScore === null ? null : Number(fruitScore.toFixed(1)),
+  };
+}
+
+function mergeFruitiness(existing: number, incoming: number | null, notes: string[]): number {
+  if (incoming !== null) {
+    return blend(existing, incoming);
+  }
+
+  if (notes.some(note => fruitKeywords.some(keyword => note.toLowerCase().includes(keyword)))) {
+    return blend(existing, 7.2);
+  }
+
+  return clamp(existing);
+}
+
+export function buildTasteRadarScores({ profile, preferences }: TasteRadarSources): TasteRadarScores | null {
+  if (!profile && !preferences) {
+    return null;
+  }
+
+  const base: TasteRadarScores = {
+    acidity: DEFAULT_SCORE,
+    sweetness: DEFAULT_SCORE,
+    body: DEFAULT_SCORE,
+    bitterness: DEFAULT_SCORE,
+    aroma: DEFAULT_SCORE,
+    fruitiness: DEFAULT_SCORE,
+  };
+
+  if (profile) {
+    base.acidity = safeNumber(profile.preferences?.acidity, DEFAULT_SCORE);
+    base.sweetness = safeNumber(profile.preferences?.sweetness, DEFAULT_SCORE);
+    base.body = safeNumber(profile.preferences?.body, DEFAULT_SCORE);
+    base.bitterness = safeNumber(profile.preferences?.bitterness, DEFAULT_SCORE);
+
+    const flavorValues = profile.flavorNotes ? Object.values(profile.flavorNotes).map(value => safeNumber(value, DEFAULT_SCORE)) : [];
+    if (flavorValues.length > 0) {
+      const average = flavorValues.reduce((sum, value) => sum + value, 0) / flavorValues.length;
+      base.aroma = clamp(Number(average.toFixed(1)));
+    }
+    const fruitVector = profile.flavorNotes?.fruity;
+    if (typeof fruitVector === 'number') {
+      base.fruitiness = clamp(Number(fruitVector.toFixed(1)));
+    }
+  }
+
+  if (preferences) {
+    const sweetnessScore = mapSweetness(preferences.sugar);
+    base.sweetness = sweetnessScore === null ? base.sweetness : blend(base.sweetness, sweetnessScore, 2);
+
+    const acidityScore = mapAcidity(preferences);
+    base.acidity = acidityScore === null ? base.acidity : blend(base.acidity, acidityScore, 2);
+
+    const bodyScore = mapBody(preferences);
+    base.body = bodyScore === null ? base.body : blend(base.body, bodyScore, 2);
+
+    const bitternessScore = mapBitterness(preferences);
+    base.bitterness = bitternessScore === null ? base.bitterness : blend(base.bitterness, bitternessScore, 1.5);
+
+    const { aroma, fruitiness } = evaluateFlavorNotes(preferences.flavorNotes);
+    base.aroma = aroma === null ? blend(base.aroma, clamp(DEFAULT_SCORE + preferences.flavorNotes.length * 0.6)) : blend(base.aroma, aroma, 1.5);
+    base.fruitiness = mergeFruitiness(base.fruitiness, fruitiness, preferences.flavorNotes);
+
+    if (preferences.preferredDrinks.includes('espresso') || preferences.preferredDrinks.includes('ristretto')) {
+      base.body = blend(base.body, clamp(base.body + 1.2));
+      base.bitterness = blend(base.bitterness, clamp(base.bitterness + 0.8));
+    }
+
+    if (preferences.preferredDrinks.includes('latte') || preferences.preferredDrinks.includes('flatwhite')) {
+      base.body = blend(base.body, clamp(base.body - 0.6));
+      base.sweetness = blend(base.sweetness, clamp(base.sweetness + 0.5));
+    }
+
+    if (preferences.milk === true) {
+      base.bitterness = blend(base.bitterness, clamp(base.bitterness - 0.6));
+      base.body = blend(base.body, clamp(base.body + 0.4));
+    }
+
+    if (preferences.temperature === 'iced') {
+      base.acidity = blend(base.acidity, clamp(base.acidity - 0.5));
+      base.sweetness = blend(base.sweetness, clamp(base.sweetness + 0.3));
+    }
+  }
+
+  return {
+    acidity: clamp(Number(base.acidity.toFixed(1))),
+    sweetness: clamp(Number(base.sweetness.toFixed(1))),
+    body: clamp(Number(base.body.toFixed(1))),
+    bitterness: clamp(Number(base.bitterness.toFixed(1))),
+    aroma: clamp(Number(base.aroma.toFixed(1))),
+    fruitiness: clamp(Number(base.fruitiness.toFixed(1))),
+  };
+}


### PR DESCRIPTION
## Summary
- replace the home screen taste tag widget with a new AI-evaluated radar chart card
- derive radar metrics from personalization data and saved questionnaire preferences through a shared utility
- persist the questionnaire sweetness selection as the sugar preference for downstream processing

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c7161f4832aae29cd6fff2a3601