### PR TITLE
Normalize AI taste vector values from 0–10 scale

### DIFF
--- a/src/components/personalization/tasteAiUtils.ts
+++ b/src/components/personalization/tasteAiUtils.ts
@@ -78,9 +78,18 @@ const sanitizeTasteVector = (value: unknown, fallback: TasteVector): TasteVector
 
   const vector = value as Partial<Record<keyof TasteVector, unknown>>;
   const sanitized: TasteVector = { ...fallback };
+  let detectedTenScale = false;
   TASTE_DIMENSIONS.forEach(dimension => {
-    sanitized[dimension] = clamp01(coerceNumber(vector[dimension], fallback[dimension]));
+    const raw = coerceNumber(vector[dimension], fallback[dimension]);
+    if (raw > 1) {
+      detectedTenScale = true;
+    }
+    const normalized = raw > 1 ? raw / TASTE_VECTOR_MAX : raw;
+    sanitized[dimension] = clamp01(normalized);
   });
+  if (detectedTenScale) {
+    console.warn('AI taste_vector appears to be on a 0–10 scale; normalizing to 0–1.');
+  }
   return sanitized;
 };
 


### PR DESCRIPTION
### Motivation

- The AI sometimes returns taste vector values on a 0–10 scale which previously got hard-clamped to 0–1 producing incorrect results.
- The goal is to detect and normalize 0–10 style outputs into the expected 0–1 range so downstream logic receives correct values.
- Add a visible warning when such a 0–10 scale is detected to help debug prompt/schema mismatches.

### Description

- Updated `sanitizeTasteVector` to read raw values with `coerceNumber` and detect values greater than `1` using a `detectedTenScale` flag.
- When a value is `> 1` it is normalized by dividing by `TASTE_VECTOR_MAX` (10) and then clamped via `clamp01` instead of hard `clamp01` on the raw input.
- Added a `console.warn` call to emit `AI taste_vector appears to be on a 0–10 scale; normalizing to 0–1.` when any dimension appears to be on a 0–10 scale.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960365111b8832a9c00a453ab18ab48)