### PR TITLE
Redesign coffee scanner screens with Material-inspired layout

### DIFF
--- a/src/components/CoffeeReceipeScanner.tsx
+++ b/src/components/CoffeeReceipeScanner.tsx
@@ -1012,24 +1012,6 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
         )}
       </View>
     </KeyboardAvoidingView>
-
-      <TouchableOpacity
-        style={[styles.fab, currentView === 'recipe' ? styles.fabVisible : null]}
-        onPress={clearAll}
-        activeOpacity={0.85}
-      >
-        <Text style={styles.fabIcon}>➕</Text>
-      </TouchableOpacity>
-
-      {overlayVisible && (
-        <View style={styles.loadingOverlay}>
-          <View style={styles.loadingContainer}>
-            <ActivityIndicator size="large" color="#6B4423" />
-            <Text style={styles.loadingText}>{overlayText}</Text>
-          </View>
-        </View>
-      )}
-    </View>
   );
 };
 

--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -388,6 +388,26 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       color: palette.textPrimary,
       lineHeight: 20,
     },
+    recommendationCard: {
+      backgroundColor: palette.surface,
+      borderRadius: 20,
+      padding: 20,
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      marginBottom: 20,
+      ...baseShadow,
+    },
+    recommendationTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: palette.textPrimary,
+      marginBottom: 8,
+    },
+    recommendationText: {
+      fontSize: 14,
+      color: palette.textSecondary,
+      lineHeight: 20,
+    },
     ratingCard: {
       backgroundColor: palette.cream,
       borderRadius: 20,
@@ -477,6 +497,9 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       color: '#FFFFFF',
     },
     tasteSection: {
+      marginBottom: 24,
+    },
+    purchaseSection: {
       marginBottom: 24,
     },
     tasteInputContainer: {
@@ -592,6 +615,47 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       fontWeight: '700',
       fontSize: 14,
     },
+    actionButtons: {
+      flexDirection: 'row',
+      gap: 12,
+      marginBottom: 20,
+    },
+    button: {
+      flex: 1,
+      borderRadius: 16,
+      paddingVertical: 14,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: palette.primary,
+      ...baseShadow,
+    },
+    buttonSecondary: {
+      backgroundColor: palette.surface,
+      borderWidth: 2,
+      borderColor: palette.border,
+      ...baseShadow,
+    },
+    buttonSelected: {
+      transform: [{ scale: 1.02 }],
+      backgroundColor: 'rgba(255,140,66,0.12)',
+      borderColor: palette.accent,
+    },
+    buttonDisabled: {
+      opacity: 0.6,
+    },
+    buttonText: {
+      color: '#FFFFFF',
+      fontSize: 14,
+      fontWeight: '700',
+    },
+    buttonTextSecondary: {
+      color: palette.textPrimary,
+    },
+    submitButton: {
+      flex: 1,
+      backgroundColor: palette.accent,
+      borderWidth: 0,
+    },
     fab: {
       position: 'absolute',
       bottom: 32,
@@ -617,6 +681,31 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       backgroundColor: 'rgba(0,0,0,0.6)',
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    offlineModalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.55)',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 24,
+    },
+    offlineModalContent: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: palette.surface,
+      borderRadius: 24,
+      padding: 24,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      ...baseShadow,
+    },
+    offlineModalText: {
+      fontSize: 14,
+      color: palette.textPrimary,
+      textAlign: 'center',
+      marginBottom: 16,
+      lineHeight: 20,
     },
     loadingContainer: {
       backgroundColor: palette.surface,


### PR DESCRIPTION
## Summary
- streamline the CoffeeReceipeScanner view by keeping a single floating action button and overlay inside the redesigned phone container
- rebuild CoffeeTasteScanner with the Material-style welcome, action cards, scan results, rating, and purchase prompts while preserving offline handling
- extend the shared scanner styles to support the new recommendation card, offline modal, and reusable button treatments

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e575a35abc832a824e06c05e89d840