### PR TITLE
Relax taste profile payload requirements for OCR evaluation

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -368,16 +368,17 @@ const mapTasteProfilePayload = (
     return null;
   }
 
-  const profileUpdatedAt =
-    'preferences' in profile ? profile.updatedAt ?? profile.lastRecalculatedAt ?? null : null;
-  if (!profileUpdatedAt) {
-    console.warn(
-      '[OCR] Skipping taste_profile payload because timestamps are missing.',
-      {
-        hasPreferencesProfile: 'preferences' in profile,
-      },
-    );
-    return null;
+  if ('preferences' in profile) {
+    const profileUpdatedAt = profile.updatedAt ?? profile.lastRecalculatedAt ?? null;
+    if (!profileUpdatedAt) {
+      console.warn(
+        '[OCR] Skipping taste_profile payload because timestamps are missing.',
+        {
+          hasPreferencesProfile: true,
+        },
+      );
+      return null;
+    }
   }
 
   const tasteVector = extractTasteVector(profile);
@@ -1313,6 +1314,8 @@ export const processOCR = async (
                   payload.taste_profile = tasteProfilePayload;
                 }
               }
+              // Manual QA: submit the questionnaire flow (TasteProfileVector) and confirm
+              // `/ocr/evaluate` receives `taste_profile` with only taste_vector + sweetness/acidity/bitterness/body.
               const evaluationResult = await loggedFetchWithStatusRetry(
                 `${API_URL}/ocr/evaluate`,
                 {


### PR DESCRIPTION
### Motivation

- Allow sending a minimal taste profile when the app only has a plain `TasteProfileVector` instead of a full `UserTasteProfile` with timestamps.
- Avoid skipping `taste_profile` payloads for questionnaire flows that produce only taste vectors.
- Ensure the `/ocr/evaluate` endpoint receives a taste profile for both user preferences and survey/questionnaire inputs.

### Description

- Update `mapTasteProfilePayload` in `src/services/ocrServices.ts` to only enforce `updatedAt/lastRecalculatedAt` when the profile contains `preferences` (i.e., a `UserTasteProfile`).
- Preserve the minimal payload for plain `TasteProfileVector` containing only `taste_vector`, `sweetness`, `acidity`, `bitterness`, and `body`.
- Add an inline Manual QA note near the `/ocr/evaluate` request to verify questionnaire flows submit the minimal `taste_profile` payload.

### Testing

- No automated unit tests were added in this change.
- No automated test suite was executed as part of this rollout (no `jest` run).  
- A manual QA comment was added to help validate that `/ocr/evaluate` receives `taste_profile` for questionnaire flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696017dbc53c832a826319740dc00915)