### PR TITLE
Limit OCR taste profile to 4D

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -294,6 +294,13 @@ const CoffeePreferenceForm = ({
     return result;
   };
 
+  const mapTasteVectorForStorage = (vector: TasteVector) => ({
+    sweetness: vector.sweetness,
+    acidity: vector.acidity,
+    bitterness: vector.bitterness,
+    body: vector.body,
+  });
+
   const getAnswerLabel = (questionId: string, quizAnswers: Record<string, string>) => {
     const question = allQuestions.find(q => q.id === questionId);
     const selectedValue = quizAnswers[questionId];
@@ -500,7 +507,8 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
     const preferences = {
       quiz_version: 'taste-2024-10',
       quiz_answers: answers,
-      taste_vector: tasteVector,
+      // OCR evaluácia používa iba 4D profil, preto pri ukladaní odrezávame extra dimenzie.
+      taste_vector: mapTasteVectorForStorage(tasteVector),
       consistency_score: confidence,
       ai_confidence: confidence,
     };

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -361,6 +361,13 @@ const extractTasteVector = (
   return profile;
 };
 
+const mapOcrTasteVector = (vector: TasteProfileVector): TasteProfileVector => ({
+  sweetness: vector.sweetness,
+  acidity: vector.acidity,
+  bitterness: vector.bitterness,
+  body: vector.body,
+});
+
 const mapTasteProfilePayload = (
   profile?: TasteProfileVector | UserTasteProfile | null,
 ): Record<string, unknown> | null => {
@@ -385,17 +392,19 @@ const mapTasteProfilePayload = (
   if (!tasteVector) {
     return null;
   }
+  // OCR evaluácia používa len 4D chuťový profil (sweetness/acidity/bitterness/body).
+  const ocrTasteVector = mapOcrTasteVector(tasteVector);
 
   if ('preferences' in profile) {
     const flavorNoteEntries = profile.flavorNotes ?? {};
     const flavorNotes = Object.keys(flavorNoteEntries).filter(Boolean);
     return {
       user_id: profile.userId,
-      taste_vector: tasteVector,
-      sweetness: tasteVector.sweetness,
-      acidity: tasteVector.acidity,
-      bitterness: tasteVector.bitterness,
-      body: tasteVector.body,
+      taste_vector: ocrTasteVector,
+      sweetness: ocrTasteVector.sweetness,
+      acidity: ocrTasteVector.acidity,
+      bitterness: ocrTasteVector.bitterness,
+      body: ocrTasteVector.body,
       flavor_notes: flavorNotes,
       flavor_note_weights: flavorNoteEntries,
       milk_preferences: profile.milkPreferences,
@@ -413,11 +422,11 @@ const mapTasteProfilePayload = (
   }
 
   return {
-    taste_vector: tasteVector,
-    sweetness: tasteVector.sweetness,
-    acidity: tasteVector.acidity,
-    bitterness: tasteVector.bitterness,
-    body: tasteVector.body,
+    taste_vector: ocrTasteVector,
+    sweetness: ocrTasteVector.sweetness,
+    acidity: ocrTasteVector.acidity,
+    bitterness: ocrTasteVector.bitterness,
+    body: ocrTasteVector.body,
   };
 };
 
@@ -1323,6 +1332,7 @@ export const processOCR = async (
               }
               // Manual QA: submit the questionnaire flow (TasteProfileVector) and confirm
               // `/ocr/evaluate` receives `taste_profile` with only taste_vector + sweetness/acidity/bitterness/body.
+              // Extra dimensions (intensity/experimentalism) are intentionally dropped for OCR evaluation.
               const evaluationResult = await loggedFetchWithStatusRetry(
                 `${API_URL}/ocr/evaluate`,
                 {


### PR DESCRIPTION
### Motivation
- The OCR evaluation endpoint should only receive core taste dimensions to match backend expectations and avoid implying the 6D questionnaire vector is evaluated by OCR.
- Questionnaire logic still computes a 6D `TasteVector` (adds `intensity` and `experimentalism`) for AI recommendation quality, but OCR needs a stable 4D payload.
- Persisted preference payloads should be explicit about which dimensions are saved to prevent accidental storage of non-supported fields.
- Make the behavior explicit in code comments so future contributors understand the intentional trimming of extra dimensions.

### Description
- Added `mapTasteVectorForStorage` in `src/components/personalization/CoffeePreferenceForm.tsx` and used it when saving `coffee_preferences` so only `sweetness`, `acidity`, `bitterness`, and `body` are persisted.
- Added `mapOcrTasteVector` in `src/services/ocrServices.ts` and updated `mapTasteProfilePayload` to send an OCR payload with only the 4 core dimensions and corresponding fields (`taste_vector`, `sweetness`, `acidity`, `bitterness`, `body`).
- Documented the decision by adding comments near the OCR evaluation call that extra dimensions (`intensity`/`experimentalism`) are intentionally dropped for OCR.
- No other behavioral changes to AI recommendation generation; the 6D vector is still computed and used locally for AI flows.

### Testing
- No automated tests were run for this change.
- (No unit/integration test suite executed as part of this PR.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960341b3098832aa7b046b559b61ed7)