### PR TITLE
Handle insufficient coffee data evaluations

### DIFF
--- a/server/routes/__tests__/ocr-evaluation.test.js
+++ b/server/routes/__tests__/ocr-evaluation.test.js
@@ -48,4 +48,28 @@ describe('isValidEvaluationResponse', () => {
 
     expect(isValidEvaluationResponse(response)).toBe(false);
   });
+
+  it('accepts insufficient coffee data responses without verdicts', () => {
+    const response = {
+      status: 'insufficient_coffee_data',
+      verdict: null,
+      confidence: null,
+      verdict_explanation: {
+        user_preferences_summary: 'Tvoje preferencie sú uložené.',
+        coffee_profile_summary: 'Profil kávy je neúplný.',
+        comparison_summary: 'Porovnanie zatiaľ nie je možné.',
+      },
+      insight: {
+        headline: 'Máme málo údajov',
+        why: ['Chýbajú kľúčové informácie o káve.'],
+        what_youll_like: [],
+        what_might_bother_you: [],
+        how_to_brew_for_better_match: ['Skús doplniť údaje o pôvode.'],
+        recommended_alternatives: [],
+      },
+      disclaimer: 'Vyhodnotenie bude možné po doplnení údajov.',
+    };
+
+    expect(isValidEvaluationResponse(response)).toBe(true);
+  });
 });

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1248,13 +1248,7 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     };
 
     if (!hasMeaningfulCoffeeData(coffeeAttributes)) {
-      return res.json(
-        buildLowConfidenceFallbackResponse({
-          preferences,
-          coffeeAttributes,
-          correctedText,
-        })
-      );
+      return res.json(INSUFFICIENT_COFFEE_DATA_RESPONSE);
     }
 
     // The comparison-based structure prevents contradictions because verdict and insight share the same summaries.

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -573,12 +573,15 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
     };
   }
   if (normalizedStatus !== 'ok') {
+    const summary = useNeutralCopy
+      ? normalizeEvaluationText(record.summary, NEUTRAL_EVALUATION_COPY.summary)
+      : normalizeEvaluationText(record.summary);
     // Unknown payloads remain neutral so the UI can display a generic fallback state.
     return {
       status: normalizedStatus,
       verdict: null,
       confidence: null,
-      summary: typeof record.summary === 'string' ? record.summary : '',
+      summary,
       reasons: [],
       what_youll_like: whatYoullLike,
       what_might_bother_you: whatMightBotherYou,


### PR DESCRIPTION
### Motivation
- Return a strict schema response when coffee attributes are missing instead of fabricating a low-confidence verdict. 
- Prevent the frontend from showing a full `verdict` when the backend indicates insufficient coffee data. 
- Keep evaluation normalization neutral for non-`ok` statuses so the UI can present a guidance/CTA flow. 
- Add test coverage to assert the new `insufficient_coffee_data` payload is accepted.

### Description
- Replace the low-confidence fallback with `INSUFFICIENT_COFFEE_DATA_RESPONSE` in `server/routes/ocr.js` when `hasMeaningfulCoffeeData(...)` is false. 
- Ensure `normalizeEvaluationResponse` in `src/services/ocrServices.ts` derives a neutral `summary` for non-`ok` statuses (including `insufficient_coffee_data`) so the FE shows neutral copy. 
- Add a unit test in `server/routes/__tests__/ocr-evaluation.test.js` that verifies an `insufficient_coffee_data` response without `verdict` is accepted by `isValidEvaluationResponse`. 

### Testing
- Added a unit test (`server/routes/__tests__/ocr-evaluation.test.js`) that asserts `insufficient_coffee_data` responses validate as true. 
- No automated test suite was executed as part of this change. 
- Code changes were lint/compiled locally via project tooling during development (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee3b28c6c832aa77d215a63272a0d)