### PR TITLE
Store confirmed structured OCR data in scan events

### DIFF
--- a/db/migrations/schema/12_add_scan_event_confirmed_structured_fields.sql
+++ b/db/migrations/schema/12_add_scan_event_confirmed_structured_fields.sql
@@ -1,0 +1,5 @@
+-- Add fields for storing user-confirmed structured OCR metadata.
+ALTER TABLE public.scan_events
+  ADD COLUMN IF NOT EXISTS confirmed_structured_metadata jsonb,
+  ADD COLUMN IF NOT EXISTS confirmed_structured_confidence jsonb,
+  ADD COLUMN IF NOT EXISTS confirmed_structured_raw jsonb;

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1374,8 +1374,7 @@ ${EVALUATION_RESPONSE_SCHEMA}
  * Potvrdí štruktúrované údaje skenu a uchová ich pre budúce odporúčania.
  *
  * Endpoint len validuje vstup a uloží auditný log, aby FE vedel, že
- * potvrdenie prebehlo úspešne. DB schéma aktuálne neobsahuje
- * dedikované polia na štruktúrované dáta, preto hodnoty iba logujeme.
+ * potvrdenie prebehlo úspešne.
  */
 router.post('/api/ocr/:id/structured/confirm', async (req, res) => {
   const idToken = req.headers.authorization?.split(' ')[1];
@@ -1410,9 +1409,35 @@ router.post('/api/ocr/:id/structured/confirm', async (req, res) => {
       if (err) console.error('❌ Chyba pri logovaní structured confirm:', err);
     });
 
-    return res
-      .status(200)
-      .json({ message: 'Štruktúrované dáta potvrdené', ok: true });
+    const normalizeJsonField = (value) =>
+      value === undefined || value === null ? null : JSON.stringify(value);
+    const normalizedMetadata = metadata && typeof metadata === 'object' ? metadata : null;
+    const normalizedConfidence = confidence && typeof confidence === 'object' ? confidence : null;
+
+    const updateResult = await db.query(
+      `UPDATE scan_events
+       SET confirmed_structured_metadata = $1::jsonb,
+           confirmed_structured_confidence = $2::jsonb,
+           confirmed_structured_raw = $3::jsonb
+       WHERE id = $4 AND user_id = $5
+       RETURNING id`,
+      [
+        normalizeJsonField(normalizedMetadata),
+        normalizeJsonField(normalizedConfidence),
+        normalizeJsonField(raw),
+        scanId,
+        decoded.uid,
+      ]
+    );
+
+    if (updateResult.rowCount === 0) {
+      return res.status(404).json({ error: 'Sken neexistuje' });
+    }
+
+    return res.status(200).json({
+      message: 'Štruktúrované dáta potvrdené',
+      ok: true,
+    });
   } catch (err) {
     console.error('❌ Chyba pri potvrdení štruktúrovaných dát:', err);
     return res
@@ -1487,6 +1512,9 @@ router.get('/api/ocr/history', async (req, res) => {
         thumbnail_url,
         structured_confidence,
         structured_uncertainty,
+        confirmed_structured_metadata,
+        confirmed_structured_confidence,
+        confirmed_structured_raw,
         match_score,
         is_recommended,
         created_at
@@ -1512,6 +1540,9 @@ router.get('/api/ocr/history', async (req, res) => {
       thumbnail_url: row.thumbnail_url,
       structured_confidence: row.structured_confidence,
       structured_uncertainty: row.structured_uncertainty,
+      confirmed_structured_metadata: row.confirmed_structured_metadata,
+      confirmed_structured_confidence: row.confirmed_structured_confidence,
+      confirmed_structured_raw: row.confirmed_structured_raw,
       created_at: row.created_at,
       rating: null,
       match_percentage: row.match_score,

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -1178,13 +1178,29 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   };
 
   const buildMetadataFromHistory = useCallback((item: OCRHistory): StructuredCoffeeMetadata | null => {
-    const roaster = normalizeStructuredStringValue(item.brand);
-    const origin = normalizeStructuredStringValue(item.origin);
-    const roastLevel = normalizeStructuredStringValue(item.roast_level);
-    const processing = normalizeStructuredStringValue(item.processing);
-    const roastDate = normalizeStructuredStringValue(item.roast_date);
-    const flavorNotes = normalizeStructuredStringArrayValue(item.flavor_notes);
-    const varietals = normalizeStructuredStringArrayValue(item.varietals);
+    const confirmed = item.confirmed_structured_metadata;
+    const confirmedFlavorNotes =
+      confirmed && 'flavor_notes' in confirmed
+        ? (confirmed as StructuredCoffeeMetadata & { flavor_notes?: string[] | null }).flavor_notes
+        : null;
+    const confirmedRoastLevel =
+      confirmed && 'roast_level' in confirmed
+        ? (confirmed as StructuredCoffeeMetadata & { roast_level?: string | null }).roast_level
+        : null;
+
+    const roaster = normalizeStructuredStringValue(confirmed?.roaster ?? item.brand);
+    const origin = normalizeStructuredStringValue(confirmed?.origin ?? item.origin);
+    const roastLevel = normalizeStructuredStringValue(
+      confirmed?.roastLevel ?? confirmedRoastLevel ?? item.roast_level
+    );
+    const processing = normalizeStructuredStringValue(confirmed?.processing ?? item.processing);
+    const roastDate = normalizeStructuredStringValue(confirmed?.roastDate ?? item.roast_date);
+    const flavorNotes = normalizeStructuredStringArrayValue(
+      confirmed?.flavorNotes ?? confirmedFlavorNotes ?? item.flavor_notes
+    );
+    const varietals = normalizeStructuredStringArrayValue(
+      confirmed?.varietals ?? item.varietals
+    );
 
     const metadata: StructuredCoffeeMetadata = {
       roaster,
@@ -1194,7 +1210,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       flavorNotes,
       roastDate,
       varietals,
-      confidenceFlags: null,
+      confidenceFlags: confirmed?.confidenceFlags ?? null,
     };
 
     const hasAnyLabelValue =

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1467,6 +1467,9 @@ export interface OCRHistory {
   thumbnail_url?: string | null;
   structured_confidence?: Record<string, unknown> | null;
   structured_uncertainty?: Record<string, unknown> | null;
+  confirmed_structured_metadata?: StructuredCoffeeMetadata | null;
+  confirmed_structured_confidence?: Record<string, unknown> | null;
+  confirmed_structured_raw?: unknown | null;
 }
 
 /**
@@ -1517,6 +1520,9 @@ export const fetchOCRHistory = async (limit: number = 10): Promise<OCRHistory[]>
       thumbnail_url: item.thumbnail_url ?? null,
       structured_confidence: item.structured_confidence ?? null,
       structured_uncertainty: item.structured_uncertainty ?? null,
+      confirmed_structured_metadata: item.confirmed_structured_metadata ?? null,
+      confirmed_structured_confidence: item.confirmed_structured_confidence ?? null,
+      confirmed_structured_raw: item.confirmed_structured_raw ?? null,
     }));
   } catch (error) {
     console.error('Error fetching OCR history:', error);


### PR DESCRIPTION
### Motivation
- Save user-confirmed structured OCR outputs (metadata, confidence, raw) for personalization and purchases instead of only writing an audit log.
- Make confirmed structured values retrievable by the frontend so UI and downstream logic can prefer user-validated data.
- Add a durable schema change to persist these confirmed fields alongside existing `scan_events` data.

### Description
- Add a new migration `db/migrations/schema/12_add_scan_event_confirmed_structured_fields.sql` to add `confirmed_structured_metadata`, `confirmed_structured_confidence`, and `confirmed_structured_raw` JSONB columns to `scan_events`.
- Update the confirm endpoint in `server/routes/ocr.js` (`POST /api/ocr/:id/structured/confirm`) to persist the payload with an `UPDATE scan_events ... RETURNING id` and return 404 when the scan does not exist.
- Include the new confirmed fields in the `/api/ocr/history` query and response so clients can receive confirmed structured data.
- Update frontend types and mappings in `src/services/ocrServices.ts` and update `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to prefer `confirmed_structured_metadata` (and confidence) when building structured metadata from history entries.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696031d58714832abbbfce4e1dd47a57)