### PR TITLE
Rework stats triggers and Firebase-aware RLS

### DIFF
--- a/db/schema_hotfix_app_users.sql
+++ b/db/schema_hotfix_app_users.sql
@@ -136,13 +136,20 @@ DROP FUNCTION IF EXISTS public.handle_user_coffee_delete() CASCADE;
 DROP FUNCTION IF EXISTS public.ensure_user_stats(uuid) CASCADE;
 
 CREATE OR REPLACE FUNCTION public.ensure_user_stats(u_id uuid)
-RETURNS void AS $$
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
+  IF u_id IS NULL THEN
+    RETURN;
+  END IF;
+
   INSERT INTO public.user_statistics(user_id)
   VALUES (u_id)
   ON CONFLICT (user_id) DO NOTHING;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.update_user_stats_delta(
   u_id uuid,
@@ -150,8 +157,15 @@ CREATE OR REPLACE FUNCTION public.update_user_stats_delta(
   recipe_delta int,
   scan_delta int,
   coffee_delta int
-) RETURNS void AS $$
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
+  IF u_id IS NULL THEN
+    RETURN;
+  END IF;
+
   PERFORM public.ensure_user_stats(u_id);
   UPDATE public.user_statistics
   SET
@@ -162,71 +176,111 @@ BEGIN
     updated_at = now()
   WHERE user_id = u_id;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_brew_history_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 1, 0, 0, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 1, 0, 0, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_brew_history_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, -1, 0, 0, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, -1, 0, 0, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_recipe_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 1, 0, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 1, 0, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_recipe_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, -1, 0, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, -1, 0, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_scan_event_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 1, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 1, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_scan_event_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, -1, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, -1, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_coffee_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 0, 1);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 0, 1);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_coffee_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, 0, -1);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, 0, -1);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- 4) Refresh triggers to point at new handlers (only if the tables exist)
 DO $$ BEGIN
@@ -306,56 +360,352 @@ END $$;
 -- Recreate ownership policies with uuid-based auth.uid() matching
 DO $$ BEGIN
   IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
-    CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.brew_history') IS NOT NULL THEN
-    CREATE POLICY select_own_brew_history ON public.brew_history FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_brew_history ON public.brew_history FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_brew_history ON public.brew_history FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_brew_history ON public.brew_history FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_brew_history ON public.brew_history
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_brew_history ON public.brew_history
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_brew_history ON public.brew_history
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_brew_history ON public.brew_history
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.learning_events') IS NOT NULL THEN
-    CREATE POLICY select_own_learning_events ON public.learning_events FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_learning_events ON public.learning_events FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_learning_events ON public.learning_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_learning_events ON public.learning_events FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_learning_events ON public.learning_events
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_learning_events ON public.learning_events
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_learning_events ON public.learning_events
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_learning_events ON public.learning_events
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.user_onboarding_responses') IS NOT NULL THEN
-    CREATE POLICY select_own_onboarding ON public.user_onboarding_responses FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_onboarding ON public.user_onboarding_responses FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_onboarding ON public.user_onboarding_responses
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_onboarding ON public.user_onboarding_responses
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.user_recipes') IS NOT NULL THEN
-    CREATE POLICY select_own_user_recipes ON public.user_recipes FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_user_recipes ON public.user_recipes FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_user_recipes ON public.user_recipes FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_user_recipes ON public.user_recipes FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_user_recipes ON public.user_recipes
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_user_recipes ON public.user_recipes
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_user_recipes ON public.user_recipes
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_user_recipes ON public.user_recipes
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.user_coffees') IS NOT NULL THEN
-    CREATE POLICY select_own_user_coffees ON public.user_coffees FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_user_coffees ON public.user_coffees FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_user_coffees ON public.user_coffees FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_user_coffees ON public.user_coffees FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_user_coffees ON public.user_coffees
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_user_coffees ON public.user_coffees
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_user_coffees ON public.user_coffees
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_user_coffees ON public.user_coffees
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.scan_events') IS NOT NULL THEN
-    CREATE POLICY select_own_scan_events ON public.scan_events FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY insert_own_scan_events ON public.scan_events FOR INSERT WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY update_own_scan_events ON public.scan_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-    CREATE POLICY delete_own_scan_events ON public.scan_events FOR DELETE USING (auth.uid() = user_id);
+    CREATE POLICY select_own_scan_events ON public.scan_events
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY insert_own_scan_events ON public.scan_events
+      FOR INSERT WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_scan_events ON public.scan_events
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY delete_own_scan_events ON public.scan_events
+      FOR DELETE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 
   IF to_regclass('public.user_statistics') IS NOT NULL THEN
-    CREATE POLICY select_own_statistics ON public.user_statistics FOR SELECT USING (auth.uid() = user_id);
-    CREATE POLICY update_own_statistics ON public.user_statistics FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY select_own_statistics ON public.user_statistics
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
+    CREATE POLICY update_own_statistics ON public.user_statistics
+      FOR UPDATE USING (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      ) WITH CHECK (
+        EXISTS (
+          SELECT 1
+          FROM public.app_users au
+          WHERE au.id = user_id
+            AND au.firebase_uid = auth.jwt() ->> 'sub'
+        )
+      );
   END IF;
 END $$;

--- a/db/supabase_schema_reset.sql
+++ b/db/supabase_schema_reset.sql
@@ -232,22 +232,32 @@ CREATE TABLE public.user_statistics (
 
 -- Keep updated_at fresh
 CREATE OR REPLACE FUNCTION public.touch_updated_at()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- Ensure stats row exists
 CREATE OR REPLACE FUNCTION public.ensure_user_stats(u_id uuid)
-RETURNS void AS $$
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
+  IF u_id IS NULL THEN
+    RETURN;
+  END IF;
+
   INSERT INTO public.user_statistics(user_id)
   VALUES (u_id)
   ON CONFLICT (user_id) DO NOTHING;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- Generic counter updater
 CREATE OR REPLACE FUNCTION public.update_user_stats_delta(
@@ -256,8 +266,15 @@ CREATE OR REPLACE FUNCTION public.update_user_stats_delta(
   recipe_delta int,
   scan_delta int,
   coffee_delta int
-) RETURNS void AS $$
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
+  IF u_id IS NULL THEN
+    RETURN;
+  END IF;
+
   PERFORM public.ensure_user_stats(u_id);
   UPDATE public.user_statistics
   SET
@@ -268,72 +285,112 @@ BEGIN
     updated_at = now()
   WHERE user_id = u_id;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- Trigger handlers for stats
 CREATE OR REPLACE FUNCTION public.handle_brew_history_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 1, 0, 0, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 1, 0, 0, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_brew_history_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, -1, 0, 0, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, -1, 0, 0, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_recipe_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 1, 0, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 1, 0, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_recipe_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, -1, 0, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, -1, 0, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_scan_event_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 1, 0);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 1, 0);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_scan_event_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, -1, 0);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, -1, 0);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_coffee_insert()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 0, 1);
+  IF NEW.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(NEW.user_id, 0, 0, 0, 1);
+  END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE OR REPLACE FUNCTION public.handle_user_coffee_delete()
-RETURNS trigger AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
 BEGIN
-  PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, 0, -1);
+  IF OLD.user_id IS NOT NULL THEN
+    PERFORM public.update_user_stats_delta(OLD.user_id, 0, 0, 0, -1);
+  END IF;
   RETURN OLD;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 -- =====================
 -- CREATE NEW TRIGGERS
@@ -405,43 +462,339 @@ ALTER TABLE public.scan_events ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_statistics ENABLE ROW LEVEL SECURITY;
 
 -- Ownership based policies
-CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_user_taste_profiles ON public.user_taste_profiles
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_user_taste_profiles ON public.user_taste_profiles
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_user_taste_profiles ON public.user_taste_profiles
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_user_taste_profiles ON public.user_taste_profiles
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_brew_history ON public.brew_history FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_brew_history ON public.brew_history FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_brew_history ON public.brew_history FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_brew_history ON public.brew_history FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_brew_history ON public.brew_history
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_brew_history ON public.brew_history
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_brew_history ON public.brew_history
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_brew_history ON public.brew_history
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_learning_events ON public.learning_events FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_learning_events ON public.learning_events FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_learning_events ON public.learning_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_learning_events ON public.learning_events FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_learning_events ON public.learning_events
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_learning_events ON public.learning_events
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_learning_events ON public.learning_events
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_learning_events ON public.learning_events
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_onboarding ON public.user_onboarding_responses FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_onboarding ON public.user_onboarding_responses FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_onboarding ON public.user_onboarding_responses
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_onboarding ON public.user_onboarding_responses
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_onboarding ON public.user_onboarding_responses
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_onboarding ON public.user_onboarding_responses
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_user_recipes ON public.user_recipes FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_user_recipes ON public.user_recipes FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_user_recipes ON public.user_recipes FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_user_recipes ON public.user_recipes FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_user_recipes ON public.user_recipes
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_user_recipes ON public.user_recipes
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_user_recipes ON public.user_recipes
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_user_recipes ON public.user_recipes
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_user_coffees ON public.user_coffees FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_user_coffees ON public.user_coffees FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_user_coffees ON public.user_coffees FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_user_coffees ON public.user_coffees FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_user_coffees ON public.user_coffees
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_user_coffees ON public.user_coffees
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_user_coffees ON public.user_coffees
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_user_coffees ON public.user_coffees
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_scan_events ON public.scan_events FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY insert_own_scan_events ON public.scan_events FOR INSERT WITH CHECK (auth.uid() = user_id);
-CREATE POLICY update_own_scan_events ON public.scan_events FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
-CREATE POLICY delete_own_scan_events ON public.scan_events FOR DELETE USING (auth.uid() = user_id);
+CREATE POLICY select_own_scan_events ON public.scan_events
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY insert_own_scan_events ON public.scan_events
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_scan_events ON public.scan_events
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY delete_own_scan_events ON public.scan_events
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
-CREATE POLICY select_own_statistics ON public.user_statistics FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY update_own_statistics ON public.user_statistics FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY select_own_statistics ON public.user_statistics
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
+CREATE POLICY update_own_statistics ON public.user_statistics
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.app_users au
+      WHERE au.id = user_id
+        AND au.firebase_uid = auth.jwt() ->> 'sub'
+    )
+  );
 
 -- =====================
 -- INDEXES


### PR DESCRIPTION
### Motivation
- Make the stats counters and updated_at triggers safer and runnable under the DB migration by reimplementing trigger functions with explicit privileges and search_path.
- Prevent runtime errors when user references are NULL by adding defensive checks in stats helper functions and trigger handlers.
- Support Firebase auth identity mapping by making RLS policies authorize via `app_users.firebase_uid` (JWT `sub`) instead of using `auth.uid()` directly.
- Keep trigger handlers and helpers consistent across schema reset and hotfix migration scripts to avoid drift.

### Description
- Rewrote the functions `touch_updated_at`, `ensure_user_stats`, and `update_user_stats_delta` to use `LANGUAGE plpgsql`, `SECURITY DEFINER`, and `SET search_path = public` and added `NULL` guards for `u_id` where appropriate.
- Updated all trigger handler functions (`handle_brew_history_*`, `handle_user_recipe_*`, `handle_scan_event_*`, `handle_user_coffee_*`) to be `SECURITY DEFINER`, set `search_path`, and to skip updating stats when `NEW.user_id`/`OLD.user_id` is `NULL`.
- Replaced ownership RLS policies that used `auth.uid() = user_id` with policies that verify `app_users.firebase_uid = auth.jwt() ->> 'sub'` (using `EXISTS (SELECT 1 FROM public.app_users au WHERE au.id = user_id AND au.firebase_uid = auth.jwt() ->> 'sub')`) across all affected tables.
- Changes applied to `db/supabase_schema_reset.sql` and `db/schema_hotfix_app_users.sql`, and triggers refreshed to point at the new handlers.

### Testing
- No automated tests were executed because these are SQL-only migration/schema changes.
- Migration scripts were updated but not applied in a running database as part of this change (manual deployment required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d33860fe8832a9b31f3a43cc865fa)