### PR TITLE
Add migration to create public.app_users table

### DIFF
--- a/db/migrations/20250301_add_app_users.sql
+++ b/db/migrations/20250301_add_app_users.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS public.app_users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  firebase_uid text NOT NULL UNIQUE,
+  email text,
+  name text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc
+    WHERE proname = 'touch_updated_at'
+      AND pg_function_is_visible(oid)
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_trigger
+      WHERE tgname = 'trg_touch_app_users'
+    ) THEN
+      CREATE TRIGGER trg_touch_app_users
+        BEFORE UPDATE ON public.app_users
+        FOR EACH ROW EXECUTE FUNCTION public.touch_updated_at();
+    END IF;
+  END IF;
+END $$;


### PR DESCRIPTION
### Motivation
- Introduce a dedicated `public.app_users` table to store application user records and link Firebase UIDs.
- Ensure `updated_at` is maintained automatically when the project exposes the `touch_updated_at` trigger function.
- Make the migration idempotent so it can be applied safely in environments where the table or trigger may already exist.

### Description
- Add migration file `db/migrations/20250301_add_app_users.sql` that creates the `public.app_users` table with `id`, `firebase_uid`, `email`, `name`, `created_at`, and `updated_at` columns.
- Use `gen_random_uuid()` as the default for `id` and `now()` defaults for `created_at` and `updated_at`.
- Include a conditional `DO $$ ... $$` block that checks for the presence of the `touch_updated_at` function and creates the `trg_touch_app_users` trigger (calling `public.touch_updated_at()`) if it does not already exist.
- Use `CREATE TABLE IF NOT EXISTS` and checks against `pg_trigger` to avoid duplicate object creation.

### Testing
- No automated tests were run for this migration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1ba530b8832a9142b87bfa20f5dd)