### PR TITLE
Align OCR verdict_explanation phrasing and enforce three-line response format

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -18,10 +18,10 @@ const PROFILE_MISSING_RESPONSE = {
   confidence: null,
   verdict_explanation: {
     user_preferences_summary:
-      'Používateľský chuťový profil nie je dokončený, takže nemáme kompletné preferencie.',
-    coffee_profile_summary: 'Profil kávy je k dispozícii, no nie je s čím ho porovnať.',
+      'Tvoje preferencie: chuťový profil nie je dokončený, takže nemáme kompletné preferencie.',
+    coffee_profile_summary: 'Profil kávy: údaje o káve sú dostupné, ale nie je s čím ich porovnať.',
     comparison_summary:
-      'Dokonči chuťový profil, aby sme vedeli porovnať kávu s tvojimi preferenciami.',
+      'Porovnanie s tvojím profilom: dokonči chuťový profil, aby sme vedeli porovnať kávu s tvojimi preferenciami.',
   },
   insight: {
     headline: 'Dokonči chuťový profil',
@@ -47,11 +47,11 @@ const INSUFFICIENT_COFFEE_DATA_RESPONSE = {
   confidence: null,
   verdict_explanation: {
     user_preferences_summary:
-      'Tvoje chuťové preferencie máme uložené, ale chýbajú detaily o káve.',
+      'Tvoje preferencie: chuťové preferencie máme uložené, ale chýbajú detaily o káve.',
     coffee_profile_summary:
-      'Z dostupných údajov nevieme spoľahlivo zhrnúť profil kávy, preto zostávame opatrní.',
+      'Profil kávy: z dostupných údajov nevieme spoľahlivo zhrnúť profil kávy, preto zostávame opatrní.',
     comparison_summary:
-      'Skús malý test (napr. cupping alebo jednu dávku) alebo rescan balenia a doplň pôvod, tóny a spracovanie.',
+      'Porovnanie s tvojím profilom: skús malý test (napr. cupping alebo jednu dávku) alebo rescan balenia a doplň pôvod, tóny a spracovanie.',
   },
   insight: {
     headline: 'Máme príliš málo údajov',
@@ -108,22 +108,22 @@ const buildDeterministicFallbackResponse = ({ preferences, coffeeAttributes, cor
 
   const coffeeProfileSummary =
     profileBits.length > 0
-      ? `Profil kávy obsahuje ${profileBits.join(', ')}.`
-      : 'Káva má základné údaje z OCR textu a balenia.';
+      ? `Profil kávy: obsahuje ${profileBits.join(', ')}.`
+      : 'Profil kávy: máme len základné údaje z OCR textu a balenia.';
 
   const formatPreference = (value) =>
     value === null || value === undefined || value === '' ? 'neznáme' : value;
-  const userPreferencesSummary = `Profil používateľa: sladkosť ${formatPreference(
+  const userPreferencesSummary = `Tvoje preferencie: sladkosť ${formatPreference(
     safePreferences.sweetness
   )}, acidita ${formatPreference(safePreferences.acidity)}, horkosť ${formatPreference(
     safePreferences.bitterness
   )}, telo ${formatPreference(safePreferences.body)}.`;
   const comparisonSummary =
     verdict === 'suitable'
-      ? `Textová zhoda vychádza na ${Math.round(
+      ? `Porovnanie s tvojím profilom: textová zhoda vychádza na ${Math.round(
           normalizedScore
         )} %, preto kávu hodnotíme ako vhodnú.`
-      : `Textová zhoda vychádza na ${Math.round(
+      : `Porovnanie s tvojím profilom: textová zhoda vychádza na ${Math.round(
           normalizedScore
         )} %, preto kávu hodnotíme ako menej vhodnú.`;
 
@@ -842,14 +842,17 @@ Odpovedaj výhradne v slovenčine.
 Vráť striktne platný JSON podľa zadanej schémy, bez markdownu a bez dodatočného textu.
 Nikdy nehádaj chýbajúce dáta. Ak chýba profil alebo údaje o káve, priznaj neistotu podľa schémy.
 Verdict a insight musia vychádzať z toho istého porovnania preferencií a atribútov kávy a nesmú si odporovať.`;
-    const userPrompt = `Vyhodnoť vhodnosť naskenovanej kávy pre používateľa.
+const userPrompt = `Vyhodnoť vhodnosť naskenovanej kávy pre používateľa.
 
 PRAVIDLÁ:
 - Výstup musí byť STRICT JSON podľa schémy nižšie.
 - Ak chýba alebo je neúplný chuťový profil → status="profile_missing", verdict=null.
 - Ak chýbajú kľúčové atribúty kávy → status="insufficient_coffee_data", verdict=null.
 - Ak sú dáta dostatočné → status="ok" a verdict je "suitable" | "not_suitable" | "uncertain".
-- Vysvetlenie musí byť porovnávacie: zhrň používateľove preferencie, zhrň profil kávy, porovnaj ich.
+- Každé pole verdict_explanation musí byť presne jedna veta v tomto formáte:
+  - user_preferences_summary začína "Tvoje preferencie:" a stručne zhrnie chuťový profil.
+  - coffee_profile_summary začína "Profil kávy:" a stručne zhrnie profil kávy.
+  - comparison_summary začína "Porovnanie s tvojím profilom:" a jasne porovná oba profily.
 - Insight musí byť konzistentný s verdictom (bez protichodných tvrdení).
 - Použi jediný kontrakt: insight objekt s poliami zo schémy (žiadne top-level zoznamy).
 

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2376,6 +2376,8 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
           + `Horkosť ${Math.round(bitterness)}/10, `
           + `Telo ${Math.round(body)}/10.`,
       );
+    } else {
+      summaryLines.push('Tvoje preferencie: Chuťový profil nie je k dispozícii.');
     }
 
     const structuredDetails = [
@@ -2389,16 +2391,20 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
 
     if (structuredDetails.length) {
       summaryLines.push(`Profil kávy: ${structuredDetails.join(' • ')}.`);
-    }
-
-    if (tasteAttributes.length) {
+    } else if (tasteAttributes.length) {
       const tasteSummary = tasteAttributes
         .map(attribute => `${attribute.label} ${Math.round(attribute.value)}/10`)
         .join(', ');
-      summaryLines.push(`Odhad chutí z etikety: ${tasteSummary}.`);
+      summaryLines.push(`Profil kávy: odhadnuté chute z etikety ${tasteSummary}.`);
+    } else {
+      summaryLines.push('Profil kávy: máme len základné údaje zo skenu.');
     }
 
-    return summaryLines.length ? summaryLines.join('\n') : null;
+    summaryLines.push(
+      'Porovnanie s tvojím profilom: nemáme dostatok údajov na presné porovnanie.',
+    );
+
+    return summaryLines.join('\n');
   }, [evaluationStatus, profile?.preferences, structuredMetadata, tasteAttributes]);
 
   const verdictLabel = evaluationVerdictLabel;
@@ -2418,15 +2424,9 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         // 2) Popíš profil kávy.
         // 3) Jasne porovnaj oba profily v slovenčine.
         const explanationLines = [
-          userPreferencesSummary
-            ? `Tvoje preferencie: ${userPreferencesSummary}`
-            : null,
-          coffeeProfileSummary
-            ? `Profil kávy: ${coffeeProfileSummary}`
-            : null,
-          comparisonSummary
-            ? `Porovnanie s tvojím profilom: ${comparisonSummary}`
-            : null,
+          userPreferencesSummary,
+          coffeeProfileSummary,
+          comparisonSummary,
         ].filter((line): line is string => Boolean(line));
         if (explanationLines.length) {
           return explanationLines.join('\n');


### PR DESCRIPTION
### Motivation
- Make the backend AI prompt and deterministic fallbacks produce a standardized, three-line `verdict_explanation` so the UI can render them verbatim.
- Ensure `PROFILE_MISSING_RESPONSE` and `INSUFFICIENT_COFFEE_DATA_RESPONSE` use the same sentence prefixes as the deterministic fallback for consistency. 
- Prevent AI outputs from varying phrasing/structure which caused inconsistent post-scan display and potential contradiction with `insight`/`verdict`.

### Description
- Tighten the OpenAI `userPrompt` in `server/routes/ocr.js` to require each `verdict_explanation` field be exactly one sentence and start with the prefixes `Tvoje preferencie:`, `Profil kávy:`, and `Porovnanie s tvojím profilom:` respectively. 
- Adjust `PROFILE_MISSING_RESPONSE`, `INSUFFICIENT_COFFEE_DATA_RESPONSE`, and the deterministic fallback in `server/routes/ocr.js` to use the same prefixed phrasing for `user_preferences_summary`, `coffee_profile_summary`, and `comparison_summary`.
- Update the FE `fallbackVerdictExplanation` and `verdictExplanation` assembly in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to produce and render the three lines verbatim (and use the same fallback wording when data are missing).
- Files changed: `server/routes/ocr.js` and `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`.

### Testing
- No automated tests were executed as part of this change.
- Existing runtime validation still enforces the JSON schema via `isValidEvaluationResponse` and deterministic fallback logic which remain unchanged.
- Manual runtime/QA in the app is recommended to verify the post-scan screen shows the three lines verbatim and that AI-produced responses follow the new prefixes.
- CI should run unit and integration tests (not executed here) to validate there are no regressions in OCR evaluation flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4d4486ec832ab0b89e8a4cfdf4d1)