### PR TITLE
Send taste profiles without timestamps and suppress profile_missing UI

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -87,6 +87,7 @@ interface ScanResult {
   structuredConfidence?: Record<string, unknown> | null;
   structuredRaw?: unknown;
   evaluation?: CoffeeEvaluationResult | null;
+  tasteProfileSent?: boolean;
 }
 
 type ScanResultLike = ScanResult & { rawStructuredResponse?: unknown };
@@ -2111,7 +2112,8 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   // Suppress compatibility scoring whenever the AI evaluation is not ready.
   const shouldSuppressCompatibility = evaluationStatus !== 'ok';
   const neutralVerdictCopy = 'Čakáme na AI hodnotenie';
-  const isProfileMissing = evaluationStatus === 'profile_missing';
+  const didSendTasteProfile = Boolean(scanResult?.tasteProfileSent);
+  const isProfileMissing = evaluationStatus === 'profile_missing' && !didSendTasteProfile;
   const profileMissingText = evaluation?.summary
     || evaluation?.disclaimer
     || 'Vyplň krátky dotazník a získaš osobné hodnotenie zhody pre každú kávu.';
@@ -2521,7 +2523,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     evaluationTips,
   ]);
   const insightStatusContent = useMemo(() => {
-    if (evaluationStatus === 'profile_missing') {
+    if (evaluationStatus === 'profile_missing' && !didSendTasteProfile) {
       return {
         headline: 'Získaj presnejší insight',
         body: profileMissingText,
@@ -2547,7 +2549,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       };
     }
     return null;
-  }, [evaluation, evaluationStatus, profileMissingCtaLabel, profileMissingText]);
+  }, [didSendTasteProfile, evaluation, evaluationStatus, profileMissingCtaLabel, profileMissingText]);
 
   const fallbackVerdictExplanation = useMemo(() => {
     if (evaluationStatus !== 'ok') {

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -375,19 +375,6 @@ const mapTasteProfilePayload = (
     return null;
   }
 
-  if ('preferences' in profile) {
-    const profileUpdatedAt = profile.updatedAt ?? profile.lastRecalculatedAt ?? null;
-    if (!profileUpdatedAt) {
-      console.warn(
-        '[OCR] Skipping taste_profile payload because timestamps are missing.',
-        {
-          hasPreferencesProfile: true,
-        },
-      );
-      return null;
-    }
-  }
-
   const tasteVector = extractTasteVector(profile);
   if (!tasteVector) {
     return null;
@@ -757,6 +744,7 @@ interface OCRResult {
   structuredUncertainty?: Record<string, unknown> | null;
   rawStructuredResponse?: unknown;
   evaluation?: CoffeeEvaluationResult | null;
+  tasteProfileSent?: boolean;
 }
 
 /**
@@ -1294,6 +1282,7 @@ export const processOCR = async (
       structuredMetadata,
       estimatedAttributes,
     );
+    let tasteProfileSent = false;
     const evaluatePromise =
       isCoffee === false
         ? Promise.resolve({ skipped: true } as const)
@@ -1325,6 +1314,7 @@ export const processOCR = async (
                 const tasteProfilePayload = mapTasteProfilePayload(options.tasteProfile);
                 if (tasteProfilePayload) {
                   payload.taste_profile = tasteProfilePayload;
+                  tasteProfileSent = true;
                   if (isLocalTasteProfile) {
                     payload.taste_profile_source = 'client';
                   }
@@ -1449,6 +1439,7 @@ export const processOCR = async (
       structuredUncertainty,
       rawStructuredResponse,
       evaluation,
+      tasteProfileSent,
     };
   } catch (error) {
     console.error('OCR processing error:', error);


### PR DESCRIPTION
### Motivation
- The `mapTasteProfilePayload` function previously refused to send `taste_profile` when `updatedAt`/`lastRecalculatedAt` were missing, which caused the backend and UI to surface `profile_missing` despite valid preference data being available.
- The goal is to include valid taste profile data even without timestamps and prevent the UI from showing a misleading `profile_missing` state when a profile was actually sent.

### Description
- Removed the timestamp gate in `mapTasteProfilePayload` so `taste_profile` is included even if `updatedAt`/`lastRecalculatedAt` are absent.
- Added a `tasteProfileSent` boolean that is set when `taste_profile` is attached to the evaluation payload and returned from `processOCR`.
- Propagated `tasteProfileSent` into the `ScanResult`/`ScanResultLike` types and wired it into `CoffeeTasteScanner` so `isProfileMissing` and `insightStatusContent` suppress the `profile_missing` copy when a taste profile was sent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603513a4fc832ab80fba00e413b56b)