### PR TITLE
Add `summary` to OCR evaluation schema and fallbacks

### DIFF
--- a/server/routes/__tests__/ocr-evaluation.test.js
+++ b/server/routes/__tests__/ocr-evaluation.test.js
@@ -6,6 +6,7 @@ describe('isValidEvaluationResponse', () => {
       status: 'ok',
       verdict: 'suitable',
       confidence: 0.82,
+      summary: 'Káva sa javí ako vhodná podľa profilu.',
       verdict_explanation: {
         user_preferences_summary: 'Používateľ preferuje sladšie kávy.',
         coffee_profile_summary: 'Káva má ovocné tóny a strednú aciditu.',
@@ -30,6 +31,7 @@ describe('isValidEvaluationResponse', () => {
       status: 'ok',
       verdict: null,
       confidence: null,
+      summary: 'Neplatné hodnotenie.',
       verdict_explanation: {
         user_preferences_summary: 'Chýba verdict.',
         coffee_profile_summary: 'Chýba verdict.',

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -16,6 +16,8 @@ const PROFILE_MISSING_RESPONSE = {
   status: 'profile_missing',
   verdict: null,
   confidence: null,
+  summary:
+    'Chuťový profil nie je dokončený, preto zatiaľ nevieme zhrnúť vhodnosť kávy.',
   verdict_explanation: {
     user_preferences_summary:
       'Tvoje preferencie: chuťový profil nie je dokončený, takže nemáme kompletné preferencie.',
@@ -45,6 +47,7 @@ const INSUFFICIENT_COFFEE_DATA_RESPONSE = {
   status: 'insufficient_coffee_data',
   verdict: null,
   confidence: null,
+  summary: 'Chýbajú dôležité údaje o káve, preto nevieme urobiť stručné zhrnutie.',
   verdict_explanation: {
     user_preferences_summary:
       'Tvoje preferencie: chuťové preferencie máme uložené, ale chýbajú detaily o káve.',
@@ -126,11 +129,16 @@ const buildDeterministicFallbackResponse = ({ preferences, coffeeAttributes, cor
       : `Porovnanie s tvojím profilom: textová zhoda vychádza na ${Math.round(
           normalizedScore
         )} %, preto kávu hodnotíme ako menej vhodnú.`;
+  const summary =
+    verdict === 'suitable'
+      ? 'Na základe dostupných údajov sa káva javí ako vhodná.'
+      : 'Na základe dostupných údajov sa káva javí ako menej vhodná.';
 
   return {
     status: 'ok',
     verdict,
     confidence,
+    summary,
     verdict_explanation: {
       user_preferences_summary: userPreferencesSummary,
       coffee_profile_summary: coffeeProfileSummary,
@@ -166,6 +174,7 @@ const EVALUATION_RESPONSE_SCHEMA = `JSON schema (strict):
   "status": "ok" | "profile_missing" | "insufficient_coffee_data",
   "verdict": "suitable" | "not_suitable" | "uncertain" | null,
   "confidence": number | null,
+  "summary": string,
   "verdict_explanation": {
     "user_preferences_summary": string,
     "coffee_profile_summary": string,
@@ -191,6 +200,7 @@ const EVALUATION_RESPONSE_JSON_SCHEMA = {
     'status',
     'verdict',
     'confidence',
+    'summary',
     'verdict_explanation',
     'insight',
     'disclaimer',
@@ -206,6 +216,9 @@ const EVALUATION_RESPONSE_JSON_SCHEMA = {
     },
     confidence: {
       type: ['number', 'null'],
+    },
+    summary: {
+      type: 'string',
     },
     verdict_explanation: {
       type: 'object',
@@ -413,6 +426,7 @@ const isValidEvaluationResponse = (value) => {
     'status',
     'verdict',
     'confidence',
+    'summary',
     'verdict_explanation',
     'insight',
     'disclaimer',
@@ -425,6 +439,7 @@ const isValidEvaluationResponse = (value) => {
     status,
     verdict,
     confidence,
+    summary,
     verdict_explanation,
     insight,
     disclaimer,
@@ -444,6 +459,10 @@ const isValidEvaluationResponse = (value) => {
   }
 
   if (confidence !== null && (typeof confidence !== 'number' || Number.isNaN(confidence))) {
+    return false;
+  }
+
+  if (typeof summary !== 'string') {
     return false;
   }
 
@@ -1116,7 +1135,8 @@ router.post('/api/ocr/evaluate', async (req, res) => {
 Odpovedaj výhradne v slovenčine.
 Vráť striktne platný JSON podľa zadanej schémy, bez markdownu a bez dodatočného textu.
 Nikdy nehádaj chýbajúce dáta. Ak chýba profil alebo údaje o káve, priznaj neistotu podľa schémy.
-Verdict a insight musia vychádzať z toho istého porovnania preferencií a atribútov kávy a nesmú si odporovať.`;
+Verdict a insight musia vychádzať z toho istého porovnania preferencií a atribútov kávy a nesmú si odporovať.
+Zhrnutie (summary) musí byť stručná, jedno-vetná syntéza výsledku.`;
 const userPrompt = `Vyhodnoť vhodnosť naskenovanej kávy pre používateľa.
 
 PRAVIDLÁ:
@@ -1124,6 +1144,7 @@ PRAVIDLÁ:
 - Ak chýba alebo je neúplný chuťový profil → status="profile_missing", verdict=null.
 - Ak chýbajú kľúčové atribúty kávy → status="insufficient_coffee_data", verdict=null.
 - Ak sú dáta dostatočné → status="ok" a verdict je "suitable" | "not_suitable" | "uncertain".
+- summary je jedna krátka veta, ktorá stručne zhrnie výsledok pre používateľa.
 - Každé pole verdict_explanation musí byť presne jedna veta v tomto formáte:
   - user_preferences_summary začína "Tvoje preferencie:" a stručne zhrnie chuťový profil.
   - coffee_profile_summary začína "Profil kávy:" a stručne zhrnie profil kávy.

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -532,13 +532,18 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
   const normalizedInsight =
     normalizeEvaluationInsight(record.insight) ??
     (fallbackInsightSections.length ? { headline: '', sections: fallbackInsightSections } : null);
+  const verdictExplanationFallback = normalizeVerdictExplanation(record.verdict_explanation);
+  const verdictExplanationText = resolveVerdictExplanationText(verdictExplanationFallback);
   if (normalizedStatus === 'profile_missing') {
     // Preserve profile-missing payloads so the UI can display the CTA and guidance text.
     return {
       status: normalizedStatus,
       verdict: null,
       confidence: null,
-      summary: typeof record.summary === 'string' ? record.summary : '',
+      summary: normalizeEvaluationText(
+        record.summary,
+        verdictExplanationText || NEUTRAL_EVALUATION_COPY.summary
+      ),
       reasons: [],
       what_youll_like: whatYoullLike,
       what_might_bother_you: whatMightBotherYou,
@@ -566,7 +571,12 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       status: normalizedStatus,
       verdict: null,
       confidence: null,
-      summary: typeof record.summary === 'string' ? record.summary : '',
+      summary: normalizeEvaluationText(
+        record.summary,
+        useNeutralCopy
+          ? verdictExplanationText || NEUTRAL_EVALUATION_COPY.summary
+          : verdictExplanationText
+      ),
       reasons: [],
       what_youll_like: whatYoullLike,
       what_might_bother_you: whatMightBotherYou,
@@ -581,7 +591,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
             record.verdict_explanation,
             NEUTRAL_EVALUATION_COPY.verdict_explanation
           )
-        : normalizeVerdictExplanation(record.verdict_explanation),
+        : verdictExplanationFallback,
       insight: normalizedInsight,
       raw: payload,
     };
@@ -589,8 +599,11 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
   const confidenceValue =
     typeof record.confidence === 'number' ? record.confidence : null;
   const summary = useNeutralCopy
-    ? normalizeEvaluationText(record.summary, NEUTRAL_EVALUATION_COPY.summary)
-    : normalizeEvaluationText(record.summary);
+    ? normalizeEvaluationText(
+        record.summary,
+        verdictExplanationText || NEUTRAL_EVALUATION_COPY.summary
+      )
+    : normalizeEvaluationText(record.summary, verdictExplanationText);
   const reasons = normalizeEvaluationReasons(record.reasons);
 
   return {
@@ -621,7 +634,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
           record.verdict_explanation,
           NEUTRAL_EVALUATION_COPY.verdict_explanation
         )
-      : normalizeVerdictExplanation(record.verdict_explanation),
+      : verdictExplanationFallback,
     insight: normalizedInsight,
     raw: payload,
   };


### PR DESCRIPTION
### Motivation
- Provide a short, one-sentence human-readable summary for AI evaluations so the FE can display a concise result to users. 
- Ensure the backend strictly validates and requests the `summary` from the LLM to avoid missing UI copy and inconsistencies. 
- Keep deterministic fallbacks and UI behavior resilient when the model response lacks a `summary`.

### Description
- Added `summary` to backend fallback responses (`PROFILE_MISSING_RESPONSE`, `INSUFFICIENT_COFFEE_DATA_RESPONSE`) and to the deterministic fallback created by `buildDeterministicFallbackResponse` so all fallbacks include a short summary string. 
- Extended the evaluation contract by adding `summary` to `EVALUATION_RESPONSE_SCHEMA` and `EVALUATION_RESPONSE_JSON_SCHEMA`, and updated `isValidEvaluationResponse` to require a string `summary`. 
- Updated the OpenAI prompts (`systemPrompt` / `userPrompt`) to instruct the model to return a concise one-sentence `summary` and included the `summary` rule in the prompt text. 
- Added frontend normalization/fallback logic in `normalizeEvaluationResponse` (`src/services/ocrServices.ts`) to derive `summary` from `verdict_explanation` or neutral copy when the backend response is missing `summary`, and updated the unit test expectations in `server/routes/__tests__/ocr-evaluation.test.js`.

### Testing
- Updated unit tests in `server/routes/__tests__/ocr-evaluation.test.js` to include the new `summary` field in sample responses. 
- No automated tests or CI runs were executed during this change (no test runner output available). 
- Manual static checks: code compiled locally via commit tooling (files staged and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d82ae9880832a97b7c8b291817d83)