### PR TITLE
Store `taste_vector` only in `coffee_preferences`

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -195,7 +195,6 @@ const serializeTasteProfile = (taste) => {
     return {
       ai_recommendation: null,
       manual_input: null,
-      taste_vector: null,
       is_complete: false,
       coffee_preferences: null,
     };
@@ -204,7 +203,6 @@ const serializeTasteProfile = (taste) => {
   return {
     ai_recommendation: taste.ai_recommendation ?? null,
     manual_input: taste.manual_input ?? null,
-    taste_vector: taste.taste_vector ?? null,
     is_complete: taste.is_complete ?? false,
     coffee_preferences: {
       sweetness: Number(taste.sweetness),
@@ -602,7 +600,6 @@ router.put('/api/profile', async (req, res) => {
       acidity,
       bitterness,
       body,
-      taste_vector,
       ai_recommendation,
       manual_input,
       flavor_notes,
@@ -631,7 +628,7 @@ router.put('/api/profile', async (req, res) => {
     let validatedQuizAnswers;
     try {
       // Validate taste vector shape and clamp numeric values to safe ranges.
-      validatedTasteVector = validateTasteVector(taste_vector ?? prefs.taste_vector);
+      validatedTasteVector = validateTasteVector(prefs.taste_vector);
       // Validate quiz answers shape and enforce string-only values.
       validatedQuizAnswers = validateQuizAnswers(
         prefs.quiz_answers,

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -218,7 +218,7 @@ const CoffeePreferenceForm = ({
 
       if (res.ok) {
         const data = await res.json();
-        const storedTasteVector = data.coffee_preferences?.taste_vector ?? data.taste_vector;
+        const storedTasteVector = data.coffee_preferences?.taste_vector;
         const normalizedTasteVector = storedTasteVector
           ? normalizeTasteVectorTo10(storedTasteVector)
           : undefined;
@@ -513,7 +513,6 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
         },
         body: JSON.stringify({
           coffee_preferences: preferences,
-          taste_vector: tasteVector,
           ai_recommendation: profileText,
           ai_confidence: confidence,
         }),

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -697,7 +697,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       coffee_preferences?: Record<string, unknown> | null;
       ai_recommendation?: string | null;
       consistency_score?: number | null;
-      taste_vector?: Record<string, number> | null;
     };
     const nestedSnapshot = extractPreferenceSnapshot(profileRecord?.coffee_preferences ?? null);
     if (nestedSnapshot) {
@@ -706,7 +705,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     return extractPreferenceSnapshot({
       ai_recommendation: profileRecord?.ai_recommendation,
       consistency_score: profileRecord?.consistency_score,
-      taste_vector: profileRecord?.taste_vector,
     });
   }, [profile]);
 
@@ -728,7 +726,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       }
       const data = (await response.json()) as Record<string, unknown> | null;
       const snapshot = extractPreferenceSnapshot(
-        (data?.coffee_preferences as Record<string, unknown> | null) ?? data ?? null,
+        (data?.coffee_preferences as Record<string, unknown> | null) ?? null,
       );
       if (snapshot) {
         setPreferenceSnapshot(snapshot);


### PR DESCRIPTION
### Motivation
- Consolidate the taste vector into a single source of truth under `coffee_preferences` to avoid divergence between top-level and nested fields.
- Make server validation and persistence consistently read/write the nested `taste_vector` so updates and reads behave predictably.
- Align FE readers/writers so both `CoffeeTasteScanner` and `CoffeePreferenceForm` always use the same nested `coffee_preferences.taste_vector`.

### Description
- Server: removed top-level `taste_vector` from profile serialization and from the profile response payload, and updated `PUT /api/profile` validation to use `prefs.taste_vector` only (`server/routes/profile.js`).
- FE: updated `CoffeePreferenceForm` to read `storedTasteVector` from `data.coffee_preferences?.taste_vector` and to stop sending a top-level `taste_vector` in the `PUT` body (`src/components/personalization/CoffeePreferenceForm.tsx`).
- FE: updated `CoffeeTasteScanner` to derive preference snapshots only from `coffee_preferences` and to stop falling back to a top-level `taste_vector` (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`).
- Kept existing normalization/validation logic intact so numeric clamping and quiz handling still apply to the nested `taste_vector`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edf820afc832aa29b8ffce6b92f02)