### PR TITLE
Add app_users creation and update trigger to schema reset

### DIFF
--- a/db/supabase_schema_reset.sql
+++ b/db/supabase_schema_reset.sql
@@ -38,6 +38,7 @@ DROP TABLE IF EXISTS public.user_recipes CASCADE;
 DROP TABLE IF EXISTS public.user_coffees CASCADE;
 DROP TABLE IF EXISTS public.scan_events CASCADE;
 DROP TABLE IF EXISTS public.user_statistics CASCADE;
+DROP TABLE IF EXISTS public.app_users CASCADE;
 
 -- Safely remove old trigger helpers if present
 DO $$ BEGIN
@@ -87,6 +88,15 @@ DROP FUNCTION IF EXISTS public.handle_user_coffee_delete() CASCADE;
 -- =====================
 
 -- Core taste profile maintained by personalization engine
+CREATE TABLE public.app_users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  firebase_uid text NOT NULL UNIQUE,
+  email text,
+  name text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
 CREATE TABLE public.user_taste_profiles (
   user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
   sweetness numeric(4,2) NOT NULL DEFAULT 5 CHECK (sweetness BETWEEN 0 AND 10),
@@ -328,6 +338,10 @@ $$ LANGUAGE plpgsql;
 -- =====================
 -- CREATE NEW TRIGGERS
 -- =====================
+
+CREATE TRIGGER trg_touch_app_users
+  BEFORE UPDATE ON public.app_users
+  FOR EACH ROW EXECUTE FUNCTION public.touch_updated_at();
 
 CREATE TRIGGER trg_touch_user_taste_profiles
   BEFORE UPDATE ON public.user_taste_profiles


### PR DESCRIPTION
### Motivation
- Ensure the `public.app_users` shadow table exists when running the full Supabase schema reset so auth/foreign-key dependent tables can be rebuilt consistently.
- Persist the `firebase_uid` along with basic user metadata and timestamps for app-level user mapping.
- Keep `updated_at` accurate by reusing the existing `public.touch_updated_at()` trigger handler.

### Description
- Add `DROP TABLE IF EXISTS public.app_users CASCADE;` to the top of `db/supabase_schema_reset.sql` to make the reset idempotent for the new table.
- Create `public.app_users` in `db/supabase_schema_reset.sql` with `id uuid PRIMARY KEY DEFAULT gen_random_uuid()`, `firebase_uid text NOT NULL UNIQUE`, `email text`, `name text`, `created_at timestamptz DEFAULT now()`, and `updated_at timestamptz DEFAULT now()`.
- Add trigger creation `CREATE TRIGGER trg_touch_app_users BEFORE UPDATE ON public.app_users FOR EACH ROW EXECUTE FUNCTION public.touch_updated_at();` to ensure `updated_at` is refreshed on updates.
- Change is limited to `db/supabase_schema_reset.sql` and mirrors the migration in `db/migrations/20250301_add_app_users.sql`.

### Testing
- No automated tests were run for this SQL-only change.
- The change was added and committed to the repository without running schema-validation or database migration tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2c2f4218832a977d99114df8219f)