### PR TITLE
Add migration to backfill `app_users` from text tables

### DIFF
--- a/db/migrations/20250315_backfill_app_users_from_text_tables.sql
+++ b/db/migrations/20250315_backfill_app_users_from_text_tables.sql
@@ -1,0 +1,18 @@
+INSERT INTO app_users(firebase_uid)
+SELECT DISTINCT user_id
+FROM (
+    SELECT user_id FROM user_taste_profiles
+    UNION
+    SELECT user_id FROM brew_history
+    UNION
+    SELECT user_id FROM learning_events
+    UNION
+    SELECT user_id FROM scan_events
+    UNION
+    SELECT user_id FROM user_coffees
+    UNION
+    SELECT user_id FROM user_recipes
+    UNION
+    SELECT user_id FROM user_statistics
+) AS unique_user_ids
+ON CONFLICT DO NOTHING;

--- a/db/migrations/20250315_backfill_app_users_from_text_tables.sql
+++ b/db/migrations/20250315_backfill_app_users_from_text_tables.sql
@@ -1,4 +1,4 @@
-INSERT INTO app_users(firebase_uid)
+INSERT INTO app_users(id)
 SELECT DISTINCT user_id
 FROM (
     SELECT user_id FROM user_taste_profiles


### PR DESCRIPTION
### Motivation
- Ensure all `user_id` values stored as TEXT in several tables are present in `app_users(firebase_uid)` so users are discoverable in the central users table. 
- Consolidate unique user IDs from multiple legacy/text columns into a single migrationable operation. 
- Avoid creating duplicate rows when backfilling by using conflict-safe semantics.

### Description
- Add a migration file `db/migrations/20250315_backfill_app_users_from_text_tables.sql` that performs the backfill. 
- The migration runs a single statement: `INSERT INTO app_users(firebase_uid) SELECT DISTINCT user_id FROM (...)` where the subquery `UNION`s `user_id` from `user_taste_profiles`, `brew_history`, `learning_events`, `scan_events`, `user_coffees`, `user_recipes`, and `user_statistics`.
- The statement uses `ON CONFLICT DO NOTHING` to skip existing `firebase_uid` entries and avoid duplicates.

### Testing
- No automated tests were executed for this change because it is an SQL migration-only addition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d211df62c832abad9496ae52f4701)