### PR TITLE
Use shared auth token in CoffeeTasteScanner

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -25,7 +25,6 @@ import { launchImageLibrary, ImagePickerResponse, ImageLibraryOptions } from 're
 import ImageResizer from 'react-native-image-resizer';
 import RNFS from 'react-native-fs';
 import NetInfo from '@react-native-community/netinfo';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { scannerStyles } from './styles';
 import {
   processOCR,
@@ -43,6 +42,7 @@ import {
   toggleFavorite,
   isCoffeeRelatedText,
 } from './services';
+import { getAuthToken } from '../../services/ocrServices';
 import {
   computeSignalWeight,
   CoffeeSignalRecord,
@@ -686,8 +686,9 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
 
   const loadPreferenceSnapshot = useCallback(async () => {
     try {
-      const token = await AsyncStorage.getItem('@AuthToken');
+      const token = await getAuthToken();
       if (!token) {
+        showToast('Prihlás sa, prosím.');
         return;
       }
       const response = await fetch(`${API_URL}/profile`, {

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -739,7 +739,7 @@ interface OCRResult {
  *
  * @returns {Promise<string|null>} ID token string or `null` when no authenticated user is available.
  */
-const getAuthToken = async (): Promise<string | null> => {
+export const getAuthToken = async (): Promise<string | null> => {
   try {
     const user = auth().currentUser;
     if (!user) return null;


### PR DESCRIPTION
### Motivation
- Consolidate auth token retrieval so all FE calls use a single helper instead of ad-hoc `AsyncStorage` access.
- Reduce duplication and potential mismatch between services by reusing `getAuthToken` from OCR services.
- Provide a clearer user-facing message when a token is missing during profile fetch.

### Description
- Export `getAuthToken` from `src/services/ocrServices.ts` as `export const getAuthToken` for shared use across the frontend.
- Replace `AsyncStorage.getItem('@AuthToken')` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` with `await getAuthToken()` and remove the `AsyncStorage` import.
- Add a user-facing toast call `showToast('Prihlás sa, prosím.')` when no auth token is available before attempting the profile fetch.

### Testing
- No automated tests were executed for this change.
- Local type checks or lint steps were not run as part of this change.
- Runtime behavior: manual review verifies `CoffeeTasteScanner` now imports and calls `getAuthToken` and shows the toast when token is missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8e267a10832ab5d0245967ad83a7)