### PR TITLE
Normalize OCR insight mapping and derive UI insight sections

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -551,6 +551,7 @@ PRAVIDLÁ:
 - Ak sú dáta dostatočné → status="ok" a verdict je "suitable" | "not_suitable" | "uncertain".
 - Vysvetlenie musí byť porovnávacie: zhrň používateľove preferencie, zhrň profil kávy, porovnaj ich.
 - Insight musí byť konzistentný s verdictom (bez protichodných tvrdení).
+- Použi jediný kontrakt: insight objekt s poliami zo schémy (žiadne top-level zoznamy).
 
 VSTUP:
 user_taste_profile: {

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2271,6 +2271,12 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     const rawInsight = evaluation?.insight;
     const insightHeadline = rawInsight?.headline ?? '';
     const insightSections = rawInsight?.sections ?? [];
+    const derivedSections = [
+      { title: 'Čo ti bude chutiť', bullets: evaluationLikes },
+      { title: 'Čo môže rušiť', bullets: evaluationConcerns },
+      { title: 'Tipy na lepšiu zhodu', bullets: evaluationTips },
+      { title: 'Odporúčané prípravy', bullets: evaluationBrewMethods },
+    ].filter((section) => section.bullets.length);
     const isContradictoryClaim = (text: string) => {
       const lower = text.toLowerCase();
       if (verdict === 'not_suitable') {
@@ -2290,6 +2296,15 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         return bullets.length ? { title: section.title, bullets } : null;
       })
       .filter((section): section is typeof insightSections[number] => Boolean(section));
+    const sanitizedDerivedSections = derivedSections
+      .map(section => {
+        if (section.title && isContradictoryClaim(section.title)) {
+          return null;
+        }
+        const bullets = section.bullets.filter(bullet => !isContradictoryClaim(bullet));
+        return bullets.length ? { title: section.title, bullets } : null;
+      })
+      .filter((section): section is typeof derivedSections[number] => Boolean(section));
     // If the verdict says "not_suitable", drop any "match" copy to avoid insight/verdict contradictions.
     const sanitizedHeadline = insightHeadline && isContradictoryClaim(insightHeadline)
       ? ''
@@ -2309,9 +2324,16 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         || '';
     return {
       headline: resolvedHeadline,
-      sections: filteredSections,
+      sections: filteredSections.length ? filteredSections : sanitizedDerivedSections,
     };
-  }, [evaluation, evaluationStatus]);
+  }, [
+    evaluation,
+    evaluationStatus,
+    evaluationBrewMethods,
+    evaluationConcerns,
+    evaluationLikes,
+    evaluationTips,
+  ]);
   const insightStatusContent = useMemo(() => {
     if (evaluationStatus === 'profile_missing') {
       return {

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -199,6 +199,13 @@ const normalizeEvaluationReasons = (value: unknown): CoffeeEvaluationReason[] =>
     .filter((entry): entry is CoffeeEvaluationReason => Boolean(entry));
 };
 
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string');
+};
+
 const normalizeEvaluationInsight = (value: unknown): CoffeeEvaluationInsight | null => {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -245,10 +252,27 @@ const normalizeEvaluationInsight = (value: unknown): CoffeeEvaluationInsight | n
       return { title, bullets };
     })
     .filter((entry): entry is CoffeeEvaluationInsightSection => Boolean(entry));
-  if (!headline.trim() && sections.length === 0) {
+  const derivedSections: CoffeeEvaluationInsightSection[] = [];
+  const pushSection = (title: string, items: string[]) => {
+    if (items.length) {
+      derivedSections.push({ title, bullets: items });
+    }
+  };
+  const why = normalizeStringArray(parsed.why);
+  const whatYoullLike = normalizeStringArray(parsed.what_youll_like);
+  const whatMightBotherYou = normalizeStringArray(parsed.what_might_bother_you);
+  const tipsToMakeItBetter = normalizeStringArray(parsed.how_to_brew_for_better_match);
+  const recommendedAlternatives = normalizeStringArray(parsed.recommended_alternatives);
+  pushSection('Prečo', why);
+  pushSection('Čo ti bude chutiť', whatYoullLike);
+  pushSection('Čo môže rušiť', whatMightBotherYou);
+  pushSection('Tipy na lepšiu zhodu', tipsToMakeItBetter);
+  pushSection('Odporúčané prípravy', recommendedAlternatives);
+  const resolvedSections = sections.length ? sections : derivedSections;
+  if (!headline.trim() && resolvedSections.length === 0) {
     return null;
   }
-  return { headline, sections };
+  return { headline, sections: resolvedSections };
 };
 
 const normalizeEvaluationText = (value: unknown, fallback = ''): string => {
@@ -405,6 +429,10 @@ const NEUTRAL_EVALUATION_COPY = {
 const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult => {
   const record =
     payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
+  const insightRecord =
+    record.insight && typeof record.insight === 'object'
+      ? (record.insight as Record<string, unknown>)
+      : null;
   const normalizedStatus = normalizeEvaluationStatus(record.status);
   const verdict =
     normalizeEvaluationVerdict(record.verdict) ??
@@ -413,6 +441,31 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
     verdict === 'uncertain' ||
     normalizedStatus === 'insufficient_coffee_data' ||
     normalizedStatus === 'unknown';
+  const whatYoullLike = normalizeStringArray(
+    record.what_youll_like ?? insightRecord?.what_youll_like
+  );
+  const whatMightBotherYou = normalizeStringArray(
+    record.what_might_bother_you ?? insightRecord?.what_might_bother_you
+  );
+  const tipsToMakeItBetter = normalizeStringArray(
+    record.tips_to_make_it_better ?? insightRecord?.how_to_brew_for_better_match
+  );
+  const recommendedBrewMethods = normalizeStringArray(
+    record.recommended_brew_methods ?? insightRecord?.recommended_alternatives
+  );
+  const fallbackInsightSections: CoffeeEvaluationInsightSection[] = [];
+  const addFallbackSection = (title: string, items: string[]) => {
+    if (items.length) {
+      fallbackInsightSections.push({ title, bullets: items });
+    }
+  };
+  addFallbackSection('Čo ti bude chutiť', whatYoullLike);
+  addFallbackSection('Čo môže rušiť', whatMightBotherYou);
+  addFallbackSection('Tipy na lepšiu zhodu', tipsToMakeItBetter);
+  addFallbackSection('Odporúčané prípravy', recommendedBrewMethods);
+  const normalizedInsight =
+    normalizeEvaluationInsight(record.insight) ??
+    (fallbackInsightSections.length ? { headline: '', sections: fallbackInsightSections } : null);
   if (normalizedStatus === 'profile_missing') {
     // Preserve profile-missing payloads so the UI can display the CTA and guidance text.
     return {
@@ -421,10 +474,10 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       confidence: null,
       summary: typeof record.summary === 'string' ? record.summary : '',
       reasons: [],
-      what_youll_like: [],
-      what_might_bother_you: [],
-      tips_to_make_it_better: [],
-      recommended_brew_methods: [],
+      what_youll_like: whatYoullLike,
+      what_might_bother_you: whatMightBotherYou,
+      tips_to_make_it_better: tipsToMakeItBetter,
+      recommended_brew_methods: recommendedBrewMethods,
       cta: {
         action:
           record.cta && typeof record.cta === 'object' && record.cta.action === 'complete_taste_profile'
@@ -437,7 +490,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       },
       disclaimer: normalizeEvaluationText(record.disclaimer),
       verdict_explanation: normalizeVerdictExplanation(record.verdict_explanation),
-      insight: normalizeEvaluationInsight(record.insight),
+      insight: normalizedInsight,
       raw: payload,
     };
   }
@@ -449,10 +502,10 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       confidence: null,
       summary: typeof record.summary === 'string' ? record.summary : '',
       reasons: [],
-      what_youll_like: [],
-      what_might_bother_you: [],
-      tips_to_make_it_better: [],
-      recommended_brew_methods: [],
+      what_youll_like: whatYoullLike,
+      what_might_bother_you: whatMightBotherYou,
+      tips_to_make_it_better: tipsToMakeItBetter,
+      recommended_brew_methods: recommendedBrewMethods,
       cta: { action: null, label: null },
       disclaimer: useNeutralCopy
         ? normalizeEvaluationText(record.disclaimer, NEUTRAL_EVALUATION_COPY.disclaimer)
@@ -463,7 +516,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
             NEUTRAL_EVALUATION_COPY.verdict_explanation
           )
         : normalizeVerdictExplanation(record.verdict_explanation),
-      insight: normalizeEvaluationInsight(record.insight),
+      insight: normalizedInsight,
       raw: payload,
     };
   }
@@ -480,18 +533,10 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
     confidence: confidenceValue,
     summary,
     reasons,
-    what_youll_like: Array.isArray(record.what_youll_like)
-      ? record.what_youll_like.filter((item): item is string => typeof item === 'string')
-      : [],
-    what_might_bother_you: Array.isArray(record.what_might_bother_you)
-      ? record.what_might_bother_you.filter((item): item is string => typeof item === 'string')
-      : [],
-    tips_to_make_it_better: Array.isArray(record.tips_to_make_it_better)
-      ? record.tips_to_make_it_better.filter((item): item is string => typeof item === 'string')
-      : [],
-    recommended_brew_methods: Array.isArray(record.recommended_brew_methods)
-      ? record.recommended_brew_methods.filter((item): item is string => typeof item === 'string')
-      : [],
+    what_youll_like: whatYoullLike,
+    what_might_bother_you: whatMightBotherYou,
+    tips_to_make_it_better: tipsToMakeItBetter,
+    recommended_brew_methods: recommendedBrewMethods,
     cta:
       record.cta && typeof record.cta === 'object'
         ? {
@@ -511,7 +556,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
           NEUTRAL_EVALUATION_COPY.verdict_explanation
         )
       : normalizeVerdictExplanation(record.verdict_explanation),
-    insight: normalizeEvaluationInsight(record.insight),
+    insight: normalizedInsight,
     raw: payload,
   };
 };


### PR DESCRIPTION
### Motivation
- Standardize the OCR evaluation response so all insight content lives inside a single `insight` object instead of a mix of top-level arrays and insight fields.
- Map legacy/alternative insight keys from the AI payload into a stable set of normalized fields consumed by the FE.
- Ensure the same normalized JSON drives both the verdict and insight UI to avoid contradictory claims.
- Provide deterministic fallbacks so the UI can render useful insight sections even when `insight.sections` is missing.

### Description
- Added `normalizeStringArray` and enhanced `normalizeEvaluationInsight` in `src/services/ocrServices.ts` to pull `insight.why`, `insight.what_youll_like`, `insight.what_might_bother_you`, `insight.how_to_brew_for_better_match`, and `insight.recommended_alternatives` into structured sections when available.
- Updated `normalizeEvaluationResponse` to accept either top-level arrays or the `insight` object's fields and to populate normalized fields: `what_youll_like`, `what_might_bother_you`, `tips_to_make_it_better`, and `recommended_brew_methods`, and to build a fallback `insight` from those arrays when necessary.
- Modified `CoffeeTasteScanner` (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`) to prefer `insight.sections` but derive sections from the normalized arrays (`evaluation.what_youll_like`, `evaluation.what_might_bother_you`, `evaluation.tips_to_make_it_better`, `evaluation.recommended_brew_methods`) when `insight.sections` is absent, while filtering contradictory claims.
- Added a clarity note to the OpenAI prompt in `server/routes/ocr.js` instructing the model to return a single `insight` contract only.

### Testing
- No automated tests were executed as part of this change.
- Manual smoke: updated normalization and UI code paths to use the new normalized fields (no CI/runner invoked).
- Type/shape safety is handled via the existing normalization helpers to avoid runtime exceptions when AI payloads vary.
- Further automated test coverage is recommended to assert contract mappings and UI rendering behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3c0c7b5c832abe9bab5ba18d94b7)