### PR TITLE
Fallback to preferenceSnapshot.taste_vector with normalization and test

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -65,6 +65,7 @@ import { BrewContext } from '../../types/Personalization';
 import { usePersonalization } from '../../hooks/usePersonalization';
 import { showToast } from '../../utils/toast';
 import { buildScanPreferenceComparison } from '../../utils/scanPreferenceComparison';
+import { buildPreferenceSummary } from '../../utils/preferenceSummary';
 import { API_URL } from '../../services/api';
 import { recognizeCoffee } from 'services/VisionService.ts';
 
@@ -191,25 +192,15 @@ const buildComparisonText = (
   preferenceSnapshot: CoffeePreferenceSnapshot | null | undefined,
   aiRecommendation: string | null | undefined,
   profilePreferences: Record<string, unknown> | null | undefined,
+  coffeePreferences: Record<string, unknown> | null | undefined,
 ): string => {
-  const normalizePreferenceValue = (value: unknown) =>
-    typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null;
-  const preferences = profilePreferences ?? null;
-  const preferenceSummaryEntries = preferences
-    ? [
-        { label: 'Kyslosť', value: normalizePreferenceValue(preferences.acidity) },
-        { label: 'Sladkosť', value: normalizePreferenceValue(preferences.sweetness) },
-        { label: 'Horkosť', value: normalizePreferenceValue(preferences.bitterness) },
-        { label: 'Telo', value: normalizePreferenceValue(preferences.body) },
-      ].filter(entry => entry.value !== null)
-    : [];
-  const preferenceSummary = preferenceSummaryEntries.length
-    ? preferenceSummaryEntries
-        .map(entry => `${entry.label} ${entry.value}/10`)
-        .join(', ')
-    : null;
+  const { summary: preferenceSummary, sourceLabel } = buildPreferenceSummary({
+    profilePreferences,
+    preferenceSnapshot,
+    coffeePreferences,
+  });
   const formSection = preferenceSummary
-    ? `Aktuálny profil (dotazník):\n${preferenceSummary}`
+    ? `Aktuálny profil (${sourceLabel}):\n${preferenceSummary}`
     : 'Aktuálny profil (dotazník): zatiaľ nemáme uložené hodnoty.';
 
   const hasAiText = typeof aiRecommendation === 'string' && aiRecommendation.trim().length > 0;
@@ -2015,14 +2006,18 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   const showBackButton = currentView !== 'home';
   const evaluation = scanResult?.evaluation ?? null;
   const evaluationStatus = evaluation?.status ?? 'unknown';
+  const profileCoffeePreferences =
+    (profile as unknown as { coffee_preferences?: Record<string, unknown> | null })
+      ?.coffee_preferences ?? null;
   const comparisonText = useMemo(
     () => buildComparisonText(
       evaluation,
       preferenceSnapshot,
       preferenceSnapshot?.ai_recommendation ?? null,
       profile?.preferences ?? null,
+      profileCoffeePreferences,
     ),
-    [evaluation, preferenceSnapshot, profile?.preferences],
+    [evaluation, preferenceSnapshot, profile?.preferences, profileCoffeePreferences],
   );
   // Suppress compatibility scoring whenever the AI evaluation is not ready.
   const shouldSuppressCompatibility = evaluationStatus !== 'ok';

--- a/src/utils/__tests__/preferenceSummary.test.ts
+++ b/src/utils/__tests__/preferenceSummary.test.ts
@@ -1,0 +1,21 @@
+import { buildPreferenceSummary } from '../preferenceSummary';
+
+describe('buildPreferenceSummary', () => {
+  it('uses preferenceSnapshot.taste_vector when profile preferences are missing', () => {
+    const result = buildPreferenceSummary({
+      profilePreferences: null,
+      preferenceSnapshot: {
+        taste_vector: {
+          acidity: 0.4,
+          sweetness: 0.7,
+          bitterness: 9,
+          body: 12,
+        },
+      },
+      coffeePreferences: null,
+    });
+
+    expect(result.sourceLabel).toBe('uložené preferencie');
+    expect(result.summary).toBe('Kyslosť 4/10, Sladkosť 7/10, Horkosť 9/10, Telo 10/10');
+  });
+});

--- a/src/utils/preferenceSummary.ts
+++ b/src/utils/preferenceSummary.ts
@@ -1,0 +1,76 @@
+import { normalizeVectorValue } from './scanPreferenceComparison';
+
+type TasteVector = Record<string, unknown>;
+
+type PreferenceSnapshot = {
+  taste_vector?: Record<string, number> | null;
+} | null;
+
+type PreferenceSummaryInput = {
+  profilePreferences?: TasteVector | null;
+  preferenceSnapshot?: PreferenceSnapshot | null;
+  coffeePreferences?: TasteVector | null;
+};
+
+type PreferenceSummaryResult = {
+  summary: string | null;
+  sourceLabel: 'dotazník' | 'uložené preferencie';
+};
+
+const SUMMARY_DIMENSIONS = [
+  { key: 'acidity', label: 'Kyslosť' },
+  { key: 'sweetness', label: 'Sladkosť' },
+  { key: 'bitterness', label: 'Horkosť' },
+  { key: 'body', label: 'Telo' },
+];
+
+const normalizePreferenceValue = (value: unknown): number | null => {
+  const normalized = normalizeVectorValue(value);
+  return normalized != null ? Math.round(normalized) : null;
+};
+
+const resolveVector = (source: TasteVector | null | undefined): TasteVector | null => {
+  if (!source) {
+    return null;
+  }
+  const nested = source.taste_vector;
+  if (nested && typeof nested === 'object') {
+    return nested as TasteVector;
+  }
+  return source;
+};
+
+const buildEntries = (vector: TasteVector | null | undefined) =>
+  vector
+    ? SUMMARY_DIMENSIONS
+        .map(({ key, label }) => {
+          const value = normalizePreferenceValue(vector[key]);
+          return value != null ? { label, value } : null;
+        })
+        .filter((entry): entry is { label: string; value: number } => Boolean(entry))
+    : [];
+
+export const buildPreferenceSummary = ({
+  profilePreferences,
+  preferenceSnapshot,
+  coffeePreferences,
+}: PreferenceSummaryInput): PreferenceSummaryResult => {
+  const primaryEntries = buildEntries(profilePreferences ?? null);
+  let entries = primaryEntries;
+  let sourceLabel: PreferenceSummaryResult['sourceLabel'] = 'dotazník';
+
+  if (entries.length === 0) {
+    const fallbackVector =
+      preferenceSnapshot?.taste_vector ?? resolveVector(coffeePreferences ?? null);
+    entries = buildEntries(fallbackVector);
+    if (entries.length > 0) {
+      sourceLabel = 'uložené preferencie';
+    }
+  }
+
+  const summary = entries.length
+    ? entries.map(entry => `${entry.label} ${entry.value}/10`).join(', ')
+    : null;
+
+  return { summary, sourceLabel };
+};

--- a/src/utils/scanPreferenceComparison.ts
+++ b/src/utils/scanPreferenceComparison.ts
@@ -102,7 +102,7 @@ const parseNumericValue = (value: unknown): number | null => {
   return null;
 };
 
-const normalizeVectorValue = (value: unknown): number | null => {
+export const normalizeVectorValue = (value: unknown): number | null => {
   const parsed = parseNumericValue(value);
   if (parsed == null) {
     return null;


### PR DESCRIPTION
### Motivation
- Ensure the comparison summary falls back to stored preference snapshots when questionnaire `profile.preferences` is missing.
- Normalize all taste values to a 0–10 scale so displayed summaries are consistent with scoring used elsewhere.
- Reuse existing normalization logic to avoid duplication and keep behavior consistent across comparison logic.

### Description
- Exported `normalizeVectorValue` from `src/utils/scanPreferenceComparison.ts` and added a new helper `buildPreferenceSummary` in `src/utils/preferenceSummary.ts` that builds a readable summary and chooses fallback sources.
- Updated `buildComparisonText` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to use `buildPreferenceSummary` and to accept `coffee_preferences` (stored snapshot) as a fallback source.
- Added a unit test `src/utils/__tests__/preferenceSummary.test.ts` that verifies the case when `profile.preferences` is `null` but `preferenceSnapshot.taste_vector` exists and values are normalized and rounded.

### Testing
- Added unit test `src/utils/__tests__/preferenceSummary.test.ts` covering the fallback scenario (`profilePreferences=null`, `preferenceSnapshot.taste_vector` present).
- Attempted to run the test with `npx jest src/utils/__tests__/preferenceSummary.test.ts` but the run failed due to a registry fetch error (`403 Forbidden` fetching `jest`).
- No other automated test runs were performed as the test runner could not be installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee88fc9c4832a937022082776751c)