### PR TITLE
Use PUT for profile persistence

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -463,7 +463,7 @@ class ApiLearningStorageAdapter implements LearningStorageAdapter {
       };
 
       const response = await authorizedFetch(`${API_URL}/profile`, {
-        method: 'POST',
+        method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
### Motivation
- Ensure the frontend uses the backend's update semantics by calling `PUT /api/profile` instead of `POST` when persisting taste profiles.
- Preserve the existing payload contract so the server receives both the top-level taste fields and the nested `coffee_preferences` object.
- Avoid needing to add a new `POST` handler on the backend since an optimized `PUT` handler already exists.

### Description
- Updated `ApiLearningStorageAdapter.persistProfile` in `App.tsx` to call `${API_URL}/profile` with `method: 'PUT'` instead of `POST`.
- The request payload structure was left unchanged and still includes top-level fields (`sweetness`, `acidity`, `bitterness`, `body`, etc.) plus the `coffee_preferences` object.
- Verified that the server exposes a `PUT /api/profile` handler in `server/routes/profile.js` which accepts and processes the payload shape without a contract change.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696179a24524832aa09c6ef2818fadcd)