### PR TITLE
Preserve null match percentage and show unknown UI label

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -72,7 +72,7 @@ interface ScanResult {
   original: string;
   corrected: string;
   recommendation: string;
-  matchPercentage?: number;
+  matchPercentage?: number | null;
   isRecommended?: boolean;
   scanId?: string;
   source?: 'offline' | 'online';
@@ -2158,8 +2158,12 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     }
     return 'YES';
   }, [compatibility?.bucket, evaluation, evaluationStatus]);
+  const hasExplicitMatchPercentage =
+    typeof scanResult?.matchPercentage === 'number';
   const matchLabel = compatibility
-    ? `${compatibility.score}%`
+    ? hasExplicitMatchPercentage
+      ? `${compatibility.score}%`
+      : 'Neznáme'
     : scanResult
       ? isProfileMissing
         ? undefined

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -704,7 +704,7 @@ interface OCRResult {
   original: string;
   corrected: string;
   recommendation: string;
-  matchPercentage?: number;
+  matchPercentage?: number | null;
   isRecommended?: boolean;
   scanId?: string;
   brewingMethods?: string[];
@@ -1072,7 +1072,7 @@ export const processOCR = async (
       nonCoffeeReason = `Rozpoznané: ${detectionLabels.slice(0, 3).join(', ')}`;
     }
 
-    let matchPercentage = 0;
+    let matchPercentage: number | null = null;
     let isRecommended = false;
     let scanId = '';
     let structuredMetadata: StructuredCoffeeMetadata | null = null;
@@ -1110,7 +1110,8 @@ export const processOCR = async (
       if (saveResponse.ok) {
         const saveData = await saveResponse.json();
         console.log('📥 [BE] Save OCR response:', saveData);
-        matchPercentage = saveData.match_percentage || 0;
+        matchPercentage =
+          typeof saveData.match_percentage === 'number' ? saveData.match_percentage : null;
         isRecommended = saveData.is_recommended || false;
         scanId = saveData.id || '';
 
@@ -1427,7 +1428,7 @@ export interface OCRHistory {
   corrected_text: string;
   created_at: Date;
   rating?: number;
-  match_percentage?: number;
+  match_percentage?: number | null;
   is_recommended?: boolean;
   is_purchased?: boolean;
   is_favorite?: boolean;


### PR DESCRIPTION
### Motivation

- The backend can omit `match_percentage`, and defaulting it to `0` caused misleading UI and scoring behavior.
- The taste profile UI should display `0%` only when the backend explicitly returns `0`, and otherwise hide or show an "unknown" label.

### Description

- In `src/services/ocrServices.ts` the `OCRResult.matchPercentage` and `OCRHistory.match_percentage` types were changed to allow `number | null`, `matchPercentage` is initialized to `null`, and the save response is normalized with `typeof saveData.match_percentage === 'number' ? saveData.match_percentage : null`.
- In `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` the `ScanResult.matchPercentage` type was updated to `number | null`, a `hasExplicitMatchPercentage` guard was added, and `matchLabel` logic was adjusted to show the compatibility percent only when an explicit numeric match exists and otherwise show `'Neznáme'`.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edc1623c8832aa23ddd9e76b9ac68)