### PR TITLE
Validate taste profile timestamps in OCR evaluation

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1136,13 +1136,56 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     const dbPreferences = result.rows[0];
     const requestTasteProfile =
       taste_profile && typeof taste_profile === 'object' ? taste_profile : null;
+    const requestUpdatedAtRaw =
+      requestTasteProfile?.updated_at ?? requestTasteProfile?.last_recalculated_at ?? null;
+
+    const parseTimestamp = (value) => {
+      if (!value) {
+        return null;
+      }
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    };
+
+    const dbUpdatedAt = parseTimestamp(dbPreferences?.updated_at);
+    const dbRecalculatedAt = parseTimestamp(dbPreferences?.last_recalculated_at);
+    const dbLatestTimestamp =
+      dbUpdatedAt && dbRecalculatedAt
+        ? dbUpdatedAt > dbRecalculatedAt
+          ? dbUpdatedAt
+          : dbRecalculatedAt
+        : dbUpdatedAt || dbRecalculatedAt;
+
+    let requestUpdatedAt = null;
+    if (requestTasteProfile) {
+      if (!requestUpdatedAtRaw) {
+        return res
+          .status(400)
+          .json({ error: 'Chýba taste_profile.updated_at' });
+      }
+      requestUpdatedAt = parseTimestamp(requestUpdatedAtRaw);
+      if (!requestUpdatedAt) {
+        return res
+          .status(400)
+          .json({ error: 'Neplatný taste_profile.updated_at' });
+      }
+      if (dbLatestTimestamp && requestUpdatedAt < dbLatestTimestamp) {
+        return res
+          .status(409)
+          .json({ error: 'Zastaralý chuťový profil' });
+      }
+    }
+
     const normalizedRequestTasteProfile = normalizeTasteProfileForEvaluation(requestTasteProfile);
-    const isRequestProfileComplete = isTasteProfileComplete(normalizedRequestTasteProfile);
-    const isDbProfileComplete = Boolean(
-      dbPreferences?.is_complete ?? dbPreferences?.taste_profile_completed ?? false
-    );
-    preferences = isRequestProfileComplete ? normalizedRequestTasteProfile : dbPreferences;
-    const isProfileComplete = isRequestProfileComplete || isDbProfileComplete;
+    const useRequestProfile =
+      Boolean(requestTasteProfile) &&
+      (!dbLatestTimestamp || (requestUpdatedAt && requestUpdatedAt >= dbLatestTimestamp));
+    const candidatePreferences = useRequestProfile
+      ? normalizedRequestTasteProfile
+      : dbPreferences;
+
+    const isProfileComplete = isTasteProfileComplete(candidatePreferences);
+    preferences = candidatePreferences;
 
     if (!isProfileComplete) {
       // ⬇️ Short-circuit with the strict JSON schema when profile is incomplete.


### PR DESCRIPTION
### Motivation
- Prevent the server from using stale taste profile data sent from the frontend when evaluating OCR results.
- Ensure the freshest profile is used by comparing `updated_at`/`last_recalculated_at` timestamps from the request and the DB.
- Require the request to include `taste_profile.updated_at` so recency can be established.
- Fail fast when the request profile is missing or older than the DB record to avoid inconsistent recommendations.

### Description
- Added timestamp parsing and comparison logic in `server/routes/ocr.js` around the `/api/ocr/evaluate` flow to compute a `dbLatestTimestamp` from `dbPreferences.updated_at` and `dbPreferences.last_recalculated_at`.
- Validate presence and format of `taste_profile.updated_at` (or `last_recalculated_at`) on the request and return HTTP 400 for missing/invalid timestamps.
- Return HTTP 409 when the request taste profile is older than the DB profile, and otherwise choose the freshest profile (request vs DB) before calling `isTasteProfileComplete` and `normalizeTasteProfileForEvaluation`.
- Assign the chosen profile to `preferences` so the remainder of the evaluation uses the most recent taste profile.

### Testing
- No automated tests were executed as part of this change.
- (Manual or integration testing may be required to verify client behavior on 400/409 responses.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ede4aa3b4832a822cab0ca8a2fc5a)