### PR TITLE
Allow client taste profile override in OCR evaluation

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1124,6 +1124,7 @@ router.post('/api/ocr/evaluate', async (req, res) => {
       structuredMetadata,
       coffee_attributes,
       taste_profile,
+      taste_profile_source,
     } = req.body ?? {};
     if (!corrected_text) return res.status(400).json({ error: 'Chýba text kávy' });
     correctedText = corrected_text;
@@ -1136,10 +1137,14 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     const dbPreferences = result.rows[0];
     const requestTasteProfile =
       taste_profile && typeof taste_profile === 'object' ? taste_profile : null;
+    const requestTasteProfileSource =
+      typeof taste_profile_source === 'string' ? taste_profile_source : null;
     const requestUpdatedAtRaw =
       requestTasteProfile?.updated_at ?? requestTasteProfile?.last_recalculated_at ?? null;
     const requestHasTimestamp = Boolean(requestUpdatedAtRaw);
-    if (requestTasteProfile && !requestHasTimestamp) {
+    const allowTimestamplessProfile =
+      Boolean(requestTasteProfile) && (!dbPreferences || requestTasteProfileSource === 'client');
+    if (requestTasteProfile && !requestHasTimestamp && !allowTimestamplessProfile) {
       console.warn('⚠️ [OCR] taste_profile missing timestamp; using DB profile.', {
         uid,
         hasTasteProfile: Boolean(requestTasteProfile),
@@ -1183,8 +1188,9 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     const normalizedRequestTasteProfile = normalizeTasteProfileForEvaluation(requestTasteProfile);
     const useRequestProfile =
       Boolean(requestTasteProfile) &&
-      requestUpdatedAt &&
-      (!dbLatestTimestamp || requestUpdatedAt >= dbLatestTimestamp);
+      (requestUpdatedAt
+        ? !dbLatestTimestamp || requestUpdatedAt >= dbLatestTimestamp
+        : allowTimestamplessProfile);
     const candidatePreferences = useRequestProfile
       ? normalizedRequestTasteProfile
       : dbPreferences;

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1312,6 +1312,9 @@ export const processOCR = async (
                 const tasteProfilePayload = mapTasteProfilePayload(options.tasteProfile);
                 if (tasteProfilePayload) {
                   payload.taste_profile = tasteProfilePayload;
+                  if (!('preferences' in options.tasteProfile)) {
+                    payload.taste_profile_source = 'client';
+                  }
                 }
               }
               // Manual QA: submit the questionnaire flow (TasteProfileVector) and confirm


### PR DESCRIPTION
### Motivation

- Allow the OCR evaluation endpoint to accept a `taste_profile` that lacks `updated_at`/`last_recalculated_at` when the user has no DB profile or when the client explicitly indicates the profile is a local override.
- Ensure the frontend marks locally-held `TasteProfileVector` payloads so the backend can safely prefer request data without sacrificing timestamp safeguards.

### Description

- In `server/routes/ocr.js` accept `taste_profile_source` from the request, compute `allowTimestamplessProfile`, and only treat timestampless profiles as usable when the DB profile is missing or `taste_profile_source === 'client'`.
- Update the `useRequestProfile` logic to permit timestampless request profiles when `allowTimestamplessProfile` is true while preserving existing timestamp validation and conflict responses.
- In `src/services/ocrServices.ts` add `taste_profile_source = 'client'` to the evaluation payload when submitting a local-only `TasteProfileVector` so the backend can detect a client override.
- Changed files: `server/routes/ocr.js` and `src/services/ocrServices.ts`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602fffcfb8832a941a478729747cb3)