### PR TITLE
Use string roast levels across the frontend

### DIFF
--- a/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
+++ b/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
@@ -79,10 +79,7 @@ const ScannedCoffeeDetailScreen: React.FC<{ coffeeId: string; onBack: () => void
         <DetailRow label="Pôvod" value={coffee.origin} />
         <DetailRow label="Proces" value={coffee.process} />
         <DetailRow label="Odroda" value={coffee.variety} />
-        <DetailRow
-          label="Praženie"
-          value={typeof coffee.roastLevel === 'number' ? coffee.roastLevel.toString() : undefined}
-        />
+        <DetailRow label="Praženie" value={coffee.roastLevel} />
         <DetailRow
           label="Intenzita"
           value={typeof coffee.intensity === 'number' ? coffee.intensity.toString() : undefined}

--- a/src/services/homePagesService.ts
+++ b/src/services/homePagesService.ts
@@ -47,11 +47,15 @@ const mapCoffeeItem = (item: Record<string, any>): CoffeeData => {
 
   const matchValue = item.match ?? item.match_score ?? item.match_percentage;
   const roastLevelValue =
-    typeof item.roast_level === 'number'
+    typeof item.roast_level === 'string'
       ? item.roast_level
-      : typeof item.roastLevel === 'number'
+      : typeof item.roastLevel === 'string'
         ? item.roastLevel
-        : undefined;
+        : typeof item.roast_level === 'number'
+          ? item.roast_level.toString()
+          : typeof item.roastLevel === 'number'
+            ? item.roastLevel.toString()
+            : undefined;
   const intensityValue =
     typeof item.intensity === 'number'
       ? item.intensity

--- a/src/types/Coffee.ts
+++ b/src/types/Coffee.ts
@@ -6,7 +6,7 @@
  * @property {string} name - Product or bean name displayed to users.
  * @property {string} [brand] - Coffee roaster or brand name.
  * @property {string} [origin] - Country or region of origin.
- * @property {number} [roastLevel] - Numeric roast level (e.g., 1-10) inferred from scans or metadata.
+ * @property {string} [roastLevel] - Roast level label (e.g., light, medium, dark) inferred from scans or metadata.
  * @property {number} [intensity] - Flavor intensity indicator used in UI summaries.
  * @property {string[]} [flavorNotes] - List of tasting notes associated with the coffee.
  * @property {number} [rating] - User or community rating score.
@@ -20,7 +20,7 @@ export interface Coffee {
   name: string;
   brand?: string;
   origin?: string;
-  roastLevel?: number;
+  roastLevel?: string;
   intensity?: number;
   flavorNotes?: string[];
   rating?: number;


### PR DESCRIPTION
### Motivation
- Establish a canonical `roastLevel` representation as human-readable string labels (e.g. `light`, `medium`, `dark`) on the frontend.
- Ensure incoming API payloads are normalized to that canonical form, converting numeric values to strings if needed.
- Simplify UI rendering by treating `roastLevel` as a string everywhere in the FE.
- Prevent mixed-type handling of `roastLevel` that caused extra formatting logic in multiple places.

### Description
- Change `Coffee.roastLevel` from `number` to `string` and update the JSDoc in `src/types/Coffee.ts`.
- Update `mapCoffeeItem` in `src/services/homePagesService.ts` to prefer string `roast_level`/`roastLevel` and fall back to converting numeric values to strings.
- Update `ScannedCoffeeDetailScreen` to render `roastLevel` directly with `value={coffee.roastLevel}` instead of numeric checks in `src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx`.
- Modified files: `src/types/Coffee.ts`, `src/services/homePagesService.ts`, and `src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623a679edc832a97aabd0d0fcac770)