### PR TITLE
Normalize taste vector scaling for AI (0–1 ↔ 0–10)

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -20,6 +20,8 @@ import {
   buildFallbackAIResponse,
   buildRecommendationText,
   callOpenAIJsonSchema,
+  normalizeTasteVectorTo01,
+  normalizeTasteVectorTo10,
   parseTasteAIResponse,
   TASTE_AI_SCHEMA_PROMPT,
 } from './tasteAiUtils';
@@ -216,13 +218,17 @@ const CoffeePreferenceForm = ({
 
       if (res.ok) {
         const data = await res.json();
+        const storedTasteVector = data.coffee_preferences?.taste_vector ?? data.taste_vector;
+        const normalizedTasteVector = storedTasteVector
+          ? normalizeTasteVectorTo10(storedTasteVector)
+          : undefined;
         console.log('📥 [BE] Loaded preferences:', data);
         if (data.coffee_preferences?.quiz_answers) {
           setAnswers(data.coffee_preferences.quiz_answers);
         }
         setPreviousProfile({
           quiz_answers: data.coffee_preferences?.quiz_answers,
-          taste_vector: data.coffee_preferences?.taste_vector ?? data.taste_vector,
+          taste_vector: normalizedTasteVector,
           ai_recommendation: data.coffee_preferences?.ai_recommendation ?? data.ai_recommendation,
           consistency_score: data.coffee_preferences?.consistency_score ?? data.consistency_score,
         });
@@ -352,6 +358,10 @@ const CoffeePreferenceForm = ({
         priorProfile?.quiz_answers,
       );
       const deltaSummary = answerDeltas.length > 0 ? answerDeltas.join('\n') : 'Žiadne zmeny.';
+      const normalizedPriorTasteVector = priorProfile?.taste_vector
+        ? normalizeTasteVectorTo01(priorProfile.taste_vector)
+        : null;
+      const normalizedFallbackVector = normalizeTasteVectorTo01(fallbackVector);
 
       const systemPrompt = `Si deterministický engine pre chuťové profily kávy.
 Výstup musí byť výhradne JSON podľa schémy (bez Markdownu, bez extra textu).
@@ -394,7 +404,7 @@ ${deltaSummary}
 Previous profile (if any):
 ${JSON.stringify(
         {
-          taste_vector: priorProfile?.taste_vector ?? null,
+          taste_vector: normalizedPriorTasteVector,
           ai_recommendation: priorProfile?.ai_recommendation ?? null,
           consistency_score: priorProfile?.consistency_score ?? null,
         },
@@ -403,7 +413,7 @@ ${JSON.stringify(
       )}
 
 Fallback taste vector (computed from weights):
-${JSON.stringify(fallbackVector, null, 2)}
+${JSON.stringify(normalizedFallbackVector, null, 2)}
 
 Rules for taste_vector:
 - Output floats between 0.0 and 1.0
@@ -444,7 +454,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
         console.warn('⚠️  AI response validation warnings:', warnings);
       }
 
-      const tasteVector = parsedResponse.taste_vector;
+      const tasteVector = normalizeTasteVectorTo10(parsedResponse.taste_vector);
       const confidence = parsedResponse.confidence;
       const profileText = buildRecommendationText(parsedResponse);
 
@@ -456,7 +466,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
     } catch (err) {
       console.error('AI error:', err);
       return {
-        tasteVector: fallbackResponse.taste_vector,
+        tasteVector: normalizeTasteVectorTo10(fallbackResponse.taste_vector),
         confidence: fallbackResponse.confidence,
         profileText: buildRecommendationText(fallbackResponse),
       };
@@ -512,12 +522,13 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
       console.log('📥 [BE] Save response:', resData);
       if (!res.ok) throw new Error('Failed to save preferences');
       const updatedProfile = resData?.coffee_preferences ?? null;
+      const updatedTasteVector = updatedProfile?.taste_vector ?? tasteVector;
       setRecommendation(profileText);
       setShowRecommendation(true);
       // Uložíme si aj lokálny snapshot pre ďalšie AI delty bez nutnosti refetchu.
       setPreviousProfile({
         quiz_answers: updatedProfile?.quiz_answers ?? answers,
-        taste_vector: updatedProfile?.taste_vector ?? tasteVector,
+        taste_vector: normalizeTasteVectorTo10(updatedTasteVector),
         ai_recommendation: resData?.ai_recommendation ?? profileText,
         consistency_score: updatedProfile?.consistency_score ?? confidence,
       });

--- a/src/components/personalization/EditPreferences.tsx
+++ b/src/components/personalization/EditPreferences.tsx
@@ -22,6 +22,7 @@ import {
   buildFallbackAIResponse,
   buildRecommendationText,
   callOpenAIJsonSchema,
+  normalizeTasteVectorTo01,
   parseTasteAIResponse,
   TASTE_AI_SCHEMA_PROMPT,
   TasteVector,
@@ -93,7 +94,8 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
   const generateAI = async (additionalNotes: string, options?: { reset?: boolean }) => {
     try {
       const fallbackVector = getFallbackTasteVector();
-      const fallback = buildFallbackAIResponse(fallbackVector);
+      const normalizedFallbackVector = normalizeTasteVectorTo01(fallbackVector);
+      const fallback = buildFallbackAIResponse(normalizedFallbackVector);
       const isReset = options?.reset;
 
       const systemPrompt = `Si deterministický engine pre chuťové profily kávy.
@@ -109,7 +111,7 @@ Preferences snapshot:
 ${JSON.stringify(profile?.coffee_preferences ?? {}, null, 2)}
 
 Fallback taste vector (computed from profile if available):
-${JSON.stringify(fallbackVector, null, 2)}`;
+${JSON.stringify(normalizedFallbackVector, null, 2)}`;
 
       if (!isReset && currentRecommendation) {
         prompt += `\n\nCurrent recommendation:\n${currentRecommendation}`;
@@ -159,7 +161,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
       // Validate and coerce the structured JSON so invalid output does not break the UI.
       const { response: parsedResponse, warnings } = parseTasteAIResponse(
         aiResponse,
-        fallbackVector,
+        normalizedFallbackVector,
       );
       // Fall back to a safe default if the model omitted fields or returned malformed JSON.
       if (warnings.length > 0) {

--- a/src/components/personalization/tasteAiUtils.ts
+++ b/src/components/personalization/tasteAiUtils.ts
@@ -29,15 +29,21 @@ const TASTE_DIMENSIONS: Array<keyof TasteVector> = [
 ];
 
 export const DEFAULT_TASTE_VECTOR: TasteVector = {
-  acidity: 0.45,
-  bitterness: 0.55,
-  sweetness: 0.5,
-  body: 0.55,
-  intensity: 0.5,
-  experimentalism: 0.35,
+  acidity: 4.5,
+  bitterness: 5.5,
+  sweetness: 5,
+  body: 5.5,
+  intensity: 5,
+  experimentalism: 3.5,
 };
 
-const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+const TASTE_VECTOR_MAX = 10;
+
+const clampRange = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const clamp01 = (value: number) => clampRange(value, 0, 1);
+
+const clamp10 = (value: number) => clampRange(value, 0, TASTE_VECTOR_MAX);
 
 const coerceNumber = (value: unknown, fallback: number) => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -76,6 +82,34 @@ const sanitizeTasteVector = (value: unknown, fallback: TasteVector): TasteVector
     sanitized[dimension] = clamp01(coerceNumber(vector[dimension], fallback[dimension]));
   });
   return sanitized;
+};
+
+const normalizeTasteValueTo01 = (value: unknown, fallback: number) => {
+  const raw = coerceNumber(value, fallback);
+  const normalized = raw > 1 ? raw / TASTE_VECTOR_MAX : raw;
+  return clamp01(normalized);
+};
+
+const normalizeTasteValueTo10 = (value: unknown, fallback: number) => {
+  const raw = coerceNumber(value, fallback);
+  const normalized = raw <= 1 ? raw * TASTE_VECTOR_MAX : raw;
+  return clamp10(normalized);
+};
+
+export const normalizeTasteVectorTo01 = (vector: TasteVector): TasteVector => {
+  const normalized: TasteVector = { ...vector };
+  TASTE_DIMENSIONS.forEach(dimension => {
+    normalized[dimension] = normalizeTasteValueTo01(vector[dimension], DEFAULT_TASTE_VECTOR[dimension]);
+  });
+  return normalized;
+};
+
+export const normalizeTasteVectorTo10 = (vector: TasteVector): TasteVector => {
+  const normalized: TasteVector = { ...vector };
+  TASTE_DIMENSIONS.forEach(dimension => {
+    normalized[dimension] = normalizeTasteValueTo10(vector[dimension], DEFAULT_TASTE_VECTOR[dimension]);
+  });
+  return normalized;
 };
 
 export const buildFallbackAIResponse = (fallbackVector: TasteVector): TasteAIResponse => ({

--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -85,6 +85,15 @@ function parseVectorNumber(value: unknown): number | null {
   return null;
 }
 
+const normalizeTasteVectorScore = (value: unknown, fallback: number): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const scaled = parsed <= 1 ? parsed * 10 : parsed;
+  return clamp(scaled);
+};
+
 /**
  * Normalizes a raw taste vector into the expected profile shape.
  *
@@ -504,11 +513,12 @@ export function buildTasteRadarScores({ profile, preferences }: TasteRadarSource
     const hasDetailedPreferences = Boolean(preferences.roast || preferences.intensity || preferences.preferredDrinks.length > 0);
 
     if (preferences.tasteVector && !hasDetailedPreferences) {
+      // tasteVector uses a 0–10 scale across the product; normalize if legacy 0–1 values appear.
       const normalizedVector = {
-        sweetness: safeNumber(preferences.tasteVector.sweetness, base.sweetness),
-        acidity: safeNumber(preferences.tasteVector.acidity, base.acidity),
-        body: safeNumber(preferences.tasteVector.body, base.body),
-        bitterness: safeNumber(preferences.tasteVector.bitterness, base.bitterness),
+        sweetness: normalizeTasteVectorScore(preferences.tasteVector.sweetness, base.sweetness),
+        acidity: normalizeTasteVectorScore(preferences.tasteVector.acidity, base.acidity),
+        body: normalizeTasteVectorScore(preferences.tasteVector.body, base.body),
+        bitterness: normalizeTasteVectorScore(preferences.tasteVector.bitterness, base.bitterness),
       };
       base.sweetness = blend(base.sweetness, normalizedVector.sweetness, 0.6);
       base.acidity = blend(base.acidity, normalizedVector.acidity, 0.6);


### PR DESCRIPTION
### Motivation
- Unify taste vector scale across the product so AI prompts use 0–1 while stored/UI values remain 0–10.
- Ensure AI receives normalized inputs and returns values that the frontend/backend persist consistently.
- Prevent mismatch bugs when older profiles use 0–1 values or new code expects 0–10 values.
- Make radar score building resilient to mixed-scale inputs.

### Description
- Add scaling helpers in `src/components/personalization/tasteAiUtils.ts`: `normalizeTasteVectorTo01` and `normalizeTasteVectorTo10`, plus range clamps and conversion helpers, and change `DEFAULT_TASTE_VECTOR` to the 0–10 baseline.
- Normalize stored/profile taste vectors to 0–10 when loading in `src/components/personalization/CoffeePreferenceForm.tsx` and convert `priorProfile`/`fallbackVector` to 0–1 when building the AI prompt, then convert AI `taste_vector` responses back to 0–10 before saving.
- Use normalized 0–1 fallback vectors in `src/components/personalization/EditPreferences.tsx` when calling AI so prompts match the schema.
- Update `src/utils/tasteProfile.ts` to detect legacy 0–1 values via `normalizeTasteVectorScore` and scale them to 0–10 before blending into radar scores, with an inline comment documenting the scale handling.

### Testing
- No automated tests were run as part of this change.
- Manual validation: basic load/save and AI prompt construction were updated in code paths but no CI test executed.
- No unit tests added or modified for the new conversion helpers.
- Recommend adding unit tests for `normalizeTasteVectorTo01`, `normalizeTasteVectorTo10`, and `normalizeTasteVectorScore` in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8b589c84832aa60dfac919bb08d6)