### PR TITLE
Fallback to `ai_confidence` when reading preference consistency

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -230,7 +230,11 @@ const CoffeePreferenceForm = ({
           quiz_answers: data.coffee_preferences?.quiz_answers,
           taste_vector: normalizedTasteVector,
           ai_recommendation: data.coffee_preferences?.ai_recommendation ?? data.ai_recommendation,
-          consistency_score: data.coffee_preferences?.consistency_score ?? data.consistency_score,
+          consistency_score:
+            data.coffee_preferences?.consistency_score ??
+            data.coffee_preferences?.ai_confidence ??
+            data.consistency_score ??
+            data.ai_confidence,
         });
       }
     } catch (err) {

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -171,7 +171,11 @@ const extractPreferenceSnapshot = (
   const aiRecommendation =
     typeof payload.ai_recommendation === 'string' ? payload.ai_recommendation : null;
   const consistencyScore =
-    typeof payload.consistency_score === 'number' ? payload.consistency_score : null;
+    typeof payload.consistency_score === 'number'
+      ? payload.consistency_score
+      : typeof payload.ai_confidence === 'number'
+        ? payload.ai_confidence
+        : null;
   const tasteVector =
     payload.taste_vector && typeof payload.taste_vector === 'object'
       ? (payload.taste_vector as Record<string, number>)
@@ -755,6 +759,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       coffee_preferences?: Record<string, unknown> | null;
       ai_recommendation?: string | null;
       consistency_score?: number | null;
+      ai_confidence?: number | null;
     };
     const nestedSnapshot = extractPreferenceSnapshot(profileRecord?.coffee_preferences ?? null);
     if (nestedSnapshot) {
@@ -763,6 +768,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     return extractPreferenceSnapshot({
       ai_recommendation: profileRecord?.ai_recommendation,
       consistency_score: profileRecord?.consistency_score,
+      ai_confidence: profileRecord?.ai_confidence,
     });
   }, [profile]);
 


### PR DESCRIPTION
### Motivation
- Some user profiles store the AI-derived confidence under `ai_confidence` instead of `consistency_score`, causing the app to miss available confidence values. 
- Ensure the scanner and preference form surface a usable consistency/confidence value for downstream UI and signals. 
- Keep behavior backward-compatible with existing fields while preferring the canonical `consistency_score` when present. 

### Description
- In `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` the `extractPreferenceSnapshot` function now uses `ai_confidence` as a fallback when `consistency_score` is missing. 
- The scanner context reader also includes `ai_confidence` when building the fallback profile record passed to `extractPreferenceSnapshot`. 
- In `src/components/personalization/CoffeePreferenceForm.tsx` the `loadPreferences` logic now falls back to `data.coffee_preferences?.ai_confidence` and `data.ai_confidence` when `consistency_score` is not present. 
- Small defensive updates ensure the previous profile displayed/used by the form contains the best available confidence value. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were limited to preference parsing and loading logic and compiled locally as part of development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602a651480832a927b26442323960f)