### PR TITLE
Delay OCR save until coffee confirmed

### DIFF
--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -234,6 +234,7 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
     reason?: string;
     labels?: string[];
     confidence?: number;
+    refreshHistory?: boolean;
   }) => {
     setScanResult(null);
     setEditedText('');
@@ -257,6 +258,9 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
     });
     setNonCoffeeModalVisible(true);
     showToast('Skús prosím naskenovať etiketu kávy.');
+    if (details?.refreshHistory) {
+      void Promise.all([loadHistory(), loadRecipeHistory()]);
+    }
   };
 
   /**
@@ -355,6 +359,7 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
             reason: result.nonCoffeeReason,
             labels: result.detectionLabels,
             confidence: result.detectionConfidence,
+            refreshHistory: Boolean(result.scanId),
           });
           return;
         }
@@ -372,6 +377,7 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
             reason: result.nonCoffeeReason,
             labels: detectionLabels.length ? detectionLabels : undefined,
             confidence: result.detectionConfidence,
+            refreshHistory: Boolean(result.scanId),
           });
           return;
         }

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -933,6 +933,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     reason?: string;
     labels?: string[];
     confidence?: number;
+    refreshHistory?: boolean;
   }) => {
     applyScanResult(null);
     setEditedText('');
@@ -961,6 +962,9 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     });
     setNonCoffeeModalVisible(true);
     showToast('Skús prosím naskenovať etiketu kávy.');
+    if (details?.refreshHistory) {
+      void loadHistory();
+    }
   };
 
   const resolveCoffeeIdentity = (result: ScanResult | null, nameHint: string): { id: string; name: string } | null => {
@@ -1192,6 +1196,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
             reason: result.nonCoffeeReason,
             labels: detectionLabels.length ? detectionLabels : undefined,
             confidence: result.detectionConfidence,
+            refreshHistory: Boolean(result.scanId),
           });
           return;
         }
@@ -1303,13 +1308,17 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
           reason: existingResult.nonCoffeeReason,
           labels: existingResult.detectionLabels,
           confidence: existingResult.detectionConfidence,
+          refreshHistory: Boolean(existingResult.scanId),
         });
         return;
       }
 
       const label = existingResult?.corrected || (await recognizeCoffee(imagePath));
       if (!label) {
-        handleNonCoffeeDetected({ reason: 'Nepodarilo sa rozpoznať kávu. Skús to znova.' });
+        handleNonCoffeeDetected({
+          reason: 'Nepodarilo sa rozpoznať kávu. Skús to znova.',
+          refreshHistory: Boolean(existingResult?.scanId),
+        });
         return;
       }
 
@@ -1319,6 +1328,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
           reason: existingResult?.nonCoffeeReason ?? `Rozpoznané: ${label}`,
           labels: existingResult?.detectionLabels ?? [label],
           confidence: existingResult?.detectionConfidence,
+          refreshHistory: Boolean(existingResult?.scanId),
         });
         return;
       }

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1072,32 +1072,6 @@ export const processOCR = async (
       nonCoffeeReason = `Rozpoznané: ${detectionLabels.slice(0, 3).join(', ')}`;
     }
 
-    // 3. Ulož do databázy a získaj match percentage
-    const token = await getAuthToken();
-    if (!token) {
-      throw new Error('Nie si prihlásený');
-    }
-
-    const savePayload: Record<string, unknown> = {
-      original_text: originalText,
-      corrected_text: correctedText,
-    };
-    if (initialStructuredMetadata) {
-      savePayload.structured_metadata = initialStructuredMetadata;
-    }
-    if (initialStructuredConfidence) {
-      savePayload.structured_confidence = initialStructuredConfidence;
-    }
-
-    const saveResponse = await loggedFetch(`${API_URL}/ocr/save`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(savePayload),
-    });
-
     let matchPercentage = 0;
     let isRecommended = false;
     let scanId = '';
@@ -1106,121 +1080,149 @@ export const processOCR = async (
     let structuredUncertainty: Record<string, unknown> | null = null;
     let rawStructuredResponse: unknown = null;
 
-    if (saveResponse.ok) {
-      const saveData = await saveResponse.json();
-      console.log('📥 [BE] Save OCR response:', saveData);
-      matchPercentage = saveData.match_percentage || 0;
-      isRecommended = saveData.is_recommended || false;
-      scanId = saveData.id || '';
-
-      const metadataRaw =
-        saveData.structured_metadata ??
-        saveData.structuredMetadata ??
-        initialStructuredMetadata;
-      const metadataParsed = safeParseJSON<Record<string, any>>(metadataRaw);
-      if (metadataParsed && typeof metadataParsed === 'object') {
-        const normalizeString = (value: unknown): string | null => {
-          if (typeof value !== 'string') return null;
-          const trimmed = value.trim();
-          return trimmed.length > 0 ? trimmed : null;
-        };
-
-        const normalizeStringArray = (value: unknown): string[] | null => {
-          if (Array.isArray(value)) {
-            const cleaned = value
-              .map(item => (typeof item === 'string' ? item.trim() : ''))
-              .filter(Boolean);
-            return cleaned.length ? cleaned : null;
-          }
-          if (typeof value === 'string') {
-            const parts = value
-              .split(/[,;\n]/)
-              .map(part => part.trim())
-              .filter(Boolean);
-            return parts.length ? parts : null;
-          }
-          return null;
-        };
-
-        const confidenceSource =
-          metadataParsed.confidenceFlags ??
-          metadataParsed.confidence_flags ??
-          metadataParsed.flags ??
-          null;
-
-        let confidenceFlags: StructuredCoffeeMetadata['confidenceFlags'] = null;
-        if (confidenceSource && typeof confidenceSource === 'object') {
-          confidenceFlags = {
-            roaster:
-              typeof confidenceSource.roaster === 'boolean'
-                ? confidenceSource.roaster
-                : null,
-            origin:
-              typeof confidenceSource.origin === 'boolean'
-                ? confidenceSource.origin
-                : null,
-            roastLevel:
-              typeof confidenceSource.roastLevel === 'boolean'
-                ? confidenceSource.roastLevel
-                : typeof confidenceSource.roast_level === 'boolean'
-                ? confidenceSource.roast_level
-                : null,
-            processing:
-              typeof confidenceSource.processing === 'boolean'
-                ? confidenceSource.processing
-                : null,
-            flavorNotes:
-              typeof confidenceSource.flavorNotes === 'boolean'
-                ? confidenceSource.flavorNotes
-                : typeof confidenceSource.flavor_notes === 'boolean'
-                ? confidenceSource.flavor_notes
-                : null,
-            roastDate:
-              typeof confidenceSource.roastDate === 'boolean'
-                ? confidenceSource.roastDate
-                : typeof confidenceSource.roast_date === 'boolean'
-                ? confidenceSource.roast_date
-                : null,
-            varietals:
-              typeof confidenceSource.varietals === 'boolean'
-                ? confidenceSource.varietals
-                : null,
-          };
-        }
-
-        structuredMetadata = {
-          roaster:
-            normalizeString(metadataParsed.roaster ?? metadataParsed.roaster_name) ??
-            null,
-          origin: normalizeString(metadataParsed.origin),
-          roastLevel:
-            normalizeString(metadataParsed.roastLevel ?? metadataParsed.roast_level) ??
-            null,
-          processing: normalizeString(metadataParsed.processing),
-          flavorNotes:
-            normalizeStringArray(
-              metadataParsed.flavorNotes ?? metadataParsed.flavor_notes
-            ),
-          roastDate:
-            normalizeString(metadataParsed.roastDate ?? metadataParsed.roast_date) ??
-            null,
-          varietals: normalizeStringArray(metadataParsed.varietals),
-          confidenceFlags,
-        };
-
-        rawStructuredResponse = metadataParsed;
+    let token: string | null = null;
+    if (isCoffee) {
+      token = await getAuthToken();
+      if (!token) {
+        throw new Error('Nie si prihlásený');
       }
 
-      structuredConfidence = safeParseJSON<Record<string, unknown>>(
-        saveData.structured_confidence ??
-          saveData.structuredConfidence ??
-          initialStructuredConfidence
-      );
-      structuredUncertainty = safeParseJSON<Record<string, unknown>>(
-        saveData.structured_uncertainty
-      );
-      if (rawStructuredResponse == null) {
-        rawStructuredResponse = metadataRaw ?? null;
+      const savePayload: Record<string, unknown> = {
+        original_text: originalText,
+        corrected_text: correctedText,
+      };
+      if (initialStructuredMetadata) {
+        savePayload.structured_metadata = initialStructuredMetadata;
+      }
+      if (initialStructuredConfidence) {
+        savePayload.structured_confidence = initialStructuredConfidence;
+      }
+
+      const saveResponse = await loggedFetch(`${API_URL}/ocr/save`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(savePayload),
+      });
+
+      if (saveResponse.ok) {
+        const saveData = await saveResponse.json();
+        console.log('📥 [BE] Save OCR response:', saveData);
+        matchPercentage = saveData.match_percentage || 0;
+        isRecommended = saveData.is_recommended || false;
+        scanId = saveData.id || '';
+
+        const metadataRaw =
+          saveData.structured_metadata ??
+          saveData.structuredMetadata ??
+          initialStructuredMetadata;
+        const metadataParsed = safeParseJSON<Record<string, any>>(metadataRaw);
+        if (metadataParsed && typeof metadataParsed === 'object') {
+          const normalizeString = (value: unknown): string | null => {
+            if (typeof value !== 'string') return null;
+            const trimmed = value.trim();
+            return trimmed.length > 0 ? trimmed : null;
+          };
+
+          const normalizeStringArray = (value: unknown): string[] | null => {
+            if (Array.isArray(value)) {
+              const cleaned = value
+                .map(item => (typeof item === 'string' ? item.trim() : ''))
+                .filter(Boolean);
+              return cleaned.length ? cleaned : null;
+            }
+            if (typeof value === 'string') {
+              const parts = value
+                .split(/[,;\n]/)
+                .map(part => part.trim())
+                .filter(Boolean);
+              return parts.length ? parts : null;
+            }
+            return null;
+          };
+
+          const confidenceSource =
+            metadataParsed.confidenceFlags ??
+            metadataParsed.confidence_flags ??
+            metadataParsed.flags ??
+            null;
+
+          let confidenceFlags: StructuredCoffeeMetadata['confidenceFlags'] = null;
+          if (confidenceSource && typeof confidenceSource === 'object') {
+            confidenceFlags = {
+              roaster:
+                typeof confidenceSource.roaster === 'boolean'
+                  ? confidenceSource.roaster
+                  : null,
+              origin:
+                typeof confidenceSource.origin === 'boolean'
+                  ? confidenceSource.origin
+                  : null,
+              roastLevel:
+                typeof confidenceSource.roastLevel === 'boolean'
+                  ? confidenceSource.roastLevel
+                  : typeof confidenceSource.roast_level === 'boolean'
+                  ? confidenceSource.roast_level
+                  : null,
+              processing:
+                typeof confidenceSource.processing === 'boolean'
+                  ? confidenceSource.processing
+                  : null,
+              flavorNotes:
+                typeof confidenceSource.flavorNotes === 'boolean'
+                  ? confidenceSource.flavorNotes
+                  : typeof confidenceSource.flavor_notes === 'boolean'
+                  ? confidenceSource.flavor_notes
+                  : null,
+              roastDate:
+                typeof confidenceSource.roastDate === 'boolean'
+                  ? confidenceSource.roastDate
+                  : typeof confidenceSource.roast_date === 'boolean'
+                  ? confidenceSource.roast_date
+                  : null,
+              varietals:
+                typeof confidenceSource.varietals === 'boolean'
+                  ? confidenceSource.varietals
+                  : null,
+            };
+          }
+
+          structuredMetadata = {
+            roaster:
+              normalizeString(metadataParsed.roaster ?? metadataParsed.roaster_name) ??
+              null,
+            origin: normalizeString(metadataParsed.origin),
+            roastLevel:
+              normalizeString(metadataParsed.roastLevel ?? metadataParsed.roast_level) ??
+              null,
+            processing: normalizeString(metadataParsed.processing),
+            flavorNotes:
+              normalizeStringArray(
+                metadataParsed.flavorNotes ?? metadataParsed.flavor_notes
+              ),
+            roastDate:
+              normalizeString(metadataParsed.roastDate ?? metadataParsed.roast_date) ??
+              null,
+            varietals: normalizeStringArray(metadataParsed.varietals),
+            confidenceFlags,
+          };
+
+          rawStructuredResponse = metadataParsed;
+        }
+
+        structuredConfidence = safeParseJSON<Record<string, unknown>>(
+          saveData.structured_confidence ??
+            saveData.structuredConfidence ??
+            initialStructuredConfidence
+        );
+        structuredUncertainty = safeParseJSON<Record<string, unknown>>(
+          saveData.structured_uncertainty
+        );
+        if (rawStructuredResponse == null) {
+          rawStructuredResponse = metadataRaw ?? null;
+        }
       }
     }
 
@@ -1269,8 +1271,11 @@ export const processOCR = async (
     const evaluatePromise =
       isCoffee === false
         ? Promise.resolve({ skipped: true } as const)
-        : (async () => {
+          : (async () => {
             try {
+              if (!token) {
+                throw new Error('Nie si prihlásený');
+              }
               const coffeeAttributes = {
                 corrected_text: correctedText,
                 origin: evaluationStructuredMetadata?.origin ?? null,


### PR DESCRIPTION
### Motivation
- Prevent saving OCR scans for non-coffee images and avoid requiring authentication when the scan is not a coffee. 
- Avoid unnecessary history refreshes when nothing was persisted to the backend. 
- Keep the evaluation flow intact while only performing backend saves for confirmed coffee scans. 

### Description
- In `src/services/ocrServices.ts` the call to `POST ${API_URL}/ocr/save` is deferred and now only runs when `isCoffee` is truthy, with `getAuthToken()` invoked only in that branch. 
- Added a local `token` variable used to gate evaluation requests so evaluation that needs authentication still fails fast when unauthenticated. 
- Introduced an optional `refreshHistory` flag to `handleNonCoffeeDetected` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` and `src/screens/CoffeeReceipeScanner/index.tsx` and pass `refreshHistory: Boolean(result.scanId)` from scan/offline paths so history refresh runs only when a saved scan exists. 
- Updated offline and non-coffee handling sites to set `refreshHistory` where appropriate (including offline fallbacks and computed non-coffee branches). 

### Testing
- No automated tests were run for this change. 
- Manual smoke: existing non-coffee branches now skip backend save and avoid requiring auth (no automated verification performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8f7c9748832a9a29a3bf4a39e175)