### PR TITLE
Retry OCR evaluation on 409 by removing stale taste profile

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1301,11 +1301,12 @@ export const processOCR = async (
                 roast_date: evaluationStructuredMetadata?.roastDate ?? null,
                 roaster: evaluationStructuredMetadata?.roaster ?? null,
               };
-              const payload: Record<string, unknown> = {
+              const basePayload: Record<string, unknown> = {
                 corrected_text: correctedText,
                 structured_metadata: evaluationStructuredMetadata,
                 coffee_attributes: coffeeAttributes,
               };
+              const payload: Record<string, unknown> = { ...basePayload };
               const isLocalTasteProfile =
                 Boolean(options?.tasteProfile) &&
                 options?.tasteProfile &&
@@ -1335,6 +1336,34 @@ export const processOCR = async (
                   body: JSON.stringify(payload),
                 },
               );
+
+              if (evaluationResult.response?.status === 409) {
+                console.warn(
+                  'Stale taste profile detected. Retrying evaluation without taste profile.',
+                );
+                const retryPayload = { ...basePayload };
+                const retryResult = await loggedFetchWithStatusRetry(
+                  `${API_URL}/ocr/evaluate`,
+                  {
+                    method: 'POST',
+                    headers: {
+                      Authorization: `Bearer ${token}`,
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(retryPayload),
+                  },
+                );
+                if (retryResult.response) {
+                  return {
+                    response: retryResult.response,
+                    exhaustedRetries: retryResult.exhaustedRetries,
+                  } as const;
+                }
+                return {
+                  error: retryResult.error,
+                  exhaustedRetries: retryResult.exhaustedRetries,
+                } as const;
+              }
 
               if (evaluationResult.response) {
                 return {


### PR DESCRIPTION
### Motivation
- The OCR evaluation can fail with a `409` when a user taste profile is stale, causing the overall evaluation to fail.
- The backend is expected to still evaluate when profile data is omitted, so the client should retry without the profile to recover.

### Description
- Detect `409` responses from the `POST /api/ocr/evaluate` call inside the `evaluatePromise` flow in `src/services/ocrServices.ts` by checking `evaluationResult.response?.status === 409`.
- Log a warning with `console.warn` indicating a stale taste profile and that a retry will be attempted.
- Retry the same `POST /api/ocr/evaluate` request using the `basePayload` which omits `taste_profile` and `taste_profile_source`, and return the retry response as the final evaluation result.
- Preserve existing retry/error handling paths and return the retry error if the retry path fails.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961757eec9c832aa4dea1c0c903383f)