### PR TITLE
Adjust OCR scanner layouts to fill the full screen

### DIFF
--- a/src/components/styles/ProfessionalOCRScanner.styles.ts
+++ b/src/components/styles/ProfessionalOCRScanner.styles.ts
@@ -1,7 +1,5 @@
 // ProfessionalOCRScanner.styles.ts - BrewMate Material-inspired design
-import { StyleSheet, Dimensions, Platform } from 'react-native';
-
-const { width } = Dimensions.get('window');
+import { StyleSheet, Platform } from 'react-native';
 
 const palette = {
   primary: '#6B4423',
@@ -47,21 +45,22 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       flex: 1,
     },
     scrollContent: {
+      flexGrow: 1,
       paddingBottom: 160,
     },
     contentWrapper: {
-      paddingHorizontal: 20,
-      paddingVertical: 32,
+      flex: 1,
+      paddingHorizontal: 0,
+      paddingVertical: 0,
     },
     phoneContainer: {
+      flex: 1,
+      width: '100%',
+      alignSelf: 'stretch',
       backgroundColor: palette.surface,
-      borderRadius: 36,
-      borderWidth: 1,
-      borderColor: palette.borderLight,
+      borderRadius: 0,
+      borderWidth: 0,
       overflow: 'hidden',
-      alignSelf: 'center',
-      width: Math.min(width - 24, 420),
-      ...baseShadow,
     },
     statusBar: {
       paddingHorizontal: 24,


### PR DESCRIPTION
## Summary
- allow scanner layouts to grow to the full screen width instead of rendering inside a faux phone frame
- ensure scroll containers expand and remove the inset padding so CoffeeTasteScanner and CoffeeReceipeScanner occupy the entire viewport

## Testing
- not run (React Native layout change)


------
https://chatgpt.com/codex/tasks/task_e_68e57aa22f50832a8fa726420145f359