### PR TITLE
Enforce strict OpenAI JSON schema for OCR evaluation and add validation test

### DIFF
--- a/server/routes/__tests__/ocr-evaluation.test.js
+++ b/server/routes/__tests__/ocr-evaluation.test.js
@@ -1,0 +1,51 @@
+import { isValidEvaluationResponse } from '../ocr.js';
+
+describe('isValidEvaluationResponse', () => {
+  it('accepts a valid evaluation response', () => {
+    const response = {
+      status: 'ok',
+      verdict: 'suitable',
+      confidence: 0.82,
+      verdict_explanation: {
+        user_preferences_summary: 'Používateľ preferuje sladšie kávy.',
+        coffee_profile_summary: 'Káva má ovocné tóny a strednú aciditu.',
+        comparison_summary: 'Profil kávy zodpovedá preferenciám.',
+      },
+      insight: {
+        headline: 'Dobrá zhoda',
+        why: ['Profil kávy zapadá do preferencií.'],
+        what_youll_like: ['Jemná sladkosť a ovocné tóny.'],
+        what_might_bother_you: [],
+        how_to_brew_for_better_match: ['Skús kratšiu extrakciu.'],
+        recommended_alternatives: [],
+      },
+      disclaimer: 'Vyhodnotenie je orientačné.',
+    };
+
+    expect(isValidEvaluationResponse(response)).toBe(true);
+  });
+
+  it('rejects responses that violate the schema rules', () => {
+    const response = {
+      status: 'ok',
+      verdict: null,
+      confidence: null,
+      verdict_explanation: {
+        user_preferences_summary: 'Chýba verdict.',
+        coffee_profile_summary: 'Chýba verdict.',
+        comparison_summary: 'Chýba verdict.',
+      },
+      insight: {
+        headline: 'Neplatné',
+        why: ['Nesprávne hodnotenie.'],
+        what_youll_like: [],
+        what_might_bother_you: [],
+        how_to_brew_for_better_match: [],
+        recommended_alternatives: [],
+      },
+      disclaimer: 'Neplatné hodnotenie.',
+    };
+
+    expect(isValidEvaluationResponse(response)).toBe(false);
+  });
+});

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -184,6 +184,69 @@ const EVALUATION_RESPONSE_SCHEMA = `JSON schema (strict):
 
 Return JSON only. Do not include markdown fences or extra text.`;
 
+const EVALUATION_RESPONSE_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'status',
+    'verdict',
+    'confidence',
+    'verdict_explanation',
+    'insight',
+    'disclaimer',
+  ],
+  properties: {
+    status: {
+      type: 'string',
+      enum: ['ok', 'profile_missing', 'insufficient_coffee_data'],
+    },
+    verdict: {
+      type: ['string', 'null'],
+      enum: ['suitable', 'not_suitable', 'uncertain', null],
+    },
+    confidence: {
+      type: ['number', 'null'],
+    },
+    verdict_explanation: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'user_preferences_summary',
+        'coffee_profile_summary',
+        'comparison_summary',
+      ],
+      properties: {
+        user_preferences_summary: { type: 'string' },
+        coffee_profile_summary: { type: 'string' },
+        comparison_summary: { type: 'string' },
+      },
+    },
+    insight: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'headline',
+        'why',
+        'what_youll_like',
+        'what_might_bother_you',
+        'how_to_brew_for_better_match',
+        'recommended_alternatives',
+      ],
+      properties: {
+        headline: { type: 'string' },
+        why: { type: 'array', items: { type: 'string' } },
+        what_youll_like: { type: 'array', items: { type: 'string' } },
+        what_might_bother_you: { type: 'array', items: { type: 'string' } },
+        how_to_brew_for_better_match: { type: 'array', items: { type: 'string' } },
+        recommended_alternatives: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    disclaimer: {
+      type: 'string',
+    },
+  },
+};
+
 const normalizeOpenAiJson = (value) => {
   if (!value) {
     return value;
@@ -567,7 +630,7 @@ user_taste_profile: {
 coffee_attributes: ${JSON.stringify(coffeeAttributes)}
 
 SCHEMA:
-{ ... (schema from task stub #2) ... }
+${EVALUATION_RESPONSE_SCHEMA}
 `;
 
     console.log('📤 [OpenAI] Prompt:', userPrompt);
@@ -582,6 +645,14 @@ SCHEMA:
           },
           { role: 'user', content: userPrompt },
         ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'coffee_evaluation',
+            schema: EVALUATION_RESPONSE_JSON_SCHEMA,
+            strict: true,
+          },
+        },
         temperature: 0.2,
       },
       {
@@ -843,4 +914,5 @@ router.post('/api/ocr/purchase', async (req, res) => {
   }
 });
 
+export { isValidEvaluationResponse };
 export default router;


### PR DESCRIPTION
### Motivation
- Prevent malformed AI payloads from reaching the frontend by enforcing a strict evaluation contract.
- Direct the OpenAI model to return strict JSON using the same machine-readable schema the server expects.
- Make the AI-response validator testable and exportable so validation logic can be unit-tested. 
- Add a test to catch regressions in the evaluation response validation.

### Description
- Added `EVALUATION_RESPONSE_JSON_SCHEMA` (a JSON Schema object) and interpolated the existing human-readable `EVALUATION_RESPONSE_SCHEMA` into the model prompt.
- Requested strict JSON from OpenAI by adding a `response_format` payload with `type: 'json_schema'` and `schema: EVALUATION_RESPONSE_JSON_SCHEMA` to the chat completion request.
- Exported `isValidEvaluationResponse` from `server/routes/ocr.js` and retained the deterministic fallback (`buildDeterministicFallbackResponse`) when validation fails or the response is not `status: 'ok'`.
- Added a Jest unit test `server/routes/__tests__/ocr-evaluation.test.js` that asserts `isValidEvaluationResponse` accepts a valid payload and rejects a schema-violating payload.

### Testing
- A new Jest test file `server/routes/__tests__/ocr-evaluation.test.js` was added to cover `isValidEvaluationResponse`.
- The test includes a positive case (valid `status: 'ok'` evaluation) and a negative case (an `ok` status with `null` verdict/confidence that violates the schema).
- No automated tests were executed during this rollout.
- To run the new tests locally, execute `npm test` (project uses Jest).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3fdb29ec832a9c82084e2ac3ed59)