### PR TITLE
Migrate user_id FKs to use public.app_users UUIDs

### DIFF
--- a/db/schema_hotfix_app_users.sql
+++ b/db/schema_hotfix_app_users.sql
@@ -1,5 +1,5 @@
 -- Migration delta to align existing databases with the Firebase-friendly schema
--- Introduces app_users shadow table and retargets user_id FKs to text IDs
+-- Introduces app_users shadow table and retargets user_id FKs to UUID IDs
 -- without requiring a full reset.
 
 -- Ensure pgcrypto for UUID generation (harmless if already enabled)
@@ -7,10 +7,12 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- 1) Create app_users shadow table for Firebase UID storage
 CREATE TABLE IF NOT EXISTS public.app_users (
-  id text PRIMARY KEY,
-  email text UNIQUE,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  firebase_uid text NOT NULL UNIQUE,
+  email text,
   name text,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
 );
 
 -- Drop RLS policies that reference the old uuid-typed user_id so type changes succeed
@@ -70,58 +72,58 @@ DO $$ BEGIN
   END IF;
 END $$;
 
--- 2) Retarget user_id foreign keys to app_users with text type
+-- 2) Retarget user_id foreign keys to app_users with uuid type
 DO $$ BEGIN
   IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
     ALTER TABLE public.user_taste_profiles DROP CONSTRAINT IF EXISTS user_taste_profiles_user_id_fkey;
-    ALTER TABLE public.user_taste_profiles ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.user_taste_profiles ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.user_taste_profiles ADD CONSTRAINT user_taste_profiles_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.brew_history') IS NOT NULL THEN
     ALTER TABLE public.brew_history DROP CONSTRAINT IF EXISTS brew_history_user_id_fkey;
-    ALTER TABLE public.brew_history ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.brew_history ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.brew_history ADD CONSTRAINT brew_history_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.learning_events') IS NOT NULL THEN
     ALTER TABLE public.learning_events DROP CONSTRAINT IF EXISTS learning_events_user_id_fkey;
-    ALTER TABLE public.learning_events ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.learning_events ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.learning_events ADD CONSTRAINT learning_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.user_onboarding_responses') IS NOT NULL THEN
     ALTER TABLE public.user_onboarding_responses DROP CONSTRAINT IF EXISTS user_onboarding_responses_user_id_fkey;
-    ALTER TABLE public.user_onboarding_responses ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.user_onboarding_responses ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.user_onboarding_responses ADD CONSTRAINT user_onboarding_responses_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.user_recipes') IS NOT NULL THEN
     ALTER TABLE public.user_recipes DROP CONSTRAINT IF EXISTS user_recipes_user_id_fkey;
-    ALTER TABLE public.user_recipes ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.user_recipes ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.user_recipes ADD CONSTRAINT user_recipes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.user_coffees') IS NOT NULL THEN
     ALTER TABLE public.user_coffees DROP CONSTRAINT IF EXISTS user_coffees_user_id_fkey;
-    ALTER TABLE public.user_coffees ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.user_coffees ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.user_coffees ADD CONSTRAINT user_coffees_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.scan_events') IS NOT NULL THEN
     ALTER TABLE public.scan_events DROP CONSTRAINT IF EXISTS scan_events_user_id_fkey;
-    ALTER TABLE public.scan_events ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.scan_events ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.scan_events ADD CONSTRAINT scan_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 
   IF to_regclass('public.user_statistics') IS NOT NULL THEN
     ALTER TABLE public.user_statistics DROP CONSTRAINT IF EXISTS user_statistics_user_id_fkey;
-    ALTER TABLE public.user_statistics ALTER COLUMN user_id TYPE text USING user_id::text;
+    ALTER TABLE public.user_statistics ALTER COLUMN user_id TYPE uuid USING user_id::uuid;
     ALTER TABLE public.user_statistics ADD CONSTRAINT user_statistics_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.app_users(id) ON DELETE CASCADE;
   END IF;
 END $$;
 
--- 3) Replace legacy UUID-based stats helpers with text-based variants
+-- 3) Replace legacy UUID-based stats helpers with uuid-based variants
 DROP FUNCTION IF EXISTS public.update_user_stats_delta(uuid,int,int,int,int) CASCADE;
 DROP FUNCTION IF EXISTS public.handle_brew_history_insert() CASCADE;
 DROP FUNCTION IF EXISTS public.handle_brew_history_delete() CASCADE;
@@ -133,7 +135,7 @@ DROP FUNCTION IF EXISTS public.handle_user_coffee_insert() CASCADE;
 DROP FUNCTION IF EXISTS public.handle_user_coffee_delete() CASCADE;
 DROP FUNCTION IF EXISTS public.ensure_user_stats(uuid) CASCADE;
 
-CREATE OR REPLACE FUNCTION public.ensure_user_stats(u_id text)
+CREATE OR REPLACE FUNCTION public.ensure_user_stats(u_id uuid)
 RETURNS void AS $$
 BEGIN
   INSERT INTO public.user_statistics(user_id)
@@ -143,7 +145,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION public.update_user_stats_delta(
-  u_id text,
+  u_id uuid,
   brew_delta int,
   recipe_delta int,
   scan_delta int,
@@ -301,59 +303,59 @@ DO $$ BEGIN
   END IF;
 END $$;
 
--- Recreate ownership policies with text-based auth.uid() matching
+-- Recreate ownership policies with uuid-based auth.uid() matching
 DO $$ BEGIN
   IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
-    CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.brew_history') IS NOT NULL THEN
-    CREATE POLICY select_own_brew_history ON public.brew_history FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_brew_history ON public.brew_history FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_brew_history ON public.brew_history FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_brew_history ON public.brew_history FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_brew_history ON public.brew_history FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_brew_history ON public.brew_history FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_brew_history ON public.brew_history FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_brew_history ON public.brew_history FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.learning_events') IS NOT NULL THEN
-    CREATE POLICY select_own_learning_events ON public.learning_events FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_learning_events ON public.learning_events FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_learning_events ON public.learning_events FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_learning_events ON public.learning_events FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_learning_events ON public.learning_events FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_learning_events ON public.learning_events FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_learning_events ON public.learning_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_learning_events ON public.learning_events FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.user_onboarding_responses') IS NOT NULL THEN
-    CREATE POLICY select_own_onboarding ON public.user_onboarding_responses FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_onboarding ON public.user_onboarding_responses FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_onboarding ON public.user_onboarding_responses FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_onboarding ON public.user_onboarding_responses FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.user_recipes') IS NOT NULL THEN
-    CREATE POLICY select_own_user_recipes ON public.user_recipes FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_user_recipes ON public.user_recipes FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_user_recipes ON public.user_recipes FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_user_recipes ON public.user_recipes FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_user_recipes ON public.user_recipes FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_user_recipes ON public.user_recipes FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_user_recipes ON public.user_recipes FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_user_recipes ON public.user_recipes FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.user_coffees') IS NOT NULL THEN
-    CREATE POLICY select_own_user_coffees ON public.user_coffees FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_user_coffees ON public.user_coffees FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_user_coffees ON public.user_coffees FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_user_coffees ON public.user_coffees FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_user_coffees ON public.user_coffees FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_user_coffees ON public.user_coffees FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_user_coffees ON public.user_coffees FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_user_coffees ON public.user_coffees FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.scan_events') IS NOT NULL THEN
-    CREATE POLICY select_own_scan_events ON public.scan_events FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY insert_own_scan_events ON public.scan_events FOR INSERT WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_scan_events ON public.scan_events FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
-    CREATE POLICY delete_own_scan_events ON public.scan_events FOR DELETE USING ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_scan_events ON public.scan_events FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY insert_own_scan_events ON public.scan_events FOR INSERT WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY update_own_scan_events ON public.scan_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY delete_own_scan_events ON public.scan_events FOR DELETE USING (auth.uid() = user_id);
   END IF;
 
   IF to_regclass('public.user_statistics') IS NOT NULL THEN
-    CREATE POLICY select_own_statistics ON public.user_statistics FOR SELECT USING ((auth.uid())::text = user_id);
-    CREATE POLICY update_own_statistics ON public.user_statistics FOR UPDATE USING ((auth.uid())::text = user_id) WITH CHECK ((auth.uid())::text = user_id);
+    CREATE POLICY select_own_statistics ON public.user_statistics FOR SELECT USING (auth.uid() = user_id);
+    CREATE POLICY update_own_statistics ON public.user_statistics FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
   END IF;
 END $$;

--- a/db/supabase_schema_reset.sql
+++ b/db/supabase_schema_reset.sql
@@ -98,7 +98,7 @@ CREATE TABLE public.app_users (
 );
 
 CREATE TABLE public.user_taste_profiles (
-  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid PRIMARY KEY REFERENCES public.app_users(id) ON DELETE CASCADE,
   sweetness numeric(4,2) NOT NULL DEFAULT 5 CHECK (sweetness BETWEEN 0 AND 10),
   acidity numeric(4,2) NOT NULL DEFAULT 5 CHECK (acidity BETWEEN 0 AND 10),
   bitterness numeric(4,2) NOT NULL DEFAULT 5 CHECK (bitterness BETWEEN 0 AND 10),
@@ -117,7 +117,7 @@ CREATE TABLE public.user_taste_profiles (
 -- User brew diary entries
 CREATE TABLE public.brew_history (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   recipe_id uuid,
   beans jsonb NOT NULL DEFAULT '{}'::jsonb,
   grind_size text,
@@ -138,7 +138,7 @@ CREATE TABLE public.brew_history (
 -- Learning signals tied to brews
 CREATE TABLE public.learning_events (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   brew_history_id uuid REFERENCES public.brew_history(id) ON DELETE CASCADE,
   event_type text NOT NULL CHECK (event_type IN ('liked','disliked','favorited','repeated','shared')),
   event_weight numeric(6,3) NOT NULL DEFAULT 1.0,
@@ -149,7 +149,7 @@ CREATE TABLE public.learning_events (
 -- Persisted answers from personalization onboarding
 CREATE TABLE public.user_onboarding_responses (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   answers jsonb NOT NULL,
   analyzed_profile jsonb,
   created_at timestamptz NOT NULL DEFAULT now()
@@ -171,7 +171,7 @@ CREATE TABLE public.recipe_profiles (
 -- User-authored recipes for sharing or history
 CREATE TABLE public.user_recipes (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   title text NOT NULL,
   method text NOT NULL,
   instructions text NOT NULL,
@@ -185,7 +185,7 @@ CREATE TABLE public.user_recipes (
 -- Saved coffees in user library/inventory
 CREATE TABLE public.user_coffees (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   name text NOT NULL,
   brand text,
   origin text,
@@ -199,7 +199,7 @@ CREATE TABLE public.user_coffees (
 -- OCR/scan events to build lightweight history
 CREATE TABLE public.scan_events (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
   coffee_name text,
   brand text,
   barcode text,
@@ -218,7 +218,7 @@ CREATE TABLE public.scan_events (
 
 -- Aggregated counters to avoid heavy COUNT(*) calls
 CREATE TABLE public.user_statistics (
-  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid PRIMARY KEY REFERENCES public.app_users(id) ON DELETE CASCADE,
   brew_count integer NOT NULL DEFAULT 0,
   recipe_count integer NOT NULL DEFAULT 0,
   scan_count integer NOT NULL DEFAULT 0,


### PR DESCRIPTION
### Motivation
- Normalize all tables that use `user_id` to reference a single `public.app_users(id)` UUID key and ensure `ON DELETE CASCADE` semantics.
- Align the hotfix migration with the reset schema to use UUID-based `app_users` (with `firebase_uid`) instead of text-based IDs.
- Keep RLS policies, trigger handlers and stats helpers consistent with the UUID `user_id` type to avoid runtime mismatches.

### Description
- Updated `db/supabase_schema_reset.sql` to point `user_id` foreign keys for `user_taste_profiles`, `brew_history`, `learning_events`, `user_onboarding_responses`, `user_recipes`, `user_coffees`, `scan_events`, and `user_statistics` at `public.app_users(id)` with `ON DELETE CASCADE`.
- Modified `db/schema_hotfix_app_users.sql` to create `public.app_users` with a UUID `id` and `firebase_uid`, to alter existing `user_id` columns to `uuid` using `user_id::uuid`, and to re-add FK constraints against `public.app_users(id)`.
- Converted stats helper signatures to UUIDs by changing `ensure_user_stats` and `update_user_stats_delta` to accept `uuid` and updated the trigger-based handlers to call them accordingly.
- Rewrote RLS policy checks in the hotfix migration to compare `auth.uid()` directly to `user_id` (UUID) instead of casting to text.

### Testing
- No automated tests were run because these are SQL schema/migration changes only.
- Local repository changes were applied and saved to `db/schema_hotfix_app_users.sql` and `db/supabase_schema_reset.sql` and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d30e10368832aa28eb066fec60041)