### PR TITLE
Create scan_events table for OCR history and make scan_events indexes idempotent

### DIFF
--- a/db/migrations/indexes/07_indexes.sql
+++ b/db/migrations/indexes/07_indexes.sql
@@ -17,7 +17,7 @@ CREATE INDEX idx_user_recipes_user_created_at ON public.user_recipes(user_id, cr
 CREATE INDEX idx_user_coffees_user ON public.user_coffees(user_id);
 CREATE INDEX idx_user_coffees_flavor_notes ON public.user_coffees USING gin (flavor_notes);
 
-CREATE INDEX idx_scan_events_user_created_at ON public.scan_events(user_id, created_at DESC);
-CREATE INDEX idx_scan_events_barcode ON public.scan_events(barcode);
+CREATE INDEX IF NOT EXISTS idx_scan_events_user_created_at ON public.scan_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scan_events_barcode ON public.scan_events(barcode);
 
 CREATE INDEX idx_user_statistics_updated_at ON public.user_statistics(updated_at DESC);

--- a/db/migrations/schema/03_create_scan_events.sql
+++ b/db/migrations/schema/03_create_scan_events.sql
@@ -1,0 +1,28 @@
+-- Creates scan events table for OCR history.
+CREATE TABLE public.scan_events (
+  id bigserial PRIMARY KEY,
+  user_id text NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE,
+  coffee_name text,
+  brand text,
+  barcode text,
+  image_url text,
+  original_text text,
+  corrected_text text,
+  origin text,
+  roast_level text,
+  flavor_notes jsonb,
+  processing text,
+  roast_date text,
+  varietals jsonb,
+  thumbnail_url text,
+  structured_confidence jsonb,
+  structured_uncertainty jsonb,
+  match_score numeric,
+  is_recommended boolean NOT NULL DEFAULT false,
+  detected_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_events_user_created_at
+  ON public.scan_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scan_events_barcode ON public.scan_events(barcode);


### PR DESCRIPTION
### Motivation
- Provide a dedicated `scan_events` table to store OCR scan history and metadata referenced by `server/routes/ocr.js`.
- Ensure referential integrity by referencing `app_users(id)` for owner linkage.
- Support common query patterns (user history and barcode lookup) with appropriate indexes.
- Make index creation idempotent to avoid migration failures on repeated runs.

### Description
- Added `db/migrations/schema/03_create_scan_events.sql` which creates `public.scan_events` with columns used in `server/routes/ocr.js`, including `user_id`, `coffee_name`, `brand`, `barcode`, `image_url`, `original_text`, `corrected_text`, `origin`, `roast_level`, `flavor_notes jsonb`, `processing`, `roast_date`, `varietals jsonb`, `thumbnail_url`, `structured_confidence jsonb`, `structured_uncertainty jsonb`, `match_score numeric`, `is_recommended boolean`, `detected_at`, and `created_at`.
- The new table defines `user_id text NOT NULL REFERENCES public.app_users(id) ON DELETE CASCADE` and sensible defaults for timestamps and `is_recommended`.
- Added indexes in the migration for `idx_scan_events_user_created_at` (on `user_id, created_at DESC`) and `idx_scan_events_barcode` (on `barcode`).
- Updated `db/migrations/indexes/07_indexes.sql` to use `IF NOT EXISTS` for the `scan_events` indexes to make index creation idempotent.

### Testing
- No automated tests were executed for this change.
- Verified the migration file `db/migrations/schema/03_create_scan_events.sql` was created and the shared indexes file was updated in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602d950e68832a9bf67a27357ba6a4)