### PR TITLE
Do not default OCR history match_percentage to 0; handle nulls in FE

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1503,7 +1503,7 @@ router.get('/api/ocr/history', async (req, res) => {
       structured_uncertainty: row.structured_uncertainty,
       created_at: row.created_at,
       rating: null,
-      match_percentage: row.match_score || 0,
+      match_percentage: row.match_score,
       is_recommended: row.is_recommended || false,
       is_purchased: false,
     }));

--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -53,7 +53,7 @@ interface OCRHistory {
   corrected_text: string;
   created_at: Date;
   rating?: number;
-  match_percentage?: number;
+  match_percentage?: number | null;
   is_recommended?: boolean;
   is_favorite?: boolean;
 }
@@ -62,7 +62,7 @@ interface ScanResult {
   original: string;
   corrected: string;
   recommendation: string;
-  matchPercentage?: number;
+  matchPercentage?: number | null;
   isRecommended?: boolean;
   scanId?: string;
   brewingMethods?: string[];
@@ -643,8 +643,10 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
   };
   const showBackButton = currentView !== 'home';
   const brewingMethods = scanResult?.brewingMethods ?? [];
-  const matchLabel = scanResult?.matchPercentage
-    ? `${scanResult.matchPercentage}% zhoda`
+  const matchLabel = scanResult
+    ? typeof scanResult.matchPercentage === 'number'
+      ? `${scanResult.matchPercentage}% zhoda`
+      : 'Profil chýba'
     : undefined;
   const tasteSuggestions = useMemo(
     () => [

--- a/src/screens/ScanDetailScreen/index.tsx
+++ b/src/screens/ScanDetailScreen/index.tsx
@@ -21,7 +21,10 @@ const ScanDetailScreen: React.FC<ScanDetailScreenProps> = ({ scan }) => {
     { label: 'Pražiareň / Značka', value: scan.brand },
     { label: 'Pôvod', value: scan.origin },
     { label: 'Praženie', value: scan.roast_level },
-    { label: 'Zhoda s profilom', value: scan.match_percentage ? `${scan.match_percentage}%` : null },
+    {
+      label: 'Zhoda s profilom',
+      value: typeof scan.match_percentage === 'number' ? `${scan.match_percentage}%` : 'Profil chýba',
+    },
     { label: 'Hodnotenie', value: typeof scan.rating === 'number' ? `${scan.rating}/5` : null },
     { label: 'Odporúčanie AI', value: scan.is_recommended === false ? 'Skôr NIE' : scan.is_recommended ? 'Skôr ÁNO' : null },
     { label: 'Obľúbená', value: scan.is_favorite ? 'Áno' : null },

--- a/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
+++ b/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
@@ -93,7 +93,7 @@ const ScannedCoffeeDetailScreen: React.FC<{ coffeeId: string; onBack: () => void
         />
         <DetailRow
           label="Zhoda s profilom"
-          value={typeof coffee.match === 'number' ? `${coffee.match}%` : undefined}
+          value={typeof coffee.match === 'number' ? `${coffee.match}%` : '—'}
         />
         {coffee.flavorNotes && coffee.flavorNotes.length > 0 ? (
           <DetailRow label="Chuťové tóny" value={coffee.flavorNotes.join(', ')} />

--- a/src/services/homePagesService.ts
+++ b/src/services/homePagesService.ts
@@ -362,7 +362,7 @@ export const fetchScanHistory = async (limit: number = 5): Promise<CoffeeData[]>
       id: item.id.toString(),
       name: item.coffee_name || 'Neznáma káva',
       rating: parseFloat(item.rating || 0),
-      match: parseInt(item.match_percentage || 0),
+      match: typeof item.match_percentage === 'number' ? item.match_percentage : undefined,
       timestamp: new Date(item.created_at),
       isRecommended: item.is_recommended || false,
       brand: item.brand,

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1496,7 +1496,7 @@ export const fetchOCRHistory = async (limit: number = 10): Promise<OCRHistory[]>
       corrected_text: item.corrected_text,
       created_at: new Date(item.created_at),
       rating: item.rating,
-      match_percentage: item.match_percentage,
+      match_percentage: typeof item.match_percentage === 'number' ? item.match_percentage : null,
       is_recommended: item.is_recommended,
       is_purchased: item.is_purchased,
       is_favorite: item.is_favorite,


### PR DESCRIPTION
### Motivation

- The backend was forcing a default `0` for OCR history `match_percentage` which hides the distinction between an actual zero-score and a missing profile/score.
- Frontend code assumed a numeric `match_percentage`, which caused incorrect UI copy or misleading scores when the server intended to communicate a missing value.

### Description

- Return `match_score` unchanged from `scan_events` in `server/routes/ocr.js` by setting `match_percentage: row.match_score` instead of `row.match_score || 0`.
- Normalize the incoming history entry in `src/services/ocrServices.ts` to `match_percentage: typeof item.match_percentage === 'number' ? item.match_percentage : null` and update the `OCRHistory` type to allow `number | null`.
- Update UI consumers to handle `null` gracefully: show `Profil chýba` in `src/screens/CoffeeReceipeScanner/index.tsx` and `ScanDetailScreen`, and show `—` in `src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx` when the match is not provided.
- Stop coercing `match_percentage` to `0` in `src/services/homePagesService.ts` mapping so `match` is `undefined` when the backend did not provide a numeric score.

### Testing

- No automated tests were executed for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602ed77334832a807d843eb25a5869)