### PR TITLE
Compute and persist `is_complete` for taste profiles; add DB migrations

### DIFF
--- a/db/migrations/schema/10_add_is_complete_to_user_taste_profiles.sql
+++ b/db/migrations/schema/10_add_is_complete_to_user_taste_profiles.sql
@@ -1,0 +1,34 @@
+-- Add explicit completion marker for taste profiles based on quiz answers or taste vectors.
+DO $$ BEGIN
+  IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
+    ALTER TABLE public.user_taste_profiles
+      ADD COLUMN IF NOT EXISTS is_complete boolean NOT NULL DEFAULT false;
+
+    UPDATE public.user_taste_profiles utp
+      SET is_complete = true
+      WHERE (
+        (
+          utp.quiz_answers IS NOT NULL
+          AND jsonb_typeof(utp.quiz_answers) = 'object'
+          AND EXISTS (
+            SELECT 1
+            FROM jsonb_object_keys(utp.quiz_answers)
+            LIMIT 1
+          )
+        )
+        OR
+        (
+          utp.taste_vector IS NOT NULL
+          AND jsonb_typeof(utp.taste_vector) = 'object'
+          AND jsonb_typeof(utp.taste_vector->'sweetness') = 'number'
+          AND jsonb_typeof(utp.taste_vector->'acidity') = 'number'
+          AND jsonb_typeof(utp.taste_vector->'bitterness') = 'number'
+          AND jsonb_typeof(utp.taste_vector->'body') = 'number'
+          AND (utp.taste_vector->>'sweetness')::numeric BETWEEN 0 AND 10
+          AND (utp.taste_vector->>'acidity')::numeric BETWEEN 0 AND 10
+          AND (utp.taste_vector->>'bitterness')::numeric BETWEEN 0 AND 10
+          AND (utp.taste_vector->>'body')::numeric BETWEEN 0 AND 10
+        )
+      );
+  END IF;
+END $$;

--- a/db/migrations/schema/11_recreate_user_taste_profiles_with_completion.sql
+++ b/db/migrations/schema/11_recreate_user_taste_profiles_with_completion.sql
@@ -1,0 +1,59 @@
+-- Recreate view with explicit completion marker for taste profiles.
+DO $$ BEGIN
+  IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
+    EXECUTE $view$
+      DROP VIEW IF EXISTS public.user_taste_profiles_with_completion;
+      CREATE VIEW public.user_taste_profiles_with_completion AS
+      SELECT
+        utp.user_id,
+        utp.sweetness,
+        utp.acidity,
+        utp.bitterness,
+        utp.body,
+        utp.flavor_notes,
+        utp.milk_preferences,
+        utp.caffeine_sensitivity,
+        utp.preferred_strength,
+        utp.seasonal_adjustments,
+        utp.preference_confidence,
+        utp.quiz_version,
+        utp.quiz_answers,
+        utp.taste_vector,
+        utp.consistency_score,
+        utp.ai_recommendation,
+        utp.manual_input,
+        utp.last_recalculated_at,
+        utp.created_at,
+        utp.updated_at,
+        (
+          COALESCE(utp.is_complete, false)
+          OR
+          (
+            (
+              utp.quiz_answers IS NOT NULL
+              AND jsonb_typeof(utp.quiz_answers) = 'object'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_object_keys(utp.quiz_answers)
+                LIMIT 1
+              )
+            )
+            OR
+            (
+              utp.taste_vector IS NOT NULL
+              AND jsonb_typeof(utp.taste_vector) = 'object'
+              AND jsonb_typeof(utp.taste_vector->'sweetness') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'acidity') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'bitterness') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'body') = 'number'
+              AND (utp.taste_vector->>'sweetness')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'acidity')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'bitterness')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'body')::numeric BETWEEN 0 AND 10
+            )
+          )
+        ) AS is_complete
+      FROM public.user_taste_profiles utp
+    $view$;
+  END IF;
+END $$;

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -109,6 +109,31 @@ const isRateLimited = (uid) => {
   return false;
 };
 
+const isTasteVectorComplete = (tasteVector) => {
+  if (!isPlainObject(tasteVector)) {
+    return false;
+  }
+
+  const requiredKeys = ['sweetness', 'acidity', 'bitterness', 'body'];
+  return requiredKeys.every((key) => {
+    const value = tasteVector[key];
+    return (
+      typeof value === 'number' &&
+      Number.isFinite(value) &&
+      value >= 0 &&
+      value <= 10
+    );
+  });
+};
+
+const hasQuizAnswers = (quizAnswers) => {
+  if (!isPlainObject(quizAnswers)) {
+    return false;
+  }
+
+  return Object.keys(quizAnswers).length > 0;
+};
+
 /**
  * Validate and clamp a taste vector payload.
  *
@@ -708,6 +733,9 @@ router.put('/api/profile', async (req, res) => {
       prefs.preferred_strength ??
       existing?.preferred_strength ??
       null;
+    const resolvedIsComplete =
+      isTasteVectorComplete(resolvedTasteVector) ||
+      hasQuizAnswers(resolvedQuizAnswers);
 
     await client.query(
       `INSERT INTO user_taste_profiles (
@@ -725,12 +753,13 @@ router.put('/api/profile', async (req, res) => {
         quiz_version,
         quiz_answers,
         taste_vector,
+        is_complete,
         consistency_score,
         ai_recommendation,
         manual_input,
         last_recalculated_at,
         updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,'medium'),COALESCE($9,'balanced'),'[]',$10,$11,$12,$13,$14,$15,$16,now(),now())
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,'medium'),COALESCE($9,'balanced'),'[]',$10,$11,$12,$13,$14,$15,$16,$17,now(),now())
       ON CONFLICT (user_id) DO UPDATE SET
         sweetness = EXCLUDED.sweetness,
         acidity = EXCLUDED.acidity,
@@ -744,6 +773,7 @@ router.put('/api/profile', async (req, res) => {
         quiz_version = EXCLUDED.quiz_version,
         quiz_answers = EXCLUDED.quiz_answers,
         taste_vector = EXCLUDED.taste_vector,
+        is_complete = EXCLUDED.is_complete,
         consistency_score = EXCLUDED.consistency_score,
         ai_recommendation = EXCLUDED.ai_recommendation,
         manual_input = EXCLUDED.manual_input,
@@ -763,6 +793,7 @@ router.put('/api/profile', async (req, res) => {
         resolvedQuizVersion,
         resolvedQuizAnswers,
         resolvedTasteVector,
+        resolvedIsComplete,
         resolvedConsistencyScore,
         resolvedAiRecommendation,
         resolvedManualInput,


### PR DESCRIPTION
### Motivation
- Ensure the profile update flow (`PUT /api/profile`) derives and stores whether a taste profile is complete (so FE and views can rely on a stable flag). 
- Completion should be true when the user provided quiz answers or a taste vector with numeric `sweetness`/`acidity`/`bitterness`/`body` in the 0–10 range.
- If `is_complete` is derived in a view it must reflect taste_vector contents accurately, so the view/migrations need updating.
- Make `SELECT * FROM user_taste_profiles_with_completion` return `is_complete = true` after saving a questionnaire or valid taste vector.

### Description
- Added helpers `isTasteVectorComplete` and `hasQuizAnswers` and compute `resolvedIsComplete` in the profile update handler for `PUT /api/profile` to derive completion from validated inputs.
- Persist `is_complete` into `user_taste_profiles` by extending the `INSERT ... ON CONFLICT ... DO UPDATE` statement to include the `is_complete` column and use `EXCLUDED.is_complete` on conflict.
- Added migration `db/migrations/schema/10_add_is_complete_to_user_taste_profiles.sql` to add the `is_complete` boolean column and backfill it based on existing `quiz_answers` or valid numeric `taste_vector` fields.
- Added migration `db/migrations/schema/11_recreate_user_taste_profiles_with_completion.sql` to recreate the `user_taste_profiles_with_completion` view so it considers the explicit `is_complete` column and also still validates taste_vector numeric values when computing the view-level `is_complete`.

### Testing
- No automated tests were executed in this change (no test runner was invoked).
- Manual verification step intended: after running migrations and calling `PUT /api/profile` with a valid taste vector or quiz answers, `SELECT * FROM user_taste_profiles_with_completion WHERE user_id = '<uid>'` should return `is_complete = true`.
- Migrations and code compiled/committed locally (changes added and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee20bfbc4832a89a310805056cb0f)