### PR TITLE
Limit recent scan storage size and avoid saving large base64 images

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -1000,7 +1000,26 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     }
   };
 
-  const finalizeCoffeeScan = async (normalizedResult: ScanResultLike, base64image: string) => {
+  const MAX_RECENT_SCAN_THUMBNAIL_LENGTH = 8000;
+
+  const selectRecentScanImage = (imagePath?: string, base64image?: string) => {
+    if (imagePath) {
+      return imagePath;
+    }
+
+    if (!base64image) {
+      return undefined;
+    }
+
+    const dataUri = `data:image/jpeg;base64,${base64image}`;
+    return dataUri.length <= MAX_RECENT_SCAN_THUMBNAIL_LENGTH ? dataUri : undefined;
+  };
+
+  const finalizeCoffeeScan = async (
+    normalizedResult: ScanResultLike,
+    base64image: string,
+    imagePath?: string,
+  ) => {
     applyScanResult(normalizedResult);
     setIsFavorite(normalizedResult.isFavorite ?? false);
     setEditedText(normalizedResult.corrected);
@@ -1018,10 +1037,11 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
 
     const name = extractCoffeeName(normalizedResult.corrected || normalizedResult.original);
     const scanIdentifier = normalizedResult.scanId || Date.now().toString();
+    const recentImage = selectRecentScanImage(imagePath, base64image);
     await addRecentScan({
       id: scanIdentifier,
       name,
-      imageUrl: `data:image/jpeg;base64,${base64image}`,
+      imageUrl: recentImage,
     });
 
     const identity = resolveCoffeeIdentity(normalizedResult as ScanResult, name);
@@ -1070,7 +1090,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
 
     setIsLoading(true);
     try {
-      await finalizeCoffeeScan(confirmedResult, pendingImage);
+        await finalizeCoffeeScan(confirmedResult, pendingImage);
     } catch (error) {
       console.error('CoffeeTasteScanner: confirm anyway failed', error);
       Alert.alert('Chyba', 'Nepodarilo sa potvrdiť sken.');
@@ -1325,7 +1345,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
           return;
         }
 
-        await finalizeCoffeeScan(normalizedResult, base64image);
+        await finalizeCoffeeScan(normalizedResult, base64image, extra?.imagePath);
       }
     } catch (error) {
       console.error('Error processing image:', error);
@@ -1452,7 +1472,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         await addRecentScan({
           id: scanId,
           name,
-          imageUrl: `data:image/jpeg;base64,${base64image}`,
+          imageUrl: selectRecentScanImage(imagePath, base64image),
         });
 
         const identity = resolveCoffeeIdentity(offlineResult as ScanResult, name);

--- a/src/services/coffeeServices.ts
+++ b/src/services/coffeeServices.ts
@@ -12,6 +12,8 @@ export interface RecentScan {
 const STORAGE_KEY = 'recentScans';
 const MAX_RECENT_SCANS = 20;
 const MAX_IMAGE_URL_LENGTH = 1000;
+const MAX_IMAGE_DATA_URI_LENGTH = 8000;
+const MAX_STORAGE_BYTES = 150 * 1024;
 
 /**
  * Normalizes loose scan payloads coming from network or storage into a consistent shape.
@@ -40,18 +42,48 @@ const sanitizeRecentScan = (scan: RecentScan | Record<string, any>): RecentScan 
     (typeof (scan as any).image_url === 'string' && (scan as any).image_url) ||
     (typeof (scan as any).image === 'string' && (scan as any).image);
 
-  const sanitizedImage =
-    rawImage &&
-    rawImage.length <= MAX_IMAGE_URL_LENGTH &&
-    !rawImage.startsWith('data:')
-      ? rawImage
-      : undefined;
+  const sanitizedImage = (() => {
+    if (typeof rawImage !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = rawImage.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    if (trimmed.startsWith('data:')) {
+      return trimmed.length <= MAX_IMAGE_DATA_URI_LENGTH ? trimmed : undefined;
+    }
+
+    return trimmed.length <= MAX_IMAGE_URL_LENGTH ? trimmed : undefined;
+  })();
 
   return {
     id: idSource || Date.now().toString(),
     name: nameSource,
     imageUrl: sanitizedImage,
   };
+};
+
+const estimateStorageBytes = (value: string): number => {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length;
+  }
+
+  return value.length;
+};
+
+const trimScansToStorageLimit = (scans: RecentScan[]): RecentScan[] => {
+  const trimmed = [...scans];
+  while (trimmed.length > 0) {
+    const size = estimateStorageBytes(JSON.stringify(trimmed));
+    if (size <= MAX_STORAGE_BYTES) {
+      break;
+    }
+    trimmed.pop();
+  }
+  return trimmed;
 };
 
 /**
@@ -64,10 +96,10 @@ export const addRecentScan = async (scan: RecentScan): Promise<void> => {
   try {
     const scans = await readCachedScans();
     const sanitized = sanitizeRecentScan(scan);
-    const updated = [
+    const updated = trimScansToStorageLimit([
       sanitized,
       ...scans.filter((s) => s.id !== sanitized.id),
-    ].slice(0, MAX_RECENT_SCANS);
+    ].slice(0, MAX_RECENT_SCANS));
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
   } catch (err) {
     console.error('Failed to store recent scan', err);
@@ -90,9 +122,14 @@ const readCachedScans = async (): Promise<RecentScan[]> => {
     }
 
     const parsed = JSON.parse(cachedRaw);
-    return Array.isArray(parsed)
+    const sanitized = Array.isArray(parsed)
       ? parsed.map((item) => sanitizeRecentScan(item))
       : [];
+    const trimmed = trimScansToStorageLimit(sanitized);
+    if (trimmed.length !== sanitized.length) {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+    }
+    return trimmed;
   } catch (error: any) {
     if (
       typeof error?.message === 'string' &&
@@ -147,8 +184,9 @@ export const fetchRecentScans = async (limit: number): Promise<RecentScan[]> => 
       const normalized: RecentScan[] = Array.isArray(data)
         ? data.map((item) => sanitizeRecentScan(item)).slice(0, MAX_RECENT_SCANS)
         : [];
-      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
-      cached = normalized;
+      const trimmed = trimScansToStorageLimit(normalized);
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+      cached = trimmed;
     }
 
     return cached.slice(0, limit);


### PR DESCRIPTION
### Motivation
- Prevent AsyncStorage from hitting size limits by avoiding storing large inline base64 images in the recent scans cache.
- Keep recent scans list bounded and trim old entries so the cache stays below a conservative storage budget.
- Prefer storing file paths or small thumbnails instead of full data-URIs when recording scans from the scanner flow.

### Description
- Added `MAX_IMAGE_DATA_URI_LENGTH` and `MAX_STORAGE_BYTES` and updated `sanitizeRecentScan` to reject oversized data URIs while keeping reasonable URL lengths.
- Implemented `estimateStorageBytes` and `trimScansToStorageLimit` and applied trimming in `addRecentScan`, `readCachedScans`, and `fetchRecentScans` to cap persisted cache size.
- Changed scanner code in `CoffeeTasteScanner` to use `selectRecentScanImage` which stores either a file `imagePath` or a small `data:` thumbnail, and passed `imagePath` into `finalizeCoffeeScan` to prefer paths over large base64 strings.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee05198b4832aae982f7dfd2f1a6e)