### PR TITLE
Include brand/roaster in OCR save and evaluate payloads

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1048,11 +1048,19 @@ router.post('/api/ocr/save', async (req, res) => {
     );
 
     const storedStructuredMetadata = {
+      brand: normalizeTextField(
+        structured.brand ??
+          structured.roaster ??
+          structured.roaster_name ??
+          structured.roastery ??
+          derivedAttributes.brand
+      ),
       roaster: normalizeTextField(
         structured.roaster ??
           structured.roaster_name ??
+          structured.roastery ??
           structured.brand ??
-          structured.roastery
+          derivedAttributes.brand
       ),
       origin: resolvedOrigin,
       roastLevel: resolvedRoastLevel,
@@ -1221,6 +1229,18 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     const derivedAttributes = extractCoffeeAttributesFromText(corrected_text);
     const mergedStructuredMetadata = {
       ...structured,
+      brand:
+        structured.brand ??
+        structured.roaster ??
+        structured.roaster_name ??
+        structured.roastery ??
+        derivedAttributes.brand,
+      roaster:
+        structured.roaster ??
+        structured.roaster_name ??
+        structured.roastery ??
+        structured.brand ??
+        derivedAttributes.brand,
       origin: structured.origin ?? derivedAttributes.origin,
       roast_level: structured.roast_level ?? derivedAttributes.roast_level,
       roastLevel: structured.roastLevel ?? derivedAttributes.roast_level,
@@ -1231,6 +1251,18 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     };
     coffeeAttributes = {
       ...coffeeAttributes,
+      brand:
+        coffeeAttributes.brand ??
+        coffeeAttributes.roaster ??
+        mergedStructuredMetadata.brand ??
+        mergedStructuredMetadata.roaster ??
+        derivedAttributes.brand,
+      roaster:
+        coffeeAttributes.roaster ??
+        coffeeAttributes.brand ??
+        mergedStructuredMetadata.roaster ??
+        mergedStructuredMetadata.brand ??
+        derivedAttributes.brand,
       origin:
         coffeeAttributes.origin ??
         mergedStructuredMetadata.origin ??


### PR DESCRIPTION
### Motivation
- Ensure brand/roaster detected from OCR text is available to the frontend immediately after saving a scan. 
- Use brand/roaster as part of the evaluation grounding so AI explanations and deterministic fallbacks can consider brand signals. 
- Propagate derived `brand` into the unified coffee attributes used across `/api/ocr/save` and `/api/ocr/evaluate`.
- Preserve existing behavior while preferring explicit structured metadata when present.

### Description
- Added `brand` and `roaster` entries to the `mergedStructuredMetadata` used in `/api/ocr/evaluate`, pulling from `structured` fields or `derivedAttributes.brand` when available. 
- Propagated `brand` and `roaster` into the top-level `coffeeAttributes` resolution so `coffeeAttributes.brand`/`roaster` are populated from request, merged metadata, or derived values. 
- Included `brand` and `roaster` in the `storedStructuredMetadata` returned by `/api/ocr/save`, using `normalizeTextField` and falling back to derived brand when needed. 
- Changes applied in `server/routes/ocr.js` without altering other existing validation or profile-completion logic.

### Testing
- No automated tests were run on this change.
- No CI or unit test results are included with this PR.
- Manual runtime verification was not recorded in automated test logs.
- Recommend running existing test suite and exercising `/api/ocr/save` and `/api/ocr/evaluate` endpoints with scan payloads that include `brand`/`roaster` to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961765e7ba4832a95b58273d1203a85)