### PR TITLE
Adjust home screen layout to fill the viewport

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -13,6 +13,8 @@ import {
   RefreshControl,
   Alert,
   ActivityIndicator,
+  SafeAreaView,
+  StatusBar,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import auth from '@react-native-firebase/auth';
@@ -394,16 +396,9 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
 
   return (
     <LinearGradient colors={BACKGROUND_GRADIENT} style={styles.gradientBackground}>
-      <View style={styles.phoneShell}>
-        <View style={styles.innerContainer}>
-          <View style={styles.statusBar}>
-            <Text style={styles.statusTime}>9:41</Text>
-            <View style={styles.statusIcons}>
-              <Text>📶 📶 🔋</Text>
-            </View>
-          </View>
-
-          <View style={styles.appHeader}>
+      <StatusBar barStyle="dark-content" backgroundColor={BACKGROUND_GRADIENT[0]} />
+      <SafeAreaView style={styles.container}>
+        <View style={styles.appHeader}>
             <View style={styles.logoSection}>
               <View style={styles.logoIconWrapper}>
                 <Text style={styles.logoIcon}>☕</Text>
@@ -427,14 +422,14 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
             </View>
           </View>
 
-          <ScrollView
-            style={styles.mainContent}
-            contentContainerStyle={styles.scrollContent}
-            refreshControl={
-              <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-            }
-            showsVerticalScrollIndicator={false}
-          >
+        <ScrollView
+          style={styles.mainContent}
+          contentContainerStyle={styles.scrollContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          showsVerticalScrollIndicator={false}
+        >
             {ritualRecommendation ? (
               <View style={styles.ritualWrapper}>
                 <DailyRitualCard recommendation={ritualRecommendation} />
@@ -726,26 +721,25 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
                 )}
               </View>
             </View>
-          </ScrollView>
+        </ScrollView>
 
-          <TouchableOpacity
-            style={styles.fab}
-            onPress={onLogBrewPress}
-            activeOpacity={0.85}
-          >
-            <Text style={styles.fabIcon}>➕</Text>
-          </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.fab}
+          onPress={onLogBrewPress}
+          activeOpacity={0.85}
+        >
+          <Text style={styles.fabIcon}>➕</Text>
+        </TouchableOpacity>
 
-          <BottomNav
-            active="home"
-            onHomePress={onHomePress}
-            onDiscoverPress={onDiscoverPress}
-            onRecipesPress={onRecipesPress}
-            onFavoritesPress={onFavoritesPress}
-            onProfilePress={onProfilePress}
-          />
-        </View>
-      </View>
+        <BottomNav
+          active="home"
+          onHomePress={onHomePress}
+          onDiscoverPress={onDiscoverPress}
+          onRecipesPress={onRecipesPress}
+          onFavoritesPress={onFavoritesPress}
+          onProfilePress={onProfilePress}
+        />
+      </SafeAreaView>
     </LinearGradient>
   );
 };

--- a/src/components/styles/HomeScreen.styles.ts
+++ b/src/components/styles/HomeScreen.styles.ts
@@ -24,58 +24,16 @@ const palette = {
   borderGlass: 'rgba(139, 111, 71, 0.12)',
 };
 
-const shadow = {
-  shadowColor: '#000',
-  shadowOffset: { width: 0, height: 12 },
-  shadowOpacity: 0.12,
-  shadowRadius: 24,
-  elevation: 12,
-};
-
 export const homeStyles = () =>
   StyleSheet.create({
     container: {
       flex: 1,
       backgroundColor: palette.surfacePrimary,
+      position: 'relative',
     },
     gradientBackground: {
       flex: 1,
-      paddingHorizontal: scale(12),
-      paddingTop: Platform.OS === 'ios' ? verticalScale(24) : verticalScale(12),
       paddingBottom: verticalScale(12),
-    },
-    phoneShell: {
-      flex: 1,
-      backgroundColor: palette.surfacePrimary,
-      borderRadius: 40,
-      overflow: 'hidden',
-      ...shadow,
-    },
-    innerContainer: {
-      flex: 1,
-      backgroundColor: palette.surfacePrimary,
-      borderRadius: 36,
-      overflow: 'hidden',
-      position: 'relative',
-    },
-
-    // Status Bar
-    statusBar: {
-      height: verticalScale(44),
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingHorizontal: scale(24),
-      paddingTop: Platform.OS === 'ios' ? verticalScale(12) : verticalScale(8),
-    },
-    statusTime: {
-      color: palette.textPrimary,
-      fontSize: 14,
-      fontWeight: '600',
-    },
-    statusIcons: {
-      flexDirection: 'row',
-      alignItems: 'center',
     },
 
     // App Header


### PR DESCRIPTION
## Summary
- replace the simulated phone shell wrapper with a SafeAreaView so the home screen content spans the device display
- simplify the gradient background styling and remove the faux status bar for a cleaner, full-bleed layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42eb7edfc832a8660e0260728cb8c