### PR TITLE
Skip sending taste_profile without timestamps; accept missing timestamps server-side and add logging

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1138,6 +1138,13 @@ router.post('/api/ocr/evaluate', async (req, res) => {
       taste_profile && typeof taste_profile === 'object' ? taste_profile : null;
     const requestUpdatedAtRaw =
       requestTasteProfile?.updated_at ?? requestTasteProfile?.last_recalculated_at ?? null;
+    const requestHasTimestamp = Boolean(requestUpdatedAtRaw);
+    if (requestTasteProfile && !requestHasTimestamp) {
+      console.warn('⚠️ [OCR] taste_profile missing timestamp; using DB profile.', {
+        uid,
+        hasTasteProfile: Boolean(requestTasteProfile),
+      });
+    }
 
     const parseTimestamp = (value) => {
       if (!value) {
@@ -1158,28 +1165,26 @@ router.post('/api/ocr/evaluate', async (req, res) => {
 
     let requestUpdatedAt = null;
     if (requestTasteProfile) {
-      if (!requestUpdatedAtRaw) {
-        return res
-          .status(400)
-          .json({ error: 'Chýba taste_profile.updated_at' });
-      }
-      requestUpdatedAt = parseTimestamp(requestUpdatedAtRaw);
-      if (!requestUpdatedAt) {
-        return res
-          .status(400)
-          .json({ error: 'Neplatný taste_profile.updated_at' });
-      }
-      if (dbLatestTimestamp && requestUpdatedAt < dbLatestTimestamp) {
-        return res
-          .status(409)
-          .json({ error: 'Zastaralý chuťový profil' });
+      if (requestUpdatedAtRaw) {
+        requestUpdatedAt = parseTimestamp(requestUpdatedAtRaw);
+        if (!requestUpdatedAt) {
+          return res
+            .status(400)
+            .json({ error: 'Neplatný taste_profile.updated_at' });
+        }
+        if (dbLatestTimestamp && requestUpdatedAt < dbLatestTimestamp) {
+          return res
+            .status(409)
+            .json({ error: 'Zastaralý chuťový profil' });
+        }
       }
     }
 
     const normalizedRequestTasteProfile = normalizeTasteProfileForEvaluation(requestTasteProfile);
     const useRequestProfile =
       Boolean(requestTasteProfile) &&
-      (!dbLatestTimestamp || (requestUpdatedAt && requestUpdatedAt >= dbLatestTimestamp));
+      requestUpdatedAt &&
+      (!dbLatestTimestamp || requestUpdatedAt >= dbLatestTimestamp);
     const candidatePreferences = useRequestProfile
       ? normalizedRequestTasteProfile
       : dbPreferences;

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -368,6 +368,18 @@ const mapTasteProfilePayload = (
     return null;
   }
 
+  const profileUpdatedAt =
+    'preferences' in profile ? profile.updatedAt ?? profile.lastRecalculatedAt ?? null : null;
+  if (!profileUpdatedAt) {
+    console.warn(
+      '[OCR] Skipping taste_profile payload because timestamps are missing.',
+      {
+        hasPreferencesProfile: 'preferences' in profile,
+      },
+    );
+    return null;
+  }
+
   const tasteVector = extractTasteVector(profile);
   if (!tasteVector) {
     return null;


### PR DESCRIPTION
### Motivation

- Prevent sending local `taste_profile` payloads that lack a reliable timestamp to avoid stale/ambiguous client profiles being used for evaluation. 
- Allow the evaluation endpoint to accept missing `taste_profile.updated_at` from the FE and fall back to the DB profile for freshness checks. 
- Surface telemetry/log messages so it is clear when a local profile without timestamps is being omitted or when the server falls back to DB. 

### Description

- Updated `mapTasteProfilePayload` in `src/services/ocrServices.ts` to return `null` (and log a warning) when the incoming profile does not contain `updatedAt` or `lastRecalculatedAt`, so the FE does not send a `taste_profile` without a timestamp. 
- Modified `POST /api/ocr/evaluate` in `server/routes/ocr.js` to accept a missing `taste_profile.updated_at` by: parsing the request timestamp only when provided, logging a warning when the client profile lacks timestamps, and only using the request profile if a valid timestamp exists and is at least as fresh as the DB profile. 
- Added `console.warn` telemetry messages on both client and server paths to make it visible when local profiles without timestamps are skipped and when the DB profile is used instead. 

### Testing

- No automated tests were run for these changes. 
- Code compiled/inspected locally; no unit or integration test suite executed. 
- Manual inspection verified the new logging statements are present in `src/services/ocrServices.ts` and `server/routes/ocr.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee2ffa48c832a9d11d5aa0b57b8fe)