### PR TITLE
Require structured coffee attributes for OCR evaluation and add branded allowlist

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -254,6 +254,8 @@ const normalizeOpenAiJson = (value) => {
   return value.replace(/```json\s*/i, '').replace(/```$/i, '').trim();
 };
 
+const BRANDED_COFFEE_ALLOWLIST = ['Lavazza', 'Illy', 'Segafredo', 'Kimbo', 'Pellini', 'Bazzara'];
+
 const hasMeaningfulCoffeeData = (coffeeAttributes) => {
   if (!coffeeAttributes || typeof coffeeAttributes !== 'object') {
     return false;
@@ -286,13 +288,20 @@ const hasMeaningfulCoffeeData = (coffeeAttributes) => {
     getValue(coffeeAttributes, ['processing']) ?? getValue(structured, ['processing']);
   const varietals =
     getValue(coffeeAttributes, ['varietals']) ?? getValue(structured, ['varietals']);
-  const ocrText =
-    getValue(coffeeAttributes, ['corrected_text', 'ocr_text', 'original_text']) ??
-    getValue(structured, ['corrected_text', 'ocr_text', 'original_text']);
+  const brand =
+    getValue(coffeeAttributes, ['brand', 'roaster', 'roastery', 'roaster_name']) ??
+    getValue(structured, ['brand', 'roaster', 'roastery', 'roaster_name']);
 
-  // Require at least one core attribute or OCR text before AI evaluation.
-  // OCR text allows AI to stay uncertain without claiming specifics.
-  return [origin, roastLevel, flavorNotes, processing, varietals, ocrText].some(hasValue);
+  const hasCoreProfileDetails = [origin, flavorNotes, varietals].some(hasValue);
+  const hasRoastOrProcessing = [roastLevel, processing].some(hasValue);
+  const brandLabel = typeof brand === 'string' ? brand.trim().toLowerCase() : '';
+  const isAllowlistedBrand = BRANDED_COFFEE_ALLOWLIST.some((allowed) =>
+    brandLabel.includes(allowed.toLowerCase())
+  );
+
+  // Require structured attributes before AI evaluation.
+  // Allow recognized brands with roast/processing data to pass the check.
+  return hasCoreProfileDetails || (isAllowlistedBrand && hasRoastOrProcessing);
 };
 
 const isValidEvaluationResponse = (value) => {


### PR DESCRIPTION
### Motivation
- Prevent the evaluator from making assertions when only corrected OCR text is provided by requiring structured attributes to ground AI reasoning.
- Allow well-known branded products to pass when they include roast/processing metadata so packaged coffees are not blocked unnecessarily.
- Reduce false positives from free-text OCR and ensure `/api/ocr/evaluate` returns `insufficient_coffee_data` when only corrected text is present.

### Description
- Updated `hasMeaningfulCoffeeData` to stop treating raw OCR/corrected text as sufficient and to require structured profile attributes instead.
- Added `BRANDED_COFFEE_ALLOWLIST` and logic to accept allowlisted brands when `roastLevel` or `processing` is present (brand keys checked: `brand`, `roaster`, `roastery`, `roaster_name`).
- The new gate is used by the `/api/ocr/evaluate` flow to return the existing `INSUFFICIENT_COFFEE_DATA_RESPONSE` when structured attributes are missing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d44f94cf8832ab02ddee039c5c31d)