### PR TITLE
Add LABEL_DETECTION to Vision OCR and return labels/coffee confidence

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -411,7 +411,7 @@ router.post('/ocr', async (req, res) => {
       requests: [
         {
           image: { content: base64image },
-          features: [{ type: 'TEXT_DETECTION' }],
+          features: [{ type: 'TEXT_DETECTION' }, { type: 'LABEL_DETECTION' }],
         },
       ],
     };
@@ -423,8 +423,49 @@ router.post('/ocr', async (req, res) => {
     });
     console.log('📥 [Vision] Response:', response.data);
 
-    const text = response.data.responses?.[0]?.fullTextAnnotation?.text || '';
-    res.json({ text });
+    const visionResponse = response.data.responses?.[0] || {};
+    const text = visionResponse.fullTextAnnotation?.text || '';
+    const labelAnnotations = Array.isArray(visionResponse.labelAnnotations)
+      ? visionResponse.labelAnnotations
+      : [];
+    const labels = labelAnnotations
+      .map((label) => label?.description)
+      .filter((label) => typeof label === 'string' && label.trim().length > 0);
+
+    const coffeeKeywords = [
+      'coffee',
+      'espresso',
+      'cafe',
+      'café',
+      'latte',
+      'cappuccino',
+      'bean',
+      'beans',
+      'roast',
+    ];
+    const coffeeConfidenceCandidates = labelAnnotations
+      .map((label) => ({
+        description: label?.description,
+        score: label?.score,
+      }))
+      .filter(({ description, score }) => {
+        if (typeof description !== 'string' || typeof score !== 'number') {
+          return false;
+        }
+        const normalized = description.toLowerCase();
+        return coffeeKeywords.some((keyword) => normalized.includes(keyword));
+      })
+      .map(({ score }) => score)
+      .filter((score) => Number.isFinite(score));
+
+    const coffeeConfidence =
+      coffeeConfidenceCandidates.length > 0
+        ? Math.max(...coffeeConfidenceCandidates)
+        : null;
+    const isCoffee =
+      typeof coffeeConfidence === 'number' ? coffeeConfidence >= 0.6 : undefined;
+
+    res.json({ text, labels, coffeeConfidence, isCoffee });
   } catch (error) {
     console.error('OCR server error:', error?.message ?? error);
     res.status(500).json({ error: 'OCR failed', detail: error?.message ?? error });

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -628,9 +628,23 @@ interface OCRResult {
   source?: 'offline' | 'online';
   isCoffee?: boolean;
   nonCoffeeReason?: string;
+  /**
+   * Labels returned by Vision label detection (e.g., "coffee", "espresso").
+   * Optional when the backend does not return label annotations.
+   */
   detectionLabels?: string[];
+  /**
+   * Confidence score derived from label detection for coffee-related labels.
+   * Optional and may be undefined when label detection is unavailable.
+   */
   detectionConfidence?: number;
+  /**
+   * Structured metadata extracted from OCR text when available (e.g., origin, roast, notes).
+   */
   structuredMetadata?: StructuredCoffeeMetadata | null;
+  /**
+   * Confidence flags for structured metadata extraction when provided by the backend.
+   */
   structuredConfidence?: Record<string, unknown> | null;
   structuredUncertainty?: Record<string, unknown> | null;
   rawStructuredResponse?: unknown;
@@ -898,7 +912,8 @@ const ensureOfflineImagePath = async (
 
 
 /**
- * Processes OCR using backend services with offline fallbacks, AI enrichment, and structured metadata parsing.
+ * Processes OCR using backend services with offline fallbacks, AI enrichment, label detection,
+ * and structured metadata parsing.
  *
  * @param {string} base64image - Base64 encoded image captured from the coffee label.
  * @param {{ imagePath?: string }} [options] - Optional hints including a pre-saved image path to reuse for offline flow.


### PR DESCRIPTION
### Motivation
- Improve OCR detection by asking Google Vision for label annotations in addition to text so we can detect coffee-related imagery.  
- Surface label data and a simple `coffeeConfidence` signal so the frontend can better decide whether a scan is a coffee product.  
- Provide an explicit `isCoffee` hint and pass through any structured metadata/confidence for downstream processing.  
- Document the new optional fields in the FE service types so `processOCR()` handles missing values safely.

### Description
- Update `server/routes/ocr.js` to include `{ type: 'LABEL_DETECTION' }` in the Vision request and parse `labelAnnotations` from the response.  
- Compute `labels` (array of label descriptions), `coffeeConfidence` (max score among coffee-related labels), and `isCoffee` (boolean using a 0.6 threshold) and return them from the `/ocr` endpoint as `text`, `labels`, `coffeeConfidence`, and `isCoffee`.  
- Add comments and small type/docs updates in `src/services/ocrServices.ts` to document `detectionLabels`, `detectionConfidence`, `structuredMetadata`, and `structuredConfidence` on `OCRResult`, and update the `processOCR` docstring to mention label detection.  
- Existing `processOCR()` logic already safely parses optional fields using `safeParseJSON` and checks types, so it will work when the new fields are present or absent.

### Testing
- No automated tests were executed for this change.  
- Basic repository operations (file edits, staging, and commit) were performed locally during the change but no CI/test run was triggered.  
- The new fields are optional and `processOCR()` uses defensive parsing to avoid runtime errors when they are missing.  
- Recommend running server integration tests and FE type checks in CI to validate end-to-end behavior before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d52d72634832a81303afcb21793b8)