### PR TITLE
Make coffee scanner layout full screen

### DIFF
--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -1,864 +1,719 @@
-// ProfessionalOCRScanner.styles.ts - Coffee-themed Elegant Design
-import { StyleSheet, Dimensions, Platform } from 'react-native';
+// ProfessionalOCRScanner.styles.ts - BrewMate Material-inspired design
+import { StyleSheet, Platform } from 'react-native';
 
-const { width, height } = Dimensions.get('window');
-
-const colors = {
-  // Coffee-inspired palette
-  primary: '#8B6F47',  // Coffee brown
-  primaryLight: '#A68B5B',  // Light coffee
-  primaryDark: '#6F5339',  // Dark coffee
-
-  accent: '#D4A574',  // Cream/Latte
-  accentLight: '#F5E6D3',  // Light cream
-  accentDark: '#B8935F',  // Dark cream
-
-  // Backgrounds
-  background: '#FFFFFF',
-  backgroundSecondary: '#FAF8F5',  // Very light coffee tint
-  backgroundTertiary: '#F5F2ED',  // Slightly darker coffee tint
+const palette = {
+  primary: '#6B4423',
+  primaryDark: '#4A2F18',
+  accent: '#FF8C42',
+  accentDark: '#D06020',
+  cream: '#F5E6D3',
+  background: '#FAF8F5',
   surface: '#FFFFFF',
-
-  // Text
-  textPrimary: '#2C2825',  // Almost black coffee
-  textSecondary: '#5C5248',  // Medium brown
-  textTertiary: '#8B7F72',  // Light brown
-  textLight: '#FFFFFF',
-
-  // Status
-  success: '#7CB342',  // Green coffee bean
-  warning: '#FFA726',  // Orange
-  danger: '#E57373',  // Soft red
-
-  // Borders & Shadows
-  border: '#E8E4DE',  // Coffee cream border
-  borderLight: '#F2EFE9',
-  shadow: 'rgba(139, 111, 71, 0.08)',  // Coffee-tinted shadow
+  surfaceElevated: '#FFF9F5',
+  textPrimary: '#2C1810',
+  textSecondary: '#5D4E37',
+  textTertiary: '#8B7355',
+  success: '#7FB069',
+  warning: '#FFA000',
+  danger: '#E84855',
+  border: '#E8DED4',
+  borderLight: '#F0E6DC',
+  shadow: 'rgba(107, 68, 35, 0.15)',
 };
 
-export const scannerStyles = (isDarkMode: boolean = false) => {
-  return StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
+const baseShadow = {
+  shadowColor: palette.shadow,
+  shadowOffset: { width: 0, height: 12 },
+  shadowOpacity: 0.12,
+  shadowRadius: 24,
+  elevation: 8,
+};
 
+export const scannerStyles = (_isDarkMode: boolean = false) => {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: palette.background,
+    },
+    flex: {
+      flex: 1,
+    },
+    backgroundGradient: {
+      ...StyleSheet.absoluteFillObject,
+    },
     scrollView: {
       flex: 1,
     },
-
     scrollContent: {
-      paddingBottom: 20,
+      paddingBottom: 160,
+      flexGrow: 1,
     },
-
-    connectionBanner: {
-      padding: 6,
-      alignItems: 'center',
-    },
-    bannerOnline: {
-      backgroundColor: colors.success,
-    },
-    bannerOffline: {
-      backgroundColor: colors.danger,
-    },
-    bannerText: {
-      color: colors.textLight,
-      fontWeight: '600',
-    },
-    offlineModalOverlay: {
-      flex: 1,
-      backgroundColor: 'rgba(0,0,0,0.5)',
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    offlineModalContent: {
-      backgroundColor: colors.surface,
-      padding: 20,
-      borderRadius: 10,
-      width: '80%',
-      alignItems: 'center',
-    },
-    offlineModalText: {
-      fontSize: 16,
-      color: colors.textPrimary,
-      textAlign: 'center',
-      marginBottom: 20,
-    },
-
-    // Elegant Header
-    header: {
-      paddingTop: Platform.OS === 'ios' ? 50 : 30,
+    heroSection: {
+      paddingTop: Platform.OS === 'ios' ? 20 : 16,
       paddingHorizontal: 20,
-      paddingBottom: 20,
-      backgroundColor: colors.background,
+      paddingBottom: 36,
     },
-
+    statusBar: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 16,
+    },
+    statusTime: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: palette.textPrimary,
+    },
+    statusIcons: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+    },
+    statusIcon: {
+      fontSize: 14,
+    },
+    appHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingBottom: 8,
+    },
+    backButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255,255,255,0.75)',
+      borderWidth: 1,
+      borderColor: 'rgba(139, 111, 71, 0.08)',
+      opacity: 0,
+      transform: [{ translateX: -16 }],
+    },
+    backButtonVisible: {
+      opacity: 1,
+      transform: [{ translateX: 0 }],
+    },
+    backButtonText: {
+      fontSize: 18,
+      color: palette.textPrimary,
+    },
+    headerContent: {
+      flex: 1,
+      marginLeft: 12,
+    },
     headerRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      marginBottom: 4,
     },
-
     coffeeIcon: {
       fontSize: 20,
       marginRight: 8,
     },
-
     headerTitle: {
       fontSize: 22,
       fontWeight: '700',
-      color: colors.textPrimary,
+      color: palette.textPrimary,
       letterSpacing: -0.3,
     },
-
     headerSubtitle: {
-      fontSize: 13,
-      color: colors.textTertiary,
-      marginTop: 2,
+      fontSize: 12,
+      color: palette.textTertiary,
+      marginTop: 4,
     },
-
-    // Elegant Action Cards
+    mainContent: {
+      backgroundColor: palette.surface,
+      borderTopLeftRadius: 32,
+      borderTopRightRadius: 32,
+      paddingHorizontal: 20,
+      paddingTop: 32,
+      paddingBottom: 120,
+      marginTop: -28,
+      minHeight: '100%',
+    },
+    welcomeCard: {
+      borderRadius: 24,
+      padding: 24,
+      marginBottom: 24,
+      overflow: 'hidden',
+    },
+    welcomeEmoji: {
+      fontSize: 44,
+      marginBottom: 12,
+      color: '#FFFFFF',
+    },
+    welcomeText: {
+      fontSize: 24,
+      fontWeight: '700',
+      color: '#FFFFFF',
+      marginBottom: 8,
+    },
+    welcomeDesc: {
+      fontSize: 14,
+      color: 'rgba(255,255,255,0.9)',
+      lineHeight: 20,
+    },
     actionSection: {
-      paddingHorizontal: 16,
-      marginBottom: 20,
+      marginBottom: 24,
     },
-
     actionGrid: {
       flexDirection: 'row',
       gap: 12,
     },
-
     actionCard: {
       flex: 1,
-      backgroundColor: colors.surface,
-      borderRadius: 16,
-      padding: 16,
+      backgroundColor: palette.surface,
+      borderRadius: 20,
+      paddingVertical: 24,
       alignItems: 'center',
       borderWidth: 1,
-      borderColor: colors.borderLight,
-
-      shadowColor: colors.shadow,
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.5,
-      shadowRadius: 4,
-      elevation: 2,
+      borderColor: palette.borderLight,
+      ...baseShadow,
     },
-
     actionCardPrimary: {
-      backgroundColor: colors.accentLight,
-      borderColor: colors.accent,
+      borderColor: 'transparent',
     },
-
     actionIconContainer: {
-      width: 52,
-      height: 52,
-      borderRadius: 26,
-      backgroundColor: colors.backgroundSecondary,
+      width: 56,
+      height: 56,
+      borderRadius: 16,
+      backgroundColor: palette.cream,
+      alignItems: 'center',
       justifyContent: 'center',
-      alignItems: 'center',
-      marginBottom: 10,
-    },
-
-    actionIconContainerPrimary: {
-      backgroundColor: colors.accent,
-    },
-
-    actionIcon: {
-      fontSize: 24,
-    },
-
-    actionLabel: {
-      fontSize: 14,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      textAlign: 'center',
-      marginBottom: 2,
-    },
-
-    actionSublabel: {
-      fontSize: 11,
-      color: colors.textTertiary,
-      textAlign: 'center',
-    },
-
-    // Compact Action Buttons Alternative
-    compactActions: {
-      paddingHorizontal: 16,
-      marginBottom: 20,
-      gap: 10,
-    },
-
-    compactActionButton: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 12,
-      paddingVertical: 14,
-      paddingHorizontal: 16,
-      borderWidth: 1,
-      borderColor: colors.border,
-    },
-
-    compactActionPrimary: {
-      backgroundColor: colors.accentLight,
-      borderColor: colors.accent,
-    },
-
-    compactActionIcon: {
-      width: 40,
-      height: 40,
-      borderRadius: 10,
-      backgroundColor: colors.background,
-      justifyContent: 'center',
-      alignItems: 'center',
-      marginRight: 12,
-    },
-
-    compactActionIconPrimary: {
-      backgroundColor: 'rgba(255, 255, 255, 0.7)',
-    },
-
-    compactActionText: {
-      flex: 1,
-    },
-
-    compactActionTitle: {
-      fontSize: 15,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      marginBottom: 1,
-    },
-
-    compactActionDesc: {
-      fontSize: 12,
-      color: colors.textSecondary,
-    },
-
-    compactActionArrow: {
-      fontSize: 16,
-      color: colors.textTertiary,
-    },
-
-    // Statistics Bar
-    statsContainer: {
-      flexDirection: 'row',
-      marginHorizontal: 16,
-      marginBottom: 20,
-      padding: 16,
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 12,
-      borderWidth: 1,
-      borderColor: colors.borderLight,
-    },
-
-    statItem: {
-      flex: 1,
-      alignItems: 'center',
-    },
-
-    statNumber: {
-      fontSize: 22,
-      fontWeight: '700',
-      color: colors.primary,
-      marginBottom: 2,
-    },
-
-    statLabel: {
-      fontSize: 10,
-      color: colors.textTertiary,
-      textTransform: 'uppercase',
-      letterSpacing: 0.5,
-    },
-
-    statDivider: {
-      width: 1,
-      backgroundColor: colors.border,
-      marginHorizontal: 12,
-    },
-
-    // History Section
-    historySection: {
-      paddingHorizontal: 16,
-    },
-
-    historyHeader: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
       marginBottom: 12,
     },
-
-    historyTitle: {
-      fontSize: 17,
-      fontWeight: '600',
-      color: colors.textPrimary,
+    actionIconContainerPrimary: {
+      borderRadius: 16,
     },
-
-    historyFilter: {
+    actionIcon: {
+      fontSize: 28,
+    },
+    actionLabel: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: palette.textPrimary,
+      marginBottom: 4,
+    },
+    actionSublabel: {
+      fontSize: 12,
+      color: palette.textTertiary,
+    },
+    statsContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+      marginBottom: 24,
+      paddingVertical: 20,
+      borderRadius: 20,
+      backgroundColor: 'rgba(255,255,255,0.75)',
+      borderWidth: 1,
+      borderColor: 'rgba(139, 111, 71, 0.08)',
+      ...baseShadow,
+    },
+    statItem: {
+      alignItems: 'center',
+      flex: 1,
+    },
+    statNumber: {
+      fontSize: 24,
+      fontWeight: '800',
+      color: palette.textPrimary,
+    },
+    statLabel: {
+      fontSize: 11,
+      color: palette.textTertiary,
+      marginTop: 4,
+      textTransform: 'uppercase',
+      letterSpacing: 0.6,
+    },
+    statDivider: {
+      width: 1,
+      height: '80%',
+      backgroundColor: palette.border,
+      opacity: 0.6,
+    },
+    historySection: {
+      marginBottom: 24,
+    },
+    historyHeader: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingHorizontal: 10,
-      paddingVertical: 5,
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 8,
+      justifyContent: 'space-between',
+      marginBottom: 12,
     },
-
-    historyFilterText: {
-      fontSize: 12,
-      color: colors.textSecondary,
-      marginRight: 4,
+    historyTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: palette.textPrimary,
     },
-
-    // History Grid
+    historySeeAll: {
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: 12,
+    },
+    historySeeAllText: {
+      fontSize: 13,
+      color: palette.accent,
+      fontWeight: '600',
+    },
     historyGrid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      marginHorizontal: -5,
-    },
-
-    historyCard: {
-      width: '50%',
-      paddingHorizontal: 5,
-      marginBottom: 10,
-    },
-
-    historyCardInner: {
-      backgroundColor: colors.surface,
-      borderRadius: 12,
-      padding: 12,
-      borderWidth: 1,
-      borderColor: colors.borderLight,
-      minHeight: 85,
-    },
-
-    historyCardTop: {
-      flexDirection: 'row',
       justifyContent: 'space-between',
-      alignItems: 'flex-start',
-      marginBottom: 6,
+      rowGap: 12,
     },
-
+    historyCard: {
+      width: '48%',
+      backgroundColor: palette.surface,
+      borderRadius: 16,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      overflow: 'hidden',
+      ...baseShadow,
+    },
+    historyCardAccent: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: 4,
+      height: '100%',
+      backgroundColor: palette.accent,
+    },
+    historyCardContent: {
+      marginLeft: 8,
+    },
     historyCardName: {
-      flex: 1,
-      fontSize: 13,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      marginRight: 6,
-    },
-
-    historyCardPercentage: {
-      backgroundColor: colors.accentLight,
-      paddingHorizontal: 6,
-      paddingVertical: 2,
-      borderRadius: 6,
-    },
-
-    historyCardPercentageText: {
-      fontSize: 10,
+      fontSize: 14,
       fontWeight: '700',
-      color: colors.primaryDark,
-    },
-
-    historyCardDate: {
-      fontSize: 11,
-      color: colors.textTertiary,
+      color: palette.textPrimary,
       marginBottom: 4,
     },
-
-    historyCardRating: {
+    historyCardDate: {
       fontSize: 11,
-      marginTop: 4,
-    },
-
-    // Empty State
-    emptyState: {
-      alignItems: 'center',
-      paddingVertical: 40,
-      paddingHorizontal: 40,
-    },
-
-    emptyStateImage: {
-      width: 80,
-      height: 80,
-      borderRadius: 40,
-      backgroundColor: colors.backgroundSecondary,
-      justifyContent: 'center',
-      alignItems: 'center',
-      marginBottom: 16,
-    },
-
-    emptyStateIcon: {
-      fontSize: 40,
-    },
-
-    emptyStateTitle: {
-      fontSize: 16,
-      fontWeight: '600',
-      color: colors.textPrimary,
+      color: palette.textTertiary,
       marginBottom: 6,
     },
-
-    emptyStateDesc: {
-      fontSize: 13,
-      color: colors.textSecondary,
-      textAlign: 'center',
-      lineHeight: 18,
+    historyCardRating: {
+      fontSize: 12,
+      color: palette.warning,
     },
-
-    // Camera View
-    cameraContainer: {
-      flex: 1,
-      backgroundColor: '#000',
-    },
-
-    camera: {
-      flex: 1,
-    },
-
-    cameraOverlay: {
-      ...StyleSheet.absoluteFillObject,
-    },
-
-    cameraHeader: {
-      paddingTop: Platform.OS === 'ios' ? 50 : 30,
-      paddingHorizontal: 20,
-      alignItems: 'flex-end',
-    },
-
-    cameraCloseButton: {
-      width: 40,
-      height: 40,
-      borderRadius: 20,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
-      justifyContent: 'center',
+    emptyState: {
       alignItems: 'center',
+      paddingVertical: 48,
+      paddingHorizontal: 16,
     },
-
-    cameraCloseText: {
-      color: colors.textLight,
+    emptyStateImage: {
+      width: 100,
+      height: 100,
+      borderRadius: 50,
+      backgroundColor: palette.cream,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 16,
+      ...baseShadow,
+    },
+    emptyStateIcon: {
+      fontSize: 42,
+    },
+    emptyStateTitle: {
       fontSize: 18,
+      fontWeight: '700',
+      color: palette.textPrimary,
+      marginBottom: 8,
     },
-
-    scanFrame: {
-      position: 'absolute',
-      top: height * 0.25,
-      left: width * 0.1,
-      right: width * 0.1,
-      height: height * 0.35,
-    },
-
-    scanCorner: {
-      position: 'absolute',
-      width: 40,
-      height: 40,
-    },
-
-    scanCornerTL: {
-      top: 0,
-      left: 0,
-      borderTopWidth: 3,
-      borderLeftWidth: 3,
-      borderColor: colors.accent,
-    },
-
-    scanCornerTR: {
-      top: 0,
-      right: 0,
-      borderTopWidth: 3,
-      borderRightWidth: 3,
-      borderColor: colors.accent,
-    },
-
-    scanCornerBL: {
-      bottom: 0,
-      left: 0,
-      borderBottomWidth: 3,
-      borderLeftWidth: 3,
-      borderColor: colors.accent,
-    },
-
-    scanCornerBR: {
-      bottom: 0,
-      right: 0,
-      borderBottomWidth: 3,
-      borderRightWidth: 3,
-      borderColor: colors.accent,
-    },
-
-    cameraInstructions: {
-      position: 'absolute',
-      bottom: 200,
-      left: 20,
-      right: 20,
-      alignItems: 'center',
-    },
-
-    cameraInstructionText: {
-      color: colors.textLight,
+    emptyStateDesc: {
       fontSize: 14,
-      backgroundColor: 'rgba(0, 0, 0, 0.6)',
-      paddingHorizontal: 20,
-      paddingVertical: 10,
-      borderRadius: 20,
+      color: palette.textTertiary,
+      textAlign: 'center',
+      lineHeight: 20,
     },
-
-    cameraControls: {
-      position: 'absolute',
-      bottom: 60,
-      left: 0,
-      right: 0,
-      alignItems: 'center',
+    resultSection: {
+      marginBottom: 20,
     },
-
-    captureButton: {
-      width: 72,
-      height: 72,
-      borderRadius: 36,
-      backgroundColor: colors.background,
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderWidth: 3,
-      borderColor: 'rgba(255, 255, 255, 0.5)',
-    },
-
-    captureInner: {
-      width: 56,
-      height: 56,
-      borderRadius: 28,
-      backgroundColor: colors.primary,
-    },
-
-    // Results Section
-    resultContainer: {
-      padding: 16,
-    },
-
     resultCard: {
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 12,
-      padding: 16,
-      marginBottom: 12,
+      backgroundColor: palette.surface,
+      borderRadius: 20,
+      padding: 20,
       borderWidth: 1,
-      borderColor: colors.borderLight,
+      borderColor: palette.borderLight,
+      ...baseShadow,
     },
-
     resultHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',
       alignItems: 'center',
       marginBottom: 12,
     },
-
     resultTitle: {
-      fontSize: 15,
-      fontWeight: '600',
-      color: colors.textPrimary,
-    },
-
-    matchBadge: {
-      paddingHorizontal: 10,
-      paddingVertical: 4,
-      borderRadius: 10,
-    },
-
-    matchBadgeGood: {
-      backgroundColor: colors.success,
-    },
-
-    matchBadgeFair: {
-      backgroundColor: colors.warning,
-    },
-
-    matchText: {
-      fontSize: 11,
-      fontWeight: '700',
-      color: colors.textLight,
-    },
-
-    resultTextInput: {
-      fontSize: 14,
-      color: colors.textPrimary,
-      minHeight: 80,
-      textAlignVertical: 'top',
-      backgroundColor: colors.background,
-      borderRadius: 8,
-      padding: 10,
-      marginTop: 8,
-      borderWidth: 1,
-      borderColor: colors.border,
-    },
-
-    resultLabel: {
-      fontSize: 11,
-      fontWeight: '600',
-      color: colors.textTertiary,
-      textTransform: 'uppercase',
-      letterSpacing: 0.5,
-    },
-
-    // Recommendation
-    recommendationCard: {
-      backgroundColor: colors.accentLight,
-      borderRadius: 12,
-      padding: 14,
-      marginBottom: 12,
-      borderLeftWidth: 3,
-      borderLeftColor: colors.accent,
-    },
-
-    recommendationTitle: {
-      fontSize: 14,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      marginBottom: 6,
-    },
-
-    recommendationText: {
-      fontSize: 13,
-      color: colors.textSecondary,
-      lineHeight: 18,
-    },
-
-    purchaseContainer: {
-      marginTop: 12,
-    },
-
-    purchaseLabel: {
       fontSize: 16,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      marginBottom: 8,
+      fontWeight: '700',
+      color: palette.textPrimary,
     },
-
-    // Action Buttons
-    actionButtons: {
-      flexDirection: 'row',
-      gap: 10,
-      marginTop: 12,
-    },
-
-    button: {
-      flex: 1,
-      paddingVertical: 12,
-      borderRadius: 10,
-      alignItems: 'center',
-      backgroundColor: colors.primary,
-    },
-
-    buttonSecondary: {
-      backgroundColor: colors.background,
-      borderWidth: 1,
-      borderColor: colors.border,
-    },
-
-    buttonSelected: {
-      borderWidth: 2,
-      borderColor: colors.accent,
-    },
-
-    submitButton: {
-      marginTop: 10,
-    },
-
-    buttonDisabled: {
-      opacity: 0.5,
-    },
-
-    buttonText: {
-      fontSize: 14,
-      fontWeight: '600',
-      color: colors.textLight,
-    },
-
-    buttonTextSecondary: {
-      color: colors.textPrimary,
-    },
-
-    // Rating
-    ratingContainer: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingVertical: 14,
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 10,
-      marginBottom: 12,
-    },
-
-    ratingLabel: {
-      fontSize: 13,
-      color: colors.textSecondary,
-      marginRight: 10,
-    },
-
-    ratingStars: {
-      flexDirection: 'row',
-      gap: 4,
-    },
-
-    starButton: {
-      padding: 2,
-    },
-
-    starText: {
-      fontSize: 20,
-    },
-
-    favoriteButton: {
-      marginLeft: 12,
+    matchBadge: {
       paddingHorizontal: 12,
       paddingVertical: 6,
+      borderRadius: 12,
+    },
+    matchBadgeGood: {
+      backgroundColor: palette.success,
+    },
+    matchBadgeFair: {
+      backgroundColor: palette.warning,
+    },
+    matchText: {
+      color: '#FFFFFF',
+      fontSize: 12,
+      fontWeight: '700',
+    },
+    resultTextInput: {
+      minHeight: 120,
+      borderRadius: 16,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      backgroundColor: palette.surfaceElevated,
+      fontSize: 14,
+      color: palette.textPrimary,
+      lineHeight: 20,
+    },
+    ratingCard: {
+      backgroundColor: palette.cream,
+      borderRadius: 20,
+      padding: 20,
+      marginBottom: 20,
+      borderWidth: 1,
+      borderColor: 'rgba(255,255,255,0.4)',
+      ...baseShadow,
+    },
+    ratingContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: 12,
+    },
+    ratingLabel: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: palette.textPrimary,
+    },
+    ratingStars: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    starButton: {
+      padding: 4,
+    },
+    starIcon: {
+      fontSize: 24,
+      color: 'rgba(92,82,72,0.3)',
+    },
+    starIconFilled: {
+      color: palette.warning,
+    },
+    favoriteButton: {
+      paddingHorizontal: 16,
+      paddingVertical: 8,
       borderRadius: 16,
       borderWidth: 1,
-      borderColor: colors.border,
-      backgroundColor: colors.background,
+      borderColor: palette.border,
+      backgroundColor: palette.surface,
     },
-
     favoriteButtonActive: {
-      backgroundColor: colors.primary,
-      borderColor: colors.primary,
+      backgroundColor: 'rgba(255,140,66,0.12)',
+      borderColor: palette.accent,
     },
-
-    favoriteButtonText: {
+    favoriteText: {
       fontSize: 13,
       fontWeight: '600',
-      color: colors.textPrimary,
+      color: palette.textSecondary,
     },
-
-    favoriteButtonTextActive: {
-      color: colors.textLight,
+    favoriteTextActive: {
+      color: palette.accent,
     },
-
-    // Brewing Methods
     brewingSection: {
-      padding: 16,
-      paddingTop: 0,
+      marginBottom: 20,
     },
-
-    brewingTitle: {
-      fontSize: 15,
-      fontWeight: '600',
-      color: colors.textPrimary,
-      marginBottom: 10,
+    sectionTitle: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: palette.textPrimary,
+      marginBottom: 12,
     },
-
     brewingGrid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      marginHorizontal: -4,
+      gap: 10,
     },
-
-    brewingMethod: {
-      width: '25%',
-      paddingHorizontal: 4,
-      marginBottom: 8,
+    brewingChip: {
+      paddingVertical: 10,
+      paddingHorizontal: 18,
+      borderRadius: 20,
+      backgroundColor: palette.surface,
+      borderWidth: 2,
+      borderColor: palette.borderLight,
     },
-
-    brewingButton: {
-      paddingVertical: 9,
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 8,
-      alignItems: 'center',
-      borderWidth: 1,
-      borderColor: colors.border,
+    brewingChipSelected: {
+      backgroundColor: palette.primary,
+      borderColor: 'transparent',
     },
-
-    brewingButtonSelected: {
-      backgroundColor: colors.primary,
-      borderColor: colors.primary,
-    },
-
-    brewingText: {
-      fontSize: 11,
-      fontWeight: '500',
-      color: colors.textPrimary,
-    },
-
-    brewingTextSelected: {
-      color: colors.textLight,
-    },
-
-    // Taste Input
-    tasteSection: {
-      paddingHorizontal: 16,
-      paddingBottom: 16,
-    },
-
-    tasteLabel: {
-      fontSize: 14,
+    brewingChipText: {
+      fontSize: 13,
       fontWeight: '600',
-      color: colors.textPrimary,
-      marginBottom: 8,
+      color: palette.textSecondary,
     },
-
-    tasteInput: {
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: 10,
-      padding: 12,
-      fontSize: 14,
-      color: colors.textPrimary,
+    brewingChipTextSelected: {
+      color: '#FFFFFF',
+    },
+    tasteSection: {
+      marginBottom: 24,
+    },
+    tasteInputContainer: {
+      backgroundColor: palette.surface,
+      borderRadius: 20,
       borderWidth: 1,
-      borderColor: colors.border,
+      borderColor: palette.borderLight,
+      padding: 4,
     },
-
-    // Generate Button
+    tasteInput: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      fontSize: 14,
+      color: palette.textPrimary,
+    },
     generateButton: {
-      backgroundColor: colors.accent,
-      marginHorizontal: 16,
-      marginBottom: 16,
-      paddingVertical: 15,
-      borderRadius: 12,
+      borderRadius: 24,
+      overflow: 'hidden',
+      marginBottom: 24,
+    },
+    generateButtonDisabled: {
+      opacity: 0.6,
+    },
+    generateButtonGradient: {
+      borderRadius: 24,
+      paddingVertical: 18,
       alignItems: 'center',
-
-      shadowColor: colors.accent,
-      shadowOffset: { width: 0, height: 3 },
-      shadowOpacity: 0.3,
-      shadowRadius: 6,
-      elevation: 3,
     },
-
     generateButtonText: {
-      fontSize: 15,
+      color: '#FFFFFF',
+      fontSize: 16,
       fontWeight: '700',
-      color: colors.textPrimary,
     },
-
-    // Loading
+    recipeSection: {
+      marginBottom: 32,
+    },
+    recipeCard: {
+      backgroundColor: palette.surface,
+      borderRadius: 24,
+      padding: 24,
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      ...baseShadow,
+    },
+    recipeHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 16,
+    },
+    recipeIcon: {
+      width: 56,
+      height: 56,
+      borderRadius: 18,
+      backgroundColor: palette.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    recipeIconText: {
+      fontSize: 26,
+      color: '#FFFFFF',
+    },
+    recipeHeaderContent: {
+      marginLeft: 12,
+      flex: 1,
+    },
+    recipeTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: palette.textPrimary,
+    },
+    recipeMethod: {
+      fontSize: 13,
+      color: palette.textTertiary,
+      marginTop: 4,
+    },
+    recipeContentBox: {
+      backgroundColor: palette.surfaceElevated,
+      borderRadius: 16,
+      padding: 20,
+      marginBottom: 20,
+    },
+    recipeContent: {
+      fontSize: 15,
+      lineHeight: 22,
+      color: palette.textPrimary,
+    },
+    recipeActions: {
+      flexDirection: 'row',
+      gap: 12,
+    },
+    actionButton: {
+      flex: 1,
+      borderRadius: 16,
+      paddingVertical: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    actionButtonPrimary: {
+      backgroundColor: palette.primary,
+    },
+    actionButtonPrimaryText: {
+      color: '#FFFFFF',
+      fontWeight: '700',
+      fontSize: 14,
+    },
+    actionButtonSecondary: {
+      backgroundColor: palette.surface,
+      borderWidth: 2,
+      borderColor: palette.border,
+    },
+    actionButtonSecondaryText: {
+      color: palette.textPrimary,
+      fontWeight: '700',
+      fontSize: 14,
+    },
+    fab: {
+      position: 'absolute',
+      bottom: 32,
+      right: 32,
+      width: 56,
+      height: 56,
+      borderRadius: 28,
+      backgroundColor: palette.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+      opacity: 0,
+      ...baseShadow,
+    },
+    fabVisible: {
+      opacity: 1,
+    },
+    fabIcon: {
+      fontSize: 24,
+      color: '#FFFFFF',
+    },
     loadingOverlay: {
       ...StyleSheet.absoluteFillObject,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      alignItems: 'center',
       justifyContent: 'center',
-      alignItems: 'center',
     },
-
     loadingContainer: {
-      backgroundColor: colors.background,
-      borderRadius: 16,
-      padding: 24,
+      backgroundColor: palette.surface,
+      paddingHorizontal: 32,
+      paddingVertical: 24,
+      borderRadius: 24,
       alignItems: 'center',
-      minWidth: 180,
+      ...baseShadow,
     },
-
     loadingText: {
-      fontSize: 13,
-      fontWeight: '500',
-      color: colors.textPrimary,
-      marginTop: 10,
+      marginTop: 12,
+      fontSize: 14,
+      fontWeight: '600',
+      color: palette.textPrimary,
     },
-
-    // Mini header for scanner pages
-    miniHeader: {
-      paddingTop: Platform.OS === 'ios' ? 50 : 30,
-      paddingHorizontal: 20,
-      paddingBottom: 16,
-      backgroundColor: colors.background,
+    cameraContainer: {
+      flex: 1,
+      backgroundColor: '#000',
     },
-
-    miniTitle: {
-      fontSize: 24,
-      fontWeight: '700',
-      color: colors.textPrimary,
-      letterSpacing: -0.5,
+    camera: {
+      flex: 1,
+    },
+    cameraOverlay: {
+      ...StyleSheet.absoluteFillObject,
+      justifyContent: 'space-between',
+    },
+    cameraHeader: {
+      paddingTop: Platform.OS === 'ios' ? 60 : 40,
+      paddingHorizontal: 24,
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+    },
+    cameraCloseButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 12,
+      backgroundColor: 'rgba(0,0,0,0.4)',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cameraCloseText: {
+      color: '#FFFFFF',
+      fontSize: 18,
+    },
+    scanFrame: {
+      alignSelf: 'center',
+      width: '75%',
+      aspectRatio: 1,
+      marginTop: '20%',
+    },
+    scanCorner: {
+      position: 'absolute',
+      width: 40,
+      height: 40,
+      borderColor: '#FFFFFF',
+      borderWidth: 4,
+    },
+    scanCornerTL: {
+      top: 0,
+      left: 0,
+      borderBottomWidth: 0,
+      borderRightWidth: 0,
+    },
+    scanCornerTR: {
+      top: 0,
+      right: 0,
+      borderBottomWidth: 0,
+      borderLeftWidth: 0,
+    },
+    scanCornerBL: {
+      bottom: 0,
+      left: 0,
+      borderTopWidth: 0,
+      borderRightWidth: 0,
+    },
+    scanCornerBR: {
+      bottom: 0,
+      right: 0,
+      borderTopWidth: 0,
+      borderLeftWidth: 0,
+    },
+    cameraInstructions: {
+      alignItems: 'center',
+      paddingBottom: 40,
+    },
+    cameraInstructionText: {
+      color: '#FFFFFF',
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    cameraControls: {
+      alignItems: 'center',
+      paddingBottom: 48,
+    },
+    captureButton: {
+      width: 86,
+      height: 86,
+      borderRadius: 43,
+      borderWidth: 6,
+      borderColor: '#FFFFFF',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(255,255,255,0.1)',
+    },
+    captureInner: {
+      width: 58,
+      height: 58,
+      borderRadius: 29,
+      backgroundColor: '#FFFFFF',
     },
   });
 };


### PR DESCRIPTION
## Summary
- remove the faux phone frame wrapper so the scanner header and body stretch across the full screen
- retune the Material-inspired styles to drop the phone container, add global padding, and keep the sections aligned edge to edge
- wrap the header/status area in a gradient hero and seat the content inside a rounded white sheet so the layout reflects the provided screenshot

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e53af2af20832abc1652efcce13d67