### PR TITLE
Allow client taste profiles in OCR evaluation

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1177,7 +1177,11 @@ router.post('/api/ocr/evaluate', async (req, res) => {
             .status(400)
             .json({ error: 'Neplatný taste_profile.updated_at' });
         }
-        if (dbLatestTimestamp && requestUpdatedAt < dbLatestTimestamp) {
+        if (
+          requestTasteProfileSource !== 'client' &&
+          dbLatestTimestamp &&
+          requestUpdatedAt < dbLatestTimestamp
+        ) {
           return res
             .status(409)
             .json({ error: 'Zastaralý chuťový profil' });
@@ -1188,9 +1192,10 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     const normalizedRequestTasteProfile = normalizeTasteProfileForEvaluation(requestTasteProfile);
     const useRequestProfile =
       Boolean(requestTasteProfile) &&
-      (requestUpdatedAt
-        ? !dbLatestTimestamp || requestUpdatedAt >= dbLatestTimestamp
-        : allowTimestamplessProfile);
+      (requestTasteProfileSource === 'client' ||
+        (requestUpdatedAt
+          ? !dbLatestTimestamp || requestUpdatedAt >= dbLatestTimestamp
+          : allowTimestamplessProfile));
     const candidatePreferences = useRequestProfile
       ? normalizedRequestTasteProfile
       : dbPreferences;

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1308,11 +1308,15 @@ export const processOCR = async (
                 structured_metadata: evaluationStructuredMetadata,
                 coffee_attributes: coffeeAttributes,
               };
+              const isLocalTasteProfile =
+                Boolean(options?.tasteProfile) &&
+                options?.tasteProfile &&
+                !('preferences' in options.tasteProfile);
               if (options?.tasteProfile) {
                 const tasteProfilePayload = mapTasteProfilePayload(options.tasteProfile);
                 if (tasteProfilePayload) {
                   payload.taste_profile = tasteProfilePayload;
-                  if (!('preferences' in options.tasteProfile)) {
+                  if (isLocalTasteProfile) {
                     payload.taste_profile_source = 'client';
                   }
                 }


### PR DESCRIPTION
### Motivation
- Allow a `taste_profile` provided by the client to be accepted even when it lacks `updated_at`/`last_recalculated_at` if the database profile is missing or the request explicitly marks the profile as client-sourced.
- Prevent the backend from rejecting local-only taste vectors as stale when the front-end intends to override the DB for evaluation.
- Make the front-end explicitly mark local-only `TasteProfileVector` payloads so the backend can safely prefer request data.

### Description
- Modify `server/routes/ocr.js` to skip the stale-profile `409` check when `requestTasteProfileSource === 'client'` and to prefer the request profile when the source is `'client'`.
- Update the `useRequestProfile` selection logic to allow client-sourced profiles to override DB staleness checks.
- Change `src/services/ocrServices.ts` to detect local-only taste profiles (`TasteProfileVector` without `preferences`) and set `taste_profile_source = 'client'` on the evaluation payload.
- Introduced an `isLocalTasteProfile` variable in the OCR service and adjusted payload construction to include `taste_profile` and its source flag when present.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696030b9b468832a93b775f58858d265)