### PR TITLE
Include AI recommendation in preference snapshot

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -795,9 +795,25 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         return;
       }
       const data = (await response.json()) as Record<string, unknown> | null;
-      const snapshot = extractPreferenceSnapshot(
-        (data?.coffee_preferences as Record<string, unknown> | null) ?? null,
-      );
+      const coffeePreferences =
+        (data?.coffee_preferences as Record<string, unknown> | null) ?? null;
+      const snapshot = extractPreferenceSnapshot({
+        ...(coffeePreferences ?? {}),
+        ai_recommendation:
+          typeof data?.ai_recommendation === 'string'
+            ? data.ai_recommendation
+            : coffeePreferences?.ai_recommendation,
+        consistency_score:
+          typeof data?.consistency_score === 'number'
+            ? data.consistency_score
+            : typeof data?.ai_confidence === 'number'
+              ? data.ai_confidence
+              : coffeePreferences?.consistency_score ?? coffeePreferences?.ai_confidence,
+        ai_confidence:
+          typeof data?.ai_confidence === 'number'
+            ? data.ai_confidence
+            : coffeePreferences?.ai_confidence,
+      });
       if (snapshot) {
         setPreferenceSnapshot(snapshot);
       }


### PR DESCRIPTION
### Motivation
- Ensure the `preferenceSnapshot` used by `buildComparisonText()` includes the top-level `ai_recommendation` and related confidence fields returned by the `/api/profile` endpoint.
- Prefer top-level profile values while preserving existing nested `coffee_preferences` so AI summary and scores appear in snapshot-based comparisons.

### Description
- Updated `loadPreferenceSnapshot` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to merge top-level profile fields into the `coffee_preferences` payload before calling `extractPreferenceSnapshot`.
- The merge includes `ai_recommendation`, `consistency_score` (with fallback to `ai_confidence`), and `ai_confidence`, preferring values from the top-level `data` and falling back to `coffee_preferences` fields.
- The merged object is passed to `extractPreferenceSnapshot` and the resulting snapshot is stored via `setPreferenceSnapshot` when present.

### Testing
- No automated tests were run for this change.
- No automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696182b23118832ab58870d088b586d9)