### PR TITLE
Prefer request `taste_profile` for `/api/ocr/evaluate`

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -494,6 +494,49 @@ const isValidEvaluationResponse = (value) => {
   return true;
 };
 
+const isTasteProfileComplete = (profile) => {
+  if (!profile || typeof profile !== 'object') {
+    return false;
+  }
+
+  if (profile.is_complete === true || profile.taste_profile_completed === true) {
+    return true;
+  }
+
+  const tasteVector =
+    profile.taste_vector && typeof profile.taste_vector === 'object'
+      ? profile.taste_vector
+      : profile.preferences && typeof profile.preferences === 'object'
+      ? profile.preferences
+      : profile;
+
+  const values = [
+    tasteVector.sweetness,
+    tasteVector.acidity,
+    tasteVector.bitterness,
+    tasteVector.body,
+  ];
+
+  return values.every(
+    (value) => typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 10
+  );
+};
+
+const normalizeTasteProfileForEvaluation = (profile) => {
+  if (!profile || typeof profile !== 'object') {
+    return profile;
+  }
+
+  const tasteVector =
+    profile.taste_vector && typeof profile.taste_vector === 'object'
+      ? profile.taste_vector
+      : profile.preferences && typeof profile.preferences === 'object'
+      ? profile.preferences
+      : null;
+
+  return tasteVector ? { ...profile, ...tasteVector } : profile;
+};
+
 // ========== OCR ENDPOINTS ==========
 
 /**
@@ -983,7 +1026,13 @@ router.post('/api/ocr/evaluate', async (req, res) => {
       name: decoded.name || decoded.user?.name,
     });
 
-    const { corrected_text, structured_metadata, structuredMetadata, coffee_attributes } = req.body;
+    const {
+      corrected_text,
+      structured_metadata,
+      structuredMetadata,
+      coffee_attributes,
+      taste_profile,
+    } = req.body ?? {};
     if (!corrected_text) return res.status(400).json({ error: 'Chýba text kávy' });
     correctedText = corrected_text;
 
@@ -992,11 +1041,16 @@ router.post('/api/ocr/evaluate', async (req, res) => {
       [uid]
     );
 
-    preferences = result.rows[0];
-    // ⬇️ Use the DB completion flag/view to determine if we can safely evaluate.
-    const isProfileComplete = Boolean(
-      preferences?.is_complete ?? preferences?.taste_profile_completed ?? false
+    const dbPreferences = result.rows[0];
+    const requestTasteProfile =
+      taste_profile && typeof taste_profile === 'object' ? taste_profile : null;
+    const normalizedRequestTasteProfile = normalizeTasteProfileForEvaluation(requestTasteProfile);
+    const isRequestProfileComplete = isTasteProfileComplete(normalizedRequestTasteProfile);
+    const isDbProfileComplete = Boolean(
+      dbPreferences?.is_complete ?? dbPreferences?.taste_profile_completed ?? false
     );
+    preferences = isRequestProfileComplete ? normalizedRequestTasteProfile : dbPreferences;
+    const isProfileComplete = isRequestProfileComplete || isDbProfileComplete;
 
     if (!isProfileComplete) {
       // ⬇️ Short-circuit with the strict JSON schema when profile is incomplete.


### PR DESCRIPTION
### Motivation
- Allow the frontend to provide a complete taste profile and use it immediately for OCR evaluation without requiring a DB-stored profile.
- Make evaluation possible when the request includes a complete profile, improving UX for users who just completed the profile in the FE.

### Description
- Accepts `taste_profile` from the request body in `POST /api/ocr/evaluate` and prefers it when complete over the DB profile.
- Adds `isTasteProfileComplete` to validate completeness and `normalizeTasteProfileForEvaluation` to expose top-level preference fields for evaluation.
- Chooses `preferences = normalizedRequestTasteProfile` when the request profile is complete, otherwise falls back to DB preferences, and computes `isProfileComplete` accordingly.
- Keeps existing fallbacks and AI prompt logic but short-circuits with `PROFILE_MISSING_RESPONSE` only if neither the request nor DB profile is complete.

### Testing
- No automated tests were run against the modified code.
- Manual code linting or runtime checks were not performed as part of this change.
- Local compilation or type checks were not executed in this rollout.
- Further automated tests should be added to cover request-provided profiles and the new completeness logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d819f5040832aa4ba2dbb6a264ce0)