### PR TITLE
Add OCR attribute extraction fallback and send estimated coffee attributes from FE

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -256,6 +256,106 @@ const normalizeOpenAiJson = (value) => {
 
 const BRANDED_COFFEE_ALLOWLIST = ['Lavazza', 'Illy', 'Segafredo', 'Kimbo', 'Pellini', 'Bazzara'];
 
+const normalizeCoffeeValue = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const cleaned = value.replace(/\s+/g, ' ').trim();
+  return cleaned.length > 0 ? cleaned : null;
+};
+
+const parseDelimitedList = (value) => {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const items = value
+    .split(/[,;|/]+/)
+    .map((item) => item.replace(/[()\[\]]/g, '').trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : null;
+};
+
+const extractCoffeeAttributesFromText = (text) => {
+  if (!text || typeof text !== 'string') {
+    return {
+      origin: null,
+      roast_level: null,
+      flavor_notes: null,
+      processing: null,
+      varietals: null,
+    };
+  }
+
+  const normalizedText = text.replace(/\r/g, '');
+
+  const extractLabelValue = (labels) => {
+    for (const label of labels) {
+      const regex = new RegExp(`${label}\\s*[:\\-]\\s*([^\\n]+)`, 'i');
+      const match = normalizedText.match(regex);
+      if (match && match[1]) {
+        return normalizeCoffeeValue(match[1]);
+      }
+    }
+    return null;
+  };
+
+  const origin =
+    extractLabelValue(['origin', 'pôvod', 'povod', 'country', 'region']) ||
+    null;
+  const flavorNotesRaw = extractLabelValue([
+    'flavor notes',
+    'flavour notes',
+    'tóny',
+    'chut',
+    'notes',
+  ]);
+  const varietalsRaw = extractLabelValue([
+    'varietal',
+    'varietals',
+    'variety',
+    'odroda',
+    'odrody',
+  ]);
+
+  const processingKeywords = [
+    { label: 'washed', keywords: ['washed', 'fully washed', 'wet process', 'mokre'] },
+    { label: 'natural', keywords: ['natural', 'dry process', 'sušené', 'susene'] },
+    { label: 'honey', keywords: ['honey', 'honey process', 'pulped natural'] },
+    { label: 'anaerobic', keywords: ['anaerobic', 'anaeróbne', 'anaerobne'] },
+    { label: 'semi-washed', keywords: ['semi-washed', 'semi washed', 'wet hulled'] },
+    { label: 'carbonic maceration', keywords: ['carbonic', 'maceration'] },
+  ];
+  const lowerText = normalizedText.toLowerCase();
+  const processing =
+    extractLabelValue(['processing', 'process', 'spracovanie']) ||
+    processingKeywords.find(({ keywords }) =>
+      keywords.some((keyword) => lowerText.includes(keyword))
+    )?.label ||
+    null;
+
+  const roastLevelRaw = extractLabelValue(['roast', 'praženie', 'prazenie']);
+  const roastLevelKeywords = [
+    { label: 'light', keywords: ['light', 'svetla', 'cinnamon', 'blonde'] },
+    { label: 'medium', keywords: ['medium', 'stredna', 'city'] },
+    { label: 'medium-dark', keywords: ['medium-dark', 'medium dark', 'full city'] },
+    { label: 'dark', keywords: ['dark', 'tmava', 'french', 'italian', 'espresso'] },
+  ];
+  const roastLevel =
+    normalizeCoffeeValue(roastLevelRaw) ||
+    roastLevelKeywords.find(({ keywords }) =>
+      keywords.some((keyword) => lowerText.includes(keyword))
+    )?.label ||
+    null;
+
+  return {
+    origin,
+    roast_level: roastLevel,
+    flavor_notes: flavorNotesRaw ? parseDelimitedList(flavorNotesRaw) : null,
+    processing: normalizeCoffeeValue(processing),
+    varietals: varietalsRaw ? parseDelimitedList(varietalsRaw) : null,
+  };
+};
+
 const hasMeaningfulCoffeeData = (coffeeAttributes) => {
   if (!coffeeAttributes || typeof coffeeAttributes !== 'object') {
     return false;
@@ -680,6 +780,10 @@ router.post('/api/ocr/save', async (req, res) => {
       structured.confidence_flags ||
       null;
 
+    const derivedAttributes = extractCoffeeAttributesFromText(
+      corrected_text || original_text || ''
+    );
+
     const normalizeTextField = (value) =>
       typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
     const normalizeArrayField = (value) => {
@@ -715,6 +819,25 @@ router.post('/api/ocr/save', async (req, res) => {
       : null;
     const isRecommended = matchPercentage !== null ? matchPercentage > 75 : false;
     const coffeeName = extractCoffeeName(corrected_text || original_text);
+
+    const resolvedOrigin = normalizeTextField(
+      origin ?? structured.origin ?? derivedAttributes.origin
+    );
+    const resolvedRoastLevel = normalizeTextField(
+      roast_level ?? structured.roast_level ?? structured.roastLevel ?? derivedAttributes.roast_level
+    );
+    const resolvedFlavorNotes = normalizeJsonField(
+      flavor_notes ??
+        structured.flavor_notes ??
+        structured.flavorNotes ??
+        derivedAttributes.flavor_notes
+    );
+    const resolvedProcessing = normalizeTextField(
+      processing ?? structured.processing ?? derivedAttributes.processing
+    );
+    const resolvedVarietals = normalizeJsonField(
+      varietals ?? structured.varietals ?? derivedAttributes.varietals
+    );
 
     const result = await db.query(
       `INSERT INTO scan_events (
@@ -763,12 +886,12 @@ router.post('/api/ocr/save', async (req, res) => {
         coffeeName,
         normalizeTextField(original_text),
         normalizeTextField(corrected_text),
-        normalizeTextField(origin ?? structured.origin),
-        normalizeTextField(roast_level ?? structured.roast_level ?? structured.roastLevel),
-        normalizeJsonField(flavor_notes ?? structured.flavor_notes ?? structured.flavorNotes),
-        normalizeTextField(processing ?? structured.processing),
+        resolvedOrigin,
+        resolvedRoastLevel,
+        resolvedFlavorNotes,
+        resolvedProcessing,
         normalizeTextField(roast_date ?? structured.roast_date ?? structured.roastDate),
-        normalizeJsonField(varietals ?? structured.varietals),
+        resolvedVarietals,
         normalizeTextField(thumbnail_url ?? structured.thumbnail_url ?? structured.thumbnailUrl),
         matchPercentage,
         isRecommended,
@@ -782,16 +905,19 @@ router.post('/api/ocr/save', async (req, res) => {
           structured.brand ??
           structured.roastery
       ),
-      origin: normalizeTextField(origin ?? structured.origin),
-      roastLevel: normalizeTextField(
-        roast_level ?? structured.roast_level ?? structured.roastLevel
-      ),
-      processing: normalizeTextField(processing ?? structured.processing),
+      origin: resolvedOrigin,
+      roastLevel: resolvedRoastLevel,
+      processing: resolvedProcessing,
       flavorNotes: normalizeArrayField(
-        flavor_notes ?? structured.flavor_notes ?? structured.flavorNotes
+        flavor_notes ??
+          structured.flavor_notes ??
+          structured.flavorNotes ??
+          derivedAttributes.flavor_notes
       ),
       roastDate: normalizeTextField(roast_date ?? structured.roast_date ?? structured.roastDate),
-      varietals: normalizeArrayField(varietals ?? structured.varietals),
+      varietals: normalizeArrayField(
+        varietals ?? structured.varietals ?? derivedAttributes.varietals
+      ),
       confidenceFlags:
         confidenceFlags && typeof confidenceFlags === 'object' ? confidenceFlags : null,
     };
@@ -872,6 +998,46 @@ router.post('/api/ocr/evaluate', async (req, res) => {
             ocr_text: corrected_text,
             structured_metadata: structured,
           };
+
+    const derivedAttributes = extractCoffeeAttributesFromText(corrected_text);
+    const mergedStructuredMetadata = {
+      ...structured,
+      origin: structured.origin ?? derivedAttributes.origin,
+      roast_level: structured.roast_level ?? derivedAttributes.roast_level,
+      roastLevel: structured.roastLevel ?? derivedAttributes.roast_level,
+      flavor_notes: structured.flavor_notes ?? derivedAttributes.flavor_notes,
+      flavorNotes: structured.flavorNotes ?? derivedAttributes.flavor_notes,
+      processing: structured.processing ?? derivedAttributes.processing,
+      varietals: structured.varietals ?? derivedAttributes.varietals,
+    };
+    coffeeAttributes = {
+      ...coffeeAttributes,
+      origin:
+        coffeeAttributes.origin ??
+        mergedStructuredMetadata.origin ??
+        derivedAttributes.origin,
+      roast_level:
+        coffeeAttributes.roast_level ??
+        coffeeAttributes.roastLevel ??
+        mergedStructuredMetadata.roast_level ??
+        mergedStructuredMetadata.roastLevel ??
+        derivedAttributes.roast_level,
+      flavor_notes:
+        coffeeAttributes.flavor_notes ??
+        coffeeAttributes.flavorNotes ??
+        mergedStructuredMetadata.flavor_notes ??
+        mergedStructuredMetadata.flavorNotes ??
+        derivedAttributes.flavor_notes,
+      processing:
+        coffeeAttributes.processing ??
+        mergedStructuredMetadata.processing ??
+        derivedAttributes.processing,
+      varietals:
+        coffeeAttributes.varietals ??
+        mergedStructuredMetadata.varietals ??
+        derivedAttributes.varietals,
+      structured_metadata: mergedStructuredMetadata,
+    };
 
     if (!hasMeaningfulCoffeeData(coffeeAttributes)) {
       return res.json(INSUFFICIENT_COFFEE_DATA_RESPONSE);

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -189,6 +189,89 @@ const normalizeStringArray = (value: unknown): string[] => {
   return value.filter((item): item is string => typeof item === 'string');
 };
 
+const parseDelimitedList = (value: string): string[] | null => {
+  const items = value
+    .split(/[,;|/]+/)
+    .map(item => item.replace(/[()\[\]]/g, '').trim())
+    .filter(Boolean);
+  return items.length ? items : null;
+};
+
+const estimateCoffeeAttributesFromText = (
+  text: string,
+): Pick<StructuredCoffeeMetadata, 'origin' | 'roastLevel' | 'processing' | 'flavorNotes' | 'varietals'> => {
+  const normalizedText = text.replace(/\r/g, '');
+  const lowerText = normalizedText.toLowerCase();
+
+  const extractLabelValue = (labels: string[]): string | null => {
+    for (const label of labels) {
+      const regex = new RegExp(`${label}\\s*[:\\-]\\s*([^\\n]+)`, 'i');
+      const match = normalizedText.match(regex);
+      if (match && match[1]) {
+        const cleaned = match[1].replace(/\s+/g, ' ').trim();
+        return cleaned.length ? cleaned : null;
+      }
+    }
+    return null;
+  };
+
+  const origin = extractLabelValue(['origin', 'pôvod', 'povod', 'country', 'region']);
+  const flavorNotesRaw = extractLabelValue([
+    'flavor notes',
+    'flavour notes',
+    'tóny',
+    'chut',
+    'notes',
+  ]);
+  const varietalsRaw = extractLabelValue([
+    'varietal',
+    'varietals',
+    'variety',
+    'odroda',
+    'odrody',
+  ]);
+  const processing =
+    extractLabelValue(['processing', 'process', 'spracovanie']) ||
+    (['washed', 'natural', 'honey', 'anaerobic', 'semi-washed', 'carbonic maceration'].find(
+      keyword => lowerText.includes(keyword),
+    ) ??
+      null);
+  const roastLevelRaw = extractLabelValue(['roast', 'praženie', 'prazenie']);
+  const roastLevel =
+    roastLevelRaw ||
+    (['light', 'medium-dark', 'medium', 'dark'].find(keyword => lowerText.includes(keyword)) ??
+      null);
+
+  return {
+    origin,
+    roastLevel,
+    processing,
+    flavorNotes: flavorNotesRaw ? parseDelimitedList(flavorNotesRaw) : null,
+    varietals: varietalsRaw ? parseDelimitedList(varietalsRaw) : null,
+  };
+};
+
+const mergeStructuredMetadata = (
+  base: StructuredCoffeeMetadata | null,
+  fallback: Pick<
+    StructuredCoffeeMetadata,
+    'origin' | 'roastLevel' | 'processing' | 'flavorNotes' | 'varietals'
+  >,
+): StructuredCoffeeMetadata | null => {
+  if (!base && !fallback) {
+    return null;
+  }
+  const mergedBase = base ?? ({} as StructuredCoffeeMetadata);
+  return {
+    ...mergedBase,
+    origin: mergedBase.origin ?? fallback.origin ?? null,
+    roastLevel: mergedBase.roastLevel ?? fallback.roastLevel ?? null,
+    processing: mergedBase.processing ?? fallback.processing ?? null,
+    flavorNotes: mergedBase.flavorNotes ?? fallback.flavorNotes ?? null,
+    varietals: mergedBase.varietals ?? fallback.varietals ?? null,
+  };
+};
+
 const normalizeEvaluationInsight = (value: unknown): CoffeeEvaluationInsight | null => {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -1178,6 +1261,11 @@ export const processOCR = async (
     };
 
     // 4. Získaj AI hodnotenie a návrhy metód súčasne
+    const estimatedAttributes = estimateCoffeeAttributesFromText(correctedText);
+    const evaluationStructuredMetadata = mergeStructuredMetadata(
+      structuredMetadata,
+      estimatedAttributes,
+    );
     const evaluatePromise =
       isCoffee === false
         ? Promise.resolve({ skipped: true } as const)
@@ -1185,17 +1273,17 @@ export const processOCR = async (
             try {
               const coffeeAttributes = {
                 corrected_text: correctedText,
-                origin: structuredMetadata?.origin ?? null,
-                roast_level: structuredMetadata?.roastLevel ?? null,
-                flavor_notes: structuredMetadata?.flavorNotes ?? null,
-                processing: structuredMetadata?.processing ?? null,
-                varietals: structuredMetadata?.varietals ?? null,
-                roast_date: structuredMetadata?.roastDate ?? null,
-                roaster: structuredMetadata?.roaster ?? null,
+                origin: evaluationStructuredMetadata?.origin ?? null,
+                roast_level: evaluationStructuredMetadata?.roastLevel ?? null,
+                flavor_notes: evaluationStructuredMetadata?.flavorNotes ?? null,
+                processing: evaluationStructuredMetadata?.processing ?? null,
+                varietals: evaluationStructuredMetadata?.varietals ?? null,
+                roast_date: evaluationStructuredMetadata?.roastDate ?? null,
+                roaster: evaluationStructuredMetadata?.roaster ?? null,
               };
               const payload: Record<string, unknown> = {
                 corrected_text: correctedText,
-                structured_metadata: structuredMetadata,
+                structured_metadata: evaluationStructuredMetadata,
                 coffee_attributes: coffeeAttributes,
               };
               if (options?.tasteProfile) {


### PR DESCRIPTION
### Motivation
- Ensure `origin`, `roast_level`, `flavor_notes`, `processing` and `varietals` are available even when structured OCR metadata is missing.  
- Persist these attributes into `scan_events` so recommendations and history contain more complete coffee data.  
- Make `/api/ocr/evaluate` grounded by providing structured metadata when the FE or OCR did not include explicit fields.  
- Prevent `coffee_attributes` from being an empty object by providing deterministic fallback estimates derived from corrected OCR text.

### Description
- Backend (`server/routes/ocr.js`): added helpers `normalizeCoffeeValue`, `parseDelimitedList`, and `extractCoffeeAttributesFromText`, then used derived attributes to populate `resolvedOrigin`, `resolvedRoastLevel`, `resolvedFlavorNotes`, `resolvedProcessing`, and `resolvedVarietals` when inserting into `scan_events` and when building `storedStructuredMetadata`.  
- Backend evaluate flow: merged derived attributes into `coffeeAttributes.structured_metadata` and filled top-level `coffee_attributes` fields so the AI evaluation receives estimated attribute values when explicit metadata is missing.  
- Frontend (`src/services/ocrServices.ts`): added `parseDelimitedList`, `estimateCoffeeAttributesFromText`, and `mergeStructuredMetadata`, and updated `processOCR()` to send `structured_metadata`/`coffee_attributes` populated with estimated values to `/api/ocr/evaluate`.  
- Parsing/normalization: supports label-based extraction (e.g. `origin: ...`, `roast: ...`, `flavor notes: ...`), delimited lists, and simple keyword heuristics for processing and roast level.

### Testing
- No automated tests were executed as part of this change.
- (No additional CI runs or unit tests were triggered by the rollout.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7008055c832a8f6637d0ab3ca96e)