### PR TITLE
Sanitize and truncate server logs; reduce OCR/OpenAI verbosity

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,11 +16,68 @@ app.use(express.json({ limit: '20mb' }));
 
 app.use(cors(corsOptions));
 
+const MAX_LOG_BODY_BYTES = 5000;
+const MAX_LOG_VALUE_LENGTH = 200;
+const SENSITIVE_KEY_PATTERN =
+  /(password|token|secret|authorization|base64image|prompt|image|ocr|text)/i;
+
+const truncateValue = (value) => {
+  if (typeof value !== 'string') return value;
+  if (value.length <= MAX_LOG_VALUE_LENGTH) return value;
+  return `${value.slice(0, MAX_LOG_VALUE_LENGTH)}…[truncated ${value.length - MAX_LOG_VALUE_LENGTH} chars]`;
+};
+
+const sanitizeForLog = (value, key) => {
+  if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+    if (typeof value === 'string') {
+      return `[REDACTED ${value.length} chars]`;
+    }
+    return '[REDACTED]';
+  }
+
+  if (Array.isArray(value)) {
+    const preview = value.slice(0, 20).map((entry) => sanitizeForLog(entry));
+    return value.length > 20
+      ? [...preview, `…(${value.length - 20} more items)`]
+      : preview;
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce((acc, [childKey, childValue]) => {
+      acc[childKey] = sanitizeForLog(childValue, childKey);
+      return acc;
+    }, {});
+  }
+
+  return truncateValue(value);
+};
+
+const summarizeBody = (body) => {
+  const keys = Object.keys(body || {});
+  const base64image = typeof body?.base64image === 'string' ? body.base64image : null;
+  const mimeTypeMatch = base64image?.match(/^data:([^;]+);base64,/);
+  return {
+    bodySizeBytes: Buffer.byteLength(JSON.stringify(body || {})),
+    keys,
+    base64image: base64image
+      ? {
+          length: base64image.length,
+          mimeType: mimeTypeMatch?.[1] ?? 'unknown',
+        }
+      : undefined,
+  };
+};
+
 // Global request logger to capture communication from frontend
 app.use((req, _res, next) => {
   const base = `➡️  [${new Date().toISOString()}] ${req.method} ${req.originalUrl}`;
   if (req.body && Object.keys(req.body).length > 0) {
-    console.log(base, req.body);
+    const bodySize = Buffer.byteLength(JSON.stringify(req.body));
+    const isOcrRoute =
+      req.originalUrl.startsWith('/ocr') || req.originalUrl.startsWith('/api/ocr');
+    const shouldSummarize = isOcrRoute || bodySize > MAX_LOG_BODY_BYTES;
+    const payload = shouldSummarize ? summarizeBody(req.body) : sanitizeForLog(req.body);
+    console.log(base, payload);
   } else {
     console.log(base);
   }

--- a/server/db.js
+++ b/server/db.js
@@ -56,7 +56,10 @@ const ensureAppUserExists = async (userId, email, options = {}) => {
 // Wrap default query method to log all interactions with Supabase
 const originalQuery = db.query.bind(db);
 db.query = async (text, params) => {
-  console.log('📤 [Supabase] Query:', text, params);
+  console.log('📤 [Supabase] Query:', {
+    text,
+    paramCount: Array.isArray(params) ? params.length : 0,
+  });
   const start = Date.now();
   const res = await originalQuery(text, params);
   console.log('📥 [Supabase] Response:', {

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -541,7 +541,7 @@ const normalizeTasteProfileForEvaluation = (profile) => {
 
 /**
  * Spracuje obrázok a pošle ho do Google Vision API na OCR.
- * Loguje dĺžku vstupného obrázka a odpoveď z Vision API.
+ * Loguje dĺžku vstupného obrázka a meta-informácie z Vision API.
  */
 router.post('/ocr', async (req, res) => {
   try {
@@ -564,8 +564,6 @@ router.post('/ocr', async (req, res) => {
     const response = await axios.post(url, payload, {
       headers: { 'Content-Type': 'application/json' },
     });
-    console.log('📥 [Vision] Response:', response.data);
-
     const visionResponse = response.data.responses?.[0] || {};
     const text = visionResponse.fullTextAnnotation?.text || '';
     const labelAnnotations = Array.isArray(visionResponse.labelAnnotations)
@@ -608,6 +606,10 @@ router.post('/ocr', async (req, res) => {
     const isCoffee =
       typeof coffeeConfidence === 'number' ? coffeeConfidence >= 0.6 : undefined;
 
+    console.log('📥 [Vision] Response meta:', {
+      textLength: text.length,
+      labelCount: labels.length,
+    });
     res.json({ text, labels, coffeeConfidence, isCoffee });
   } catch (error) {
     console.error('OCR server error:', error?.message ?? error);
@@ -637,7 +639,10 @@ OCR text:
 ${text}`;
 
   try {
-    console.log('📤 [OpenAI] OCR prompt:', prompt);
+    console.log('📤 [OpenAI] OCR prompt meta:', {
+      model: 'gpt-4o',
+      chars: prompt.length,
+    });
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
@@ -660,7 +665,11 @@ ${text}`;
       }
     );
 
-    console.log('📥 [OpenAI] OCR response:', response.data);
+    console.log('📥 [OpenAI] OCR response meta:', {
+      id: response.data?.id,
+      model: response.data?.model,
+      usage: response.data?.usage,
+    });
     const corrected =
       response.data?.choices?.[0]?.message?.content?.trim() || text;
     return res.json({ corrected_text: corrected });
@@ -689,7 +698,10 @@ router.post('/api/ocr/brewing-methods', async (req, res) => {
     `Odpovedz len zoznamom metód oddelených novým riadkom. Popis: "${text}"`;
 
   try {
-    console.log('📤 [OpenAI] Brewing prompt:', prompt);
+    console.log('📤 [OpenAI] Brewing prompt meta:', {
+      model: 'gpt-4o',
+      chars: prompt.length,
+    });
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
@@ -712,7 +724,11 @@ router.post('/api/ocr/brewing-methods', async (req, res) => {
       }
     );
 
-    console.log('📥 [OpenAI] Brewing response:', response.data);
+    console.log('📥 [OpenAI] Brewing response meta:', {
+      id: response.data?.id,
+      model: response.data?.model,
+      usage: response.data?.usage,
+    });
     const content = response.data?.choices?.[0]?.message?.content || '';
     let methods = content
       .split('\n')
@@ -752,7 +768,10 @@ router.post('/api/ocr/brew-recipe', async (req, res) => {
   } chuť. Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.`;
 
   try {
-    console.log('📤 [OpenAI] Recipe prompt:', prompt);
+    console.log('📤 [OpenAI] Recipe prompt meta:', {
+      model: 'gpt-4o',
+      chars: prompt.length,
+    });
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
@@ -774,7 +793,11 @@ router.post('/api/ocr/brew-recipe', async (req, res) => {
       }
     );
 
-    console.log('📥 [OpenAI] Recipe response:', response.data);
+    console.log('📥 [OpenAI] Recipe response meta:', {
+      id: response.data?.id,
+      model: response.data?.model,
+      usage: response.data?.usage,
+    });
     const recipe = response.data?.choices?.[0]?.message?.content?.trim() || '';
     return res.json({ recipe });
   } catch (error) {
@@ -1008,7 +1031,7 @@ router.post('/api/ocr/save', async (req, res) => {
 
 /**
  * Vyhodnotí text kávy pomocou OpenAI na základe preferencií používateľa.
- * Loguje odoslaný prompt a odpoveď z OpenAI.
+ * Loguje meta-informácie o OpenAI požiadavke a odpovedi.
  */
 router.post('/api/ocr/evaluate', async (req, res) => {
   const idToken = req.headers.authorization?.split(' ')[1];
@@ -1148,7 +1171,10 @@ SCHEMA:
 ${EVALUATION_RESPONSE_SCHEMA}
 `;
 
-    console.log('📤 [OpenAI] Prompt:', userPrompt);
+    console.log('📤 [OpenAI] Prompt meta:', {
+      model: 'gpt-4o',
+      chars: userPrompt.length,
+    });
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
@@ -1177,7 +1203,11 @@ ${EVALUATION_RESPONSE_SCHEMA}
         },
       }
     );
-    console.log('📥 [OpenAI] Response:', response.data);
+    console.log('📥 [OpenAI] Response meta:', {
+      id: response.data?.id,
+      model: response.data?.model,
+      usage: response.data?.usage,
+    });
 
     const aiMessage = response.data.choices?.[0]?.message?.content?.trim();
     let parsed;


### PR DESCRIPTION
### Motivation
- Prevent sensitive or very large request bodies (e.g. `base64image`, prompts, tokens) from being recorded in plaintext logs.
- Avoid leaking query parameters and other potentially sensitive DB parameters in logs.
- Keep logs useful for debugging while bounding size to avoid huge log entries and noise.
- Ensure OCR/OpenAI interactions only emit metadata instead of full payloads or responses.

### Description
- Added request sanitization and summarization in `server/app.js` with `SENSITIVE_KEY_PATTERN`, `truncateValue`, `sanitizeForLog` and `summarizeBody` and logic to summarize `/ocr` or large bodies. 
- Changed global request logger to conditionally log a compact summary for OCR or large payloads and to truncate or redact sensitive fields instead of dumping raw `req.body`.
- Replaced detailed Supabase query parameter logging in `server/db.js` with a safe summary that logs `text` and `paramCount` only.
- Reduced verbosity in `server/routes/ocr.js` by removing full Vision/OpenAI payload logs and replacing them with concise metadata logs (e.g. prompt lengths, response `id`, `model`, `usage`, and Vision `textLength`/`labelCount`).

### Testing
- No automated tests were executed as part of this change.
- Code was lint/inspected locally by reading modified files to ensure logging calls and helpers compile logically. 
- Manual grep/inspection was used to verify replaced log locations for `OpenAI`/`Vision`/`prompt` occurrences. 
- Recommend running existing test suite and deploying to a staging environment to validate runtime logging behavior and JSON payload handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8ec9ad74832aa9dc3d6fbbdae16e)