### PR TITLE
Pass normalized preference `taste_vector` fallback to `processOCR`

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -62,6 +62,7 @@ import type {
   CoffeeEvaluationResult,
 } from './services';
 import { BrewContext } from '../../types/Personalization';
+import type { TasteProfileVector, UserTasteProfile } from '../../types/Personalization';
 import { usePersonalization } from '../../hooks/usePersonalization';
 import { showToast } from '../../utils/toast';
 import { buildScanPreferenceComparison } from '../../utils/scanPreferenceComparison';
@@ -598,6 +599,72 @@ const clampTasteValue = (value: number): number => {
   return Math.min(10, Math.max(0, value));
 };
 
+const normalizeTasteVectorTo10 = (
+  value?: Record<string, number> | null,
+): TasteProfileVector | null => {
+  if (!value) {
+    return null;
+  }
+
+  const parseValue = (entry: unknown): number | null => {
+    if (typeof entry === 'number' && Number.isFinite(entry)) {
+      return clampTasteValue(entry <= 1 ? entry * 10 : entry);
+    }
+    if (typeof entry === 'string') {
+      const parsed = Number(entry);
+      if (Number.isFinite(parsed)) {
+        return clampTasteValue(parsed <= 1 ? parsed * 10 : parsed);
+      }
+    }
+    return null;
+  };
+
+  const sweetness = parseValue(value.sweetness);
+  const acidity = parseValue(value.acidity);
+  const bitterness = parseValue(value.bitterness);
+  const body = parseValue(value.body);
+
+  if (![sweetness, acidity, bitterness, body].some(entry => entry !== null)) {
+    return null;
+  }
+
+  return {
+    sweetness: sweetness ?? 5,
+    acidity: acidity ?? 5,
+    bitterness: bitterness ?? 5,
+    body: body ?? 5,
+  };
+};
+
+const hasCompleteTasteVector = (vector?: TasteProfileVector | null): boolean => {
+  if (!vector) {
+    return false;
+  }
+  return ['sweetness', 'acidity', 'bitterness', 'body'].every(key => {
+    const value = vector[key as keyof TasteProfileVector];
+    return typeof value === 'number' && Number.isFinite(value);
+  });
+};
+
+const resolveTasteProfile = (
+  profile?: TasteProfileVector | UserTasteProfile | null,
+  snapshotVector?: TasteProfileVector | null,
+): TasteProfileVector | UserTasteProfile | null => {
+  if (profile && 'preferences' in profile) {
+    if (hasCompleteTasteVector(profile.preferences ?? null)) {
+      return profile;
+    }
+  } else if (hasCompleteTasteVector(profile ?? null)) {
+    return profile ?? null;
+  }
+
+  if (hasCompleteTasteVector(snapshotVector ?? null)) {
+    return snapshotVector ?? null;
+  }
+
+  return null;
+};
+
 type RoastCategory = 'light' | 'medium' | 'dark' | 'unknown';
 type CompatibilityBucket = 'SAFE' | 'RISKY' | 'NO-GO';
 
@@ -698,6 +765,11 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       consistency_score: profileRecord?.consistency_score,
     });
   }, [profile]);
+
+  const preferenceSnapshotVector = useMemo(
+    () => normalizeTasteVectorTo10(preferenceSnapshot?.taste_vector ?? null),
+    [preferenceSnapshot],
+  );
 
   const loadPreferenceSnapshot = useCallback(async () => {
     try {
@@ -1289,12 +1361,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       setOverlayText('Analyzujem...');
       setOverlayVisible(true);
 
-      const tasteProfile =
-        profile && 'preferences' in profile
-          ? profile.preferences
-            ? profile
-            : null
-          : profile ?? null;
+      const tasteProfile = resolveTasteProfile(profile, preferenceSnapshotVector);
       const result = await processOCR(base64image, {
         imagePath: extra?.imagePath,
         tasteProfile,


### PR DESCRIPTION
### Motivation

- Ensure the OCR pipeline always receives a usable taste profile by falling back to stored snapshot data when the live personalization `profile` is missing or incomplete.
- Convert backend `coffee_preferences.taste_vector` (which may use 0–1 or mixed formats) into the app `TasteProfileVector` (0–10) expected by downstream logic.
- Prefer questionnaire-backed preference data but use the snapshot vector to improve AI recommendations and compatibility scoring when questionnaire values are not available.
- Keep the taste profile resolution logic explicit and type-safe to avoid sending partial or malformed vectors to `processOCR`.

### Description

- Added a `normalizeTasteVectorTo10` helper that maps a raw `taste_vector` object into a `TasteProfileVector` with 0–10 scores.
- Added `hasCompleteTasteVector` and `resolveTasteProfile` helpers and imported the `TasteProfileVector`/`UserTasteProfile` types for clarity.
- Compute `preferenceSnapshotVector` from `preferenceSnapshot.taste_vector` and pass a resolved `tasteProfile` (questionnaire `profile` preferred, snapshot fallback) into `processOCR` via `processImage`.
- Updated `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to use the new helpers and to send the normalized fallback vector when appropriate.

### Testing

- No automated tests were executed for this change.
- Type/compile checks were not run as part of this PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696015f3dd8c832aad99c3d1bebc2d9d)