### PR TITLE
Harden numeric checks for sweetness and acidity in calculateMatch

### DIFF
--- a/server/utils/coffee.js
+++ b/server/utils/coffee.js
@@ -27,14 +27,10 @@ export const calculateMatch = (coffeeText, preferences) => {
   const hasStrength =
     typeof preferences.preferred_strength === 'string' &&
     preferences.preferred_strength.trim().length > 0;
-  const hasSweetness =
-    preferences.sweetness !== null &&
-    preferences.sweetness !== undefined &&
-    !Number.isNaN(Number(preferences.sweetness));
-  const hasAcidity =
-    preferences.acidity !== null &&
-    preferences.acidity !== undefined &&
-    !Number.isNaN(Number(preferences.acidity));
+  const sweetnessValue = Number(preferences.sweetness);
+  const hasSweetness = Number.isFinite(sweetnessValue);
+  const acidityValue = Number(preferences.acidity);
+  const hasAcidity = Number.isFinite(acidityValue);
   const flavorList = Array.isArray(preferences.flavor_notes)
     ? preferences.flavor_notes
     : Object.keys(preferences.flavor_notes || {});
@@ -62,8 +58,8 @@ export const calculateMatch = (coffeeText, preferences) => {
     }
   });
 
-  if (preferences.sweetness && preferences.sweetness >= 7) score += 5;
-  if (preferences.acidity && preferences.acidity <= 3) score += 5;
+  if (hasSweetness && sweetnessValue >= 7) score += 5;
+  if (hasAcidity && acidityValue <= 3) score += 5;
 
   return Math.min(score, 100);
 };


### PR DESCRIPTION
### Motivation
- Avoid relying on truthy checks for taste preferences which can mis-handle numeric strings, zero, or `NaN` values.
- Ensure `sweetness` and `acidity` are treated as explicit numbers before applying threshold logic.
- Prevent incorrect scoring when preference fields are present but not valid finite numbers.

### Description
- Updated `server/utils/coffee.js` to parse `preferences.sweetness` and `preferences.acidity` into `sweetnessValue` and `acidityValue` using `Number()`.
- Replaced previous null/undefined/`Number.isNaN` style checks with `Number.isFinite(...)` and added `hasSweetness` / `hasAcidity` guards.
- Applied the parsed values in scoring conditions: `if (hasSweetness && sweetnessValue >= 7)` and `if (hasAcidity && acidityValue <= 3)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edad1f220832a8d4d51dfeb84148d)