### PR TITLE
Move OpenAI OCR calls to backend endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,30 @@ app.use((req, _res, next) => {
 });
 
 const GOOGLE_VISION_API_KEY = process.env.GOOGLE_VISION_API_KEY || " ";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
+
+const requestOpenAIChat = async ({ messages, temperature }) => {
+  if (!OPENAI_API_KEY) {
+    throw new Error('Missing OpenAI API key');
+  }
+
+  const response = await axios.post(
+    'https://api.openai.com/v1/chat/completions',
+    {
+      model: 'gpt-4o',
+      messages,
+      temperature,
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+    },
+  );
+
+  return response.data;
+};
 
 app.get("/", (req, res) => {
   res.send("Google Vision OCR backend beží.");
@@ -717,6 +741,111 @@ app.post("/ocr", async (req, res) => {
   } catch (error) {
     console.error("OCR server error:", error?.message ?? error);
     res.status(500).json({ error: "OCR failed", detail: error?.message ?? error });
+  }
+});
+
+app.post('/api/ocr/fix', async (req, res) => {
+  try {
+    const { ocrText } = req.body;
+    if (!ocrText || typeof ocrText !== 'string') {
+      return res.status(400).json({ error: 'Chýba OCR text' });
+    }
+
+    const prompt = `
+Toto je text získaný OCR rozpoznávaním z etikety kávy.
+Oprav všetky chyby, ktoré mohli vzniknúť zlým rozpoznaním znakov.
+Zachovaj pôvodný význam a štruktúru, ale oprav OCR chyby.
+Vráť iba opravený text.
+
+OCR text:
+${ocrText}
+    `;
+
+    const data = await requestOpenAIChat({
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Si expert na kávu a opravu textov z OCR. Opravuješ chyby v rozpoznaných textoch z etikiet káv.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.2,
+    });
+
+    const text = data?.choices?.[0]?.message?.content?.trim() || '';
+    return res.json({ text });
+  } catch (error) {
+    console.error('OpenAI OCR fix error:', error?.message ?? error);
+    return res.status(500).json({ error: 'OCR fix failed' });
+  }
+});
+
+app.post('/api/ocr/brewing-methods', async (req, res) => {
+  try {
+    const { coffeeText } = req.body;
+    if (!coffeeText || typeof coffeeText !== 'string') {
+      return res.status(400).json({ error: 'Chýba popis kávy' });
+    }
+
+    const prompt =
+      `Na základe tohto popisu kávy navrhni presne 4 najvhodnejšie spôsoby prípravy kávy. ` +
+      `Odpovedz len zoznamom metód oddelených novým riadkom. Popis: "${coffeeText}"`;
+
+    const data = await requestOpenAIChat({
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Si barista, ktorý odporúča spôsoby prípravy kávy na základe popisu z etikety.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.7,
+    });
+
+    const content = data?.choices?.[0]?.message?.content || '';
+    const methods = content
+      .split('\n')
+      .map(line => line.replace(/^[-*\d.\s]+/, '').trim())
+      .filter(Boolean)
+      .slice(0, 4);
+
+    return res.json({ methods });
+  } catch (error) {
+    console.error('OpenAI brewing methods error:', error?.message ?? error);
+    return res.status(500).json({ error: 'Brewing methods failed' });
+  }
+});
+
+app.post('/api/ocr/recipe', async (req, res) => {
+  try {
+    const { method, taste } = req.body;
+    if (!method || typeof method !== 'string') {
+      return res.status(400).json({ error: 'Chýba metóda' });
+    }
+    if (!taste || typeof taste !== 'string') {
+      return res.status(400).json({ error: 'Chýba chuť' });
+    }
+
+    const prompt = `Priprav detailný recept na kávu pomocou metódy ${method}. Používateľ preferuje ${taste} chuť. Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.`;
+
+    const data = await requestOpenAIChat({
+      messages: [
+        {
+          role: 'system',
+          content: 'Si skúsený barista, ktorý navrhuje recepty na kávu.',
+        },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.7,
+    });
+
+    const recipe = data?.choices?.[0]?.message?.content?.trim() || '';
+    return res.json({ recipe });
+  } catch (error) {
+    console.error('OpenAI recipe error:', error?.message ?? error);
+    return res.status(500).json({ error: 'Recipe failed' });
   }
 });
 

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -2,25 +2,7 @@
 import auth from '@react-native-firebase/auth';
 import NetInfo from '@react-native-community/netinfo';
 import RNFS from 'react-native-fs';
-import { CONFIG } from '../config/config';
 import { API_HOST, API_URL } from './api';
-
-const OPENAI_API_KEY = CONFIG.OPENAI_API_KEY;
-const AI_CACHE_TTL = 24;
-
-/**
- * Builds a normalized cache key for AI responses to ensure consistent lookups across calls.
- *
- * @param {string} prefix - Namespace prefix describing the cached resource category (e.g. `ocr:fix`).
- * @param {string} input - Raw user or OCR input used to derive a unique key; trimmed and encoded before use.
- * @returns {string} Encoded cache key string safe for storage systems.
- */
-const createCacheKey = (prefix: string, input: string): string => {
-  const normalized = input.replace(/\s+/g, ' ').trim();
-  const encoded = encodeURIComponent(normalized).slice(0, 96);
-  return `ai:${prefix}:${encoded}`;
-};
-
 
 /**
  * Ensures the device is online before making network requests.
@@ -404,56 +386,23 @@ export const extractCoffeeName = (text: string): string => {
  * @throws {Error} Propagates network errors encountered during the OpenAI call unless a cached value exists.
  */
 const fixTextWithAI = async (ocrText: string): Promise<string> => {
-  const prompt = `
-Toto je text získaný OCR rozpoznávaním z etikety kávy.
-Oprav všetky chyby, ktoré mohli vzniknúť zlým rozpoznaním znakov.
-Zachovaj pôvodný význam a štruktúru, ale oprav OCR chyby.
-Vráť iba opravený text.
-
-OCR text:
-${ocrText}
-  `;
-
-  const cacheKey = createCacheKey('ocr:fix', ocrText);
-  
-
   try {
-    await ensureOnline();
-    console.log('📤 [OpenAI] OCR prompt:', prompt);
-    const response = await retryableFetch(() =>
-      fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-4o',
-          messages: [
-            {
-              role: 'system',
-              content:
-                'Si expert na kávu a opravu textov z OCR. Opravuješ chyby v rozpoznaných textoch z etikiet káv.',
-            },
-            { role: 'user', content: prompt },
-          ],
-          temperature: 0.2,
-        }),
-      }),
-    );
-
+    const response = await loggedFetch(`${API_URL}/ocr/fix`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ocrText }),
+    });
     const data = await response.json();
-    console.log('📥 [OpenAI] OCR response:', data);
+    console.log('📥 [BE] OCR fix response:', data);
 
-    if (data?.choices?.[0]?.message?.content) {
-      
-      return data.choices[0].message.content.trim();
+    if (typeof data?.text === 'string' && data.text.trim().length > 0) {
+      return data.text.trim();
     }
 
-    return  ocrText;
+    return ocrText;
   } catch (error) {
     console.error('AI correction error:', error);
-    return  ocrText;
+    return ocrText;
   }
 };
 
@@ -467,50 +416,17 @@ ${ocrText}
 export const suggestBrewingMethods = async (
   coffeeText: string
 ): Promise<string[]> => {
-  const prompt =
-    `Na základe tohto popisu kávy navrhni presne 4 najvhodnejšie spôsoby prípravy kávy. ` +
-    `Odpovedz len zoznamom metód oddelených novým riadkom. Popis: "${coffeeText}"`;
-
   const fallback = ['Espresso', 'French press', 'V60', 'Cold brew'];
-  const cacheKey = createCacheKey('ocr:methods', coffeeText);
-
-  if (!OPENAI_API_KEY) {
-    console.error('Chýba OpenAI API key. Vráti sa predvolený zoznam metód.');
-    return  fallback;
-  }
 
   try {
-    await ensureOnline();
-    console.log('📤 [OpenAI] Brewing prompt:', prompt);
-    const response = await retryableFetch(() =>
-      fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-4o',
-          messages: [
-            {
-              role: 'system',
-              content:
-                'Si barista, ktorý odporúča spôsoby prípravy kávy na základe popisu z etikety.',
-            },
-            { role: 'user', content: prompt },
-          ],
-          temperature: 0.7,
-        }),
-      })
-    );
-
+    const response = await loggedFetch(`${API_URL}/ocr/brewing-methods`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coffeeText }),
+    });
     const data = await response.json();
-    console.log('📥 [OpenAI] Brewing response:', data);
-    const content = data?.choices?.[0]?.message?.content || '';
-    let methods = content
-      .split('\n')
-      .map((m: string) => m.replace(/^[-*\d.\s]+/, '').trim())
-      .filter(Boolean);
+    console.log('📥 [BE] Brewing methods response:', data);
+    let methods = Array.isArray(data?.methods) ? data.methods : [];
 
     if (methods.length === 0) {
       // Ak AI nevráti žiadne metódy, použijeme predvolené hodnoty
@@ -542,42 +458,15 @@ export const getBrewRecipe = async (
   method: string,
   taste: string
 ): Promise<string> => {
-  const prompt = `Priprav detailný recept na kávu pomocou metódy ${method}. Používateľ preferuje ${taste} chuť. Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.`;
-
-  const cacheKey = createCacheKey('ocr:recipe', `${method}|${taste}`);
-
-  if (!OPENAI_API_KEY) {
-    console.error('Chýba OpenAI API key. Recept sa nevygeneruje.');
-    return  '';
-  }
-
   try {
-    await ensureOnline();
-    console.log('📤 [OpenAI] Recipe prompt:', prompt);
-    const response = await retryableFetch(() =>
-      fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-4o',
-          messages: [
-            {
-              role: 'system',
-              content: 'Si skúsený barista, ktorý navrhuje recepty na kávu.'
-            },
-            { role: 'user', content: prompt },
-          ],
-          temperature: 0.7,
-        }),
-      })
-    );
-
+    const response = await loggedFetch(`${API_URL}/ocr/recipe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ method, taste }),
+    });
     const data = await response.json();
-    console.log('📥 [OpenAI] Recipe response:', data);
-    const recipe = data?.choices?.[0]?.message?.content?.trim() || '';
+    console.log('📥 [BE] Recipe response:', data);
+    const recipe = typeof data?.recipe === 'string' ? data.recipe.trim() : '';
     if (recipe) {
       return recipe;
     }


### PR DESCRIPTION
### Motivation
- Remove direct OpenAI network calls from the mobile frontend so the OpenAI API key remains server-side.
- Centralize AI-related logic on the backend to simplify security and logging and to provide a single stable contract for FE consumption.

### Description
- Replaced in-frontend OpenAI usage in `src/services/ocrServices.ts` with calls to backend endpoints using `loggedFetch` to `
  `${API_URL}/ocr/fix`, `${API_URL}/ocr/brewing-methods` and `${API_URL}/ocr/recipe`.
- Added `requestOpenAIChat` helper and three new endpoints in `server.js`: `POST /api/ocr/fix`, `POST /api/ocr/brewing-methods` and `POST /api/ocr/recipe` that call OpenAI using `OPENAI_API_KEY` on the server.
- Updated response parsing expectations on the frontend to consume `{ text }`, `{ methods }`, and `{ recipe }` JSON shapes instead of OpenAI SDK shapes, and removed the client-side `CONFIG` OpenAI key and related cache/key helpers.

### Testing
- No automated tests were executed as part of this change.
- Manual development commit was created and files updated: `server.js` and `src/services/ocrServices.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bcd729d34832a9efda042b0e84b6c)