### PR TITLE
Normalize taste vector scale to 0–10

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -80,7 +80,7 @@ const clampNumber = (value, min, max) => Math.min(max, Math.max(min, value));
  *
  * Ensures the payload is a plain object with numeric values for the expected keys
  * (sweetness, acidity, bitterness, body, intensity, experimentalism) and clamps
- * each value to a 0–1 or 0–10 range based on scale.
+ * each value to a 0–10 range, scaling 0–1 inputs to the canonical 0–10 scale.
  *
  * @param {unknown} value - Incoming taste vector payload.
  * @returns {Record<string, number> | null} Sanitized taste vector or null when not provided.
@@ -106,11 +106,8 @@ const validateTasteVector = (value) => {
       throw new Error(`Invalid taste_vector.${key}: expected a number.`);
     }
 
-    const clamped =
-      rawValue <= 1
-        ? clampNumber(rawValue, 0, 1)
-        : clampNumber(rawValue, 0, 10);
-    sanitized[key] = clamped;
+    const normalizedValue = rawValue <= 1 ? rawValue * 10 : rawValue;
+    sanitized[key] = clampNumber(normalizedValue, 0, 10);
   });
 
   return sanitized;
@@ -564,26 +561,10 @@ router.put('/api/profile', async (req, res) => {
     const mappedTasteVector =
       !hasExplicitTasteInputs && validatedTasteVector
         ? {
-            sweetness:
-              validatedTasteVector.sweetness !== undefined &&
-              validatedTasteVector.sweetness !== null
-                ? validatedTasteVector.sweetness * 10
-                : undefined,
-            acidity:
-              validatedTasteVector.acidity !== undefined &&
-              validatedTasteVector.acidity !== null
-                ? validatedTasteVector.acidity * 10
-                : undefined,
-            bitterness:
-              validatedTasteVector.bitterness !== undefined &&
-              validatedTasteVector.bitterness !== null
-                ? validatedTasteVector.bitterness * 10
-                : undefined,
-            body:
-              validatedTasteVector.body !== undefined &&
-              validatedTasteVector.body !== null
-                ? validatedTasteVector.body * 10
-                : undefined,
+            sweetness: validatedTasteVector.sweetness ?? undefined,
+            acidity: validatedTasteVector.acidity ?? undefined,
+            bitterness: validatedTasteVector.bitterness ?? undefined,
+            body: validatedTasteVector.body ?? undefined,
           }
         : {};
 

--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -71,10 +71,7 @@ function safeNumber(value: unknown, fallback: number = DEFAULT_SCORE): number {
  * @returns {number|null} Clamped number when valid, otherwise null.
  */
 function parseVectorNumber(value: unknown): number | null {
-  const normalize = (input: number): number => {
-    const scaled = input <= 1 ? input * 10 : input;
-    return clamp(scaled);
-  };
+  const normalize = (input: number): number => clamp(input);
 
   if (typeof value === 'number' && Number.isFinite(value)) {
     return normalize(value);
@@ -507,10 +504,16 @@ export function buildTasteRadarScores({ profile, preferences }: TasteRadarSource
     const hasDetailedPreferences = Boolean(preferences.roast || preferences.intensity || preferences.preferredDrinks.length > 0);
 
     if (preferences.tasteVector && !hasDetailedPreferences) {
-      base.sweetness = blend(base.sweetness, preferences.tasteVector.sweetness, 0.6);
-      base.acidity = blend(base.acidity, preferences.tasteVector.acidity, 0.6);
-      base.body = blend(base.body, preferences.tasteVector.body, 0.6);
-      base.bitterness = blend(base.bitterness, preferences.tasteVector.bitterness, 0.6);
+      const normalizedVector = {
+        sweetness: safeNumber(preferences.tasteVector.sweetness, base.sweetness),
+        acidity: safeNumber(preferences.tasteVector.acidity, base.acidity),
+        body: safeNumber(preferences.tasteVector.body, base.body),
+        bitterness: safeNumber(preferences.tasteVector.bitterness, base.bitterness),
+      };
+      base.sweetness = blend(base.sweetness, normalizedVector.sweetness, 0.6);
+      base.acidity = blend(base.acidity, normalizedVector.acidity, 0.6);
+      base.body = blend(base.body, normalizedVector.body, 0.6);
+      base.bitterness = blend(base.bitterness, normalizedVector.bitterness, 0.6);
     }
 
     const sweetnessScore = mapSweetness(preferences.sugar);


### PR DESCRIPTION
### Motivation
- Unify taste vector representation so the canonical persisted scale is 0–10 to avoid mixed 0–1 vs 0–10 semantics.  
- Ensure backend persists a consistent scale so front-end normalization and radar calculations are simpler and less error-prone.  
- Prevent double-scaling and subtle bugs when AI or FE may return 0–1 floats while DB and UX expect 0–10 values.  

### Description
- Updated `server/routes/profile.js` `validateTasteVector` to scale incoming 0–1 values to the canonical 0–10 scale and clamp every entry to `0..10`.  
- Removed the redundant `*10` mapping when building `mappedTasteVector` so validated taste vectors are treated as already normalized to 0–10.  
- Modified `src/utils/tasteProfile.ts` `parseVectorNumber` to stop implicitly scaling 0–1 inputs and to clamp directly to the `0..10` range.  
- In `buildTasteRadarScores` preferences blending now runs `safeNumber` on `preferences.tasteVector` entries before `blend` to guarantee values are on the expected 0–10 scale.  

### Testing
- No automated tests were executed for this change.  
- Changes compile locally in the repository (no runtime tests were run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4c350fb8832aad8cf0ecdd966a52)