### PR TITLE
Include structured metadata & confidence in OCR save and response

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -627,12 +627,36 @@ router.post('/api/ocr/save', async (req, res) => {
       thumbnail_url,
       structured_metadata,
       structuredMetadata,
+      structured_confidence,
+      structuredConfidence,
     } = req.body;
 
     const structured = structured_metadata || structuredMetadata || {};
+    const confidenceFlags =
+      structured_confidence ||
+      structuredConfidence ||
+      structured.confidenceFlags ||
+      structured.confidence_flags ||
+      null;
 
     const normalizeTextField = (value) =>
       typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+    const normalizeArrayField = (value) => {
+      if (Array.isArray(value)) {
+        const normalized = value
+          .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+          .filter(Boolean);
+        return normalized.length > 0 ? normalized : null;
+      }
+      if (typeof value === 'string') {
+        const normalized = value
+          .split(/[,;\n]/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        return normalized.length > 0 ? normalized : null;
+      }
+      return null;
+    };
     const normalizeJsonField = (value) =>
       value === undefined || value === null ? null : JSON.stringify(value);
 
@@ -710,11 +734,47 @@ router.post('/api/ocr/save', async (req, res) => {
       ]
     );
 
+    const storedStructuredMetadata = {
+      roaster: normalizeTextField(
+        structured.roaster ??
+          structured.roaster_name ??
+          structured.brand ??
+          structured.roastery
+      ),
+      origin: normalizeTextField(origin ?? structured.origin),
+      roastLevel: normalizeTextField(
+        roast_level ?? structured.roast_level ?? structured.roastLevel
+      ),
+      processing: normalizeTextField(processing ?? structured.processing),
+      flavorNotes: normalizeArrayField(
+        flavor_notes ?? structured.flavor_notes ?? structured.flavorNotes
+      ),
+      roastDate: normalizeTextField(roast_date ?? structured.roast_date ?? structured.roastDate),
+      varietals: normalizeArrayField(varietals ?? structured.varietals),
+      confidenceFlags:
+        confidenceFlags && typeof confidenceFlags === 'object' ? confidenceFlags : null,
+    };
+    const hasStructuredPayload = Object.entries(storedStructuredMetadata).some(([key, value]) => {
+      if (key === 'confidenceFlags') {
+        return value !== null;
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      return Boolean(value);
+    });
+
     res.status(200).json({
       message: 'OCR uložené',
       id: result.rows[0].id,
       match_percentage: matchPercentage,
       is_recommended: isRecommended,
+      structured_metadata: hasStructuredPayload ? storedStructuredMetadata : null,
+      structured_confidence:
+        storedStructuredMetadata.confidenceFlags &&
+        typeof storedStructuredMetadata.confidenceFlags === 'object'
+          ? storedStructuredMetadata.confidenceFlags
+          : null,
     });
   } catch (err) {
     console.error('❌ Chyba pri ukladaní OCR:', err);

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -947,6 +947,12 @@ export const processOCR = async (
       : undefined;
     const detectionConfidence =
       typeof ocrData.coffeeConfidence === 'number' ? ocrData.coffeeConfidence : undefined;
+    const initialStructuredMetadata = safeParseJSON<Record<string, unknown>>(
+      ocrData.structured_metadata ?? ocrData.structuredMetadata
+    );
+    const initialStructuredConfidence = safeParseJSON<Record<string, unknown>>(
+      ocrData.structured_confidence ?? ocrData.structuredConfidence
+    );
 
     // 2. Oprav text pomocou AI
     const correctedText = await fixTextWithAI(originalText);
@@ -974,16 +980,24 @@ export const processOCR = async (
       throw new Error('Nie si prihlásený');
     }
 
+    const savePayload: Record<string, unknown> = {
+      original_text: originalText,
+      corrected_text: correctedText,
+    };
+    if (initialStructuredMetadata) {
+      savePayload.structured_metadata = initialStructuredMetadata;
+    }
+    if (initialStructuredConfidence) {
+      savePayload.structured_confidence = initialStructuredConfidence;
+    }
+
     const saveResponse = await loggedFetch(`${API_URL}/ocr/save`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        original_text: originalText,
-        corrected_text: correctedText,
-      }),
+      body: JSON.stringify(savePayload),
     });
 
     let matchPercentage = 0;
@@ -1001,7 +1015,10 @@ export const processOCR = async (
       isRecommended = saveData.is_recommended || false;
       scanId = saveData.id || '';
 
-      const metadataRaw = saveData.structured_metadata;
+      const metadataRaw =
+        saveData.structured_metadata ??
+        saveData.structuredMetadata ??
+        initialStructuredMetadata;
       const metadataParsed = safeParseJSON<Record<string, any>>(metadataRaw);
       if (metadataParsed && typeof metadataParsed === 'object') {
         const normalizeString = (value: unknown): string | null => {
@@ -1097,7 +1114,9 @@ export const processOCR = async (
       }
 
       structuredConfidence = safeParseJSON<Record<string, unknown>>(
-        saveData.structured_confidence
+        saveData.structured_confidence ??
+          saveData.structuredConfidence ??
+          initialStructuredConfidence
       );
       structuredUncertainty = safeParseJSON<Record<string, unknown>>(
         saveData.structured_uncertainty


### PR DESCRIPTION
### Motivation
- Forward any AI/upstream `structured_metadata` and confidence to the server when saving OCR so downstream evaluation and personalization can use grounded attributes.
- Return normalized structured metadata and confidence flags from the `/api/ocr/save` response so the frontend can consume and present AI-extracted fields.
- Prefer the server-returned structured metadata when parsing OCR results to ensure the FE uses the canonical, normalized version.

### Description
- In `src/services/ocrServices.ts` the save payload to `POST /api/ocr/save` now includes `structured_metadata` and `structured_confidence` when available, and parsing prefers `saveData.structured_metadata`/`structured_confidence` falling back to initial OCR values.
- In `server/routes/ocr.js` the endpoint accepts `structured_confidence`/`structuredConfidence` and builds a normalized `storedStructuredMetadata` object (including `confidenceFlags`), and the JSON response now includes `structured_metadata` and `structured_confidence` when present.
- Added normalization helpers and a `hasStructuredPayload` check to avoid returning empty structured objects, and normalized array/text fields (e.g. `flavorNotes`, `varietals`) for consistent FE consumption.

### Testing
- No automated tests were executed for these changes (no CI/tests run during this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d470a0c80832a90a4a119f961ad00)