### PR TITLE
Persist full 6D taste vector and update prompts

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -299,6 +299,8 @@ const CoffeePreferenceForm = ({
     acidity: vector.acidity,
     bitterness: vector.bitterness,
     body: vector.body,
+    intensity: vector.intensity,
+    experimentalism: vector.experimentalism,
   });
 
   const getAnswerLabel = (questionId: string, quizAnswers: Record<string, string>) => {
@@ -428,6 +430,7 @@ ${JSON.stringify(normalizedFallbackVector, null, 2)}
 
 Rules for taste_vector:
 - Output floats between 0.0 and 1.0
+- Include all 6 dimensions (acidity, bitterness, sweetness, body, intensity, experimentalism)
 - Adjust based on current answers
 - Reflect meaningful deltas vs previous answers (see delta summary)
 
@@ -507,7 +510,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
     const preferences = {
       quiz_version: 'taste-2024-10',
       quiz_answers: answers,
-      // OCR evaluácia používa iba 4D profil, preto pri ukladaní odrezávame extra dimenzie.
+      // OCR evaluácia použije iba známe dimenzie, extra hodnoty ostanú zachované.
       taste_vector: mapTasteVectorForStorage(tasteVector),
       consistency_score: confidence,
       ai_confidence: confidence,

--- a/src/components/personalization/EditPreferences.tsx
+++ b/src/components/personalization/EditPreferences.tsx
@@ -23,6 +23,7 @@ import {
   buildRecommendationText,
   callOpenAIJsonSchema,
   normalizeTasteVectorTo01,
+  normalizeTasteVectorTo10,
   parseTasteAIResponse,
   TASTE_AI_SCHEMA_PROMPT,
   TasteVector,
@@ -88,7 +89,9 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
    * Vygeneruje nové AI odporúčanie podľa zadaných poznámok.
    */
   const getFallbackTasteVector = () => {
-    return profile?.coffee_preferences?.taste_vector ?? profile?.taste_vector ?? DEFAULT_TASTE_VECTOR;
+    const vector =
+      profile?.coffee_preferences?.taste_vector ?? profile?.taste_vector ?? DEFAULT_TASTE_VECTOR;
+    return normalizeTasteVectorTo10(vector);
   };
 
   const generateAI = async (additionalNotes: string, options?: { reset?: boolean }) => {
@@ -137,6 +140,7 @@ ${JSON.stringify(normalizedFallbackVector, null, 2)}`;
 
 Rules for taste_vector:
 - Output floats between 0.0 and 1.0
+- Include all 6 dimensions (acidity, bitterness, sweetness, body, intensity, experimentalism)
 - Adjust based on the notes and preferences
 
 Rules for confidence:


### PR DESCRIPTION
### Motivation
- Ensure the personalization quiz saves the full six-dimension taste profile (acidity, bitterness, sweetness, body, intensity, experimentalism) instead of trimming to 4D.
- Keep FE AI prompts, fallbacks and edit flows consistent with the 6D profile so downstream features receive the same shape.
- Confirm server-side validation already accepts `intensity` and `experimentalism` and continues to clamp values to safe ranges.

### Description
- Updated `mapTasteVectorForStorage` in `src/components/personalization/CoffeePreferenceForm.tsx` to include `intensity` and `experimentalism` when saving preferences. 
- Reinforced the 6D requirement in AI prompt text in `CoffeePreferenceForm.tsx` so the model is instructed to return all six dimensions. 
- In `src/components/personalization/EditPreferences.tsx` the fallback taste vector is now normalized with `normalizeTasteVectorTo10` (import added) before building prompts, and the prompt guidance was updated to require all six dimensions. 
- No server code changes were required because `server/routes/profile.js` already supports the six taste keys in `validateTasteVector` and performs clamping/scaling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696176cd691c832a9a455a67a3783533)