### PR TITLE
Propagate taste profile timestamps to FE snapshots and OCR payloads

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -221,6 +221,8 @@ const serializeTasteProfile = (taste) => {
       ai_recommendation: null,
       manual_input: null,
       is_complete: false,
+      updated_at: null,
+      last_recalculated_at: null,
       coffee_preferences: null,
     };
   }
@@ -229,6 +231,8 @@ const serializeTasteProfile = (taste) => {
     ai_recommendation: taste.ai_recommendation ?? null,
     manual_input: taste.manual_input ?? null,
     is_complete: taste.is_complete ?? false,
+    updated_at: taste.updated_at ?? null,
+    last_recalculated_at: taste.last_recalculated_at ?? null,
     coffee_preferences: {
       sweetness: Number(taste.sweetness),
       acidity: Number(taste.acidity),

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -96,6 +96,8 @@ type CoffeePreferenceSnapshot = {
   ai_recommendation?: string | null;
   consistency_score?: number | null;
   taste_vector?: Record<string, number> | null;
+  updatedAt?: string | null;
+  lastRecalculatedAt?: string | null;
 };
 
 type StructuredConfirmPayload = ConfirmStructuredPayload & {
@@ -181,6 +183,18 @@ const extractPreferenceSnapshot = (
     payload.taste_vector && typeof payload.taste_vector === 'object'
       ? (payload.taste_vector as Record<string, number>)
       : null;
+  const updatedAt =
+    typeof payload.updated_at === 'string'
+      ? payload.updated_at
+      : typeof payload.updatedAt === 'string'
+        ? payload.updatedAt
+        : null;
+  const lastRecalculatedAt =
+    typeof payload.last_recalculated_at === 'string'
+      ? payload.last_recalculated_at
+      : typeof payload.lastRecalculatedAt === 'string'
+        ? payload.lastRecalculatedAt
+        : null;
 
   if (!aiRecommendation && consistencyScore == null && !tasteVector) {
     return null;
@@ -190,6 +204,8 @@ const extractPreferenceSnapshot = (
     ai_recommendation: aiRecommendation,
     consistency_score: consistencyScore,
     taste_vector: tasteVector,
+    updatedAt,
+    lastRecalculatedAt,
   };
 };
 
@@ -820,6 +836,21 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     () => normalizeTasteVectorTo10(preferenceSnapshot?.taste_vector ?? null),
     [preferenceSnapshot],
   );
+  const preferenceSnapshotProfile = useMemo(() => {
+    if (!preferenceSnapshotVector) {
+      return null;
+    }
+    const updatedAt = preferenceSnapshot?.updatedAt ?? null;
+    const lastRecalculatedAt = preferenceSnapshot?.lastRecalculatedAt ?? null;
+    if (!updatedAt && !lastRecalculatedAt) {
+      return preferenceSnapshotVector;
+    }
+    return {
+      ...preferenceSnapshotVector,
+      updatedAt: updatedAt ?? undefined,
+      lastRecalculatedAt: lastRecalculatedAt ?? undefined,
+    };
+  }, [preferenceSnapshot, preferenceSnapshotVector]);
 
   const loadPreferenceSnapshot = useCallback(async () => {
     try {
@@ -856,6 +887,14 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
           typeof data?.ai_confidence === 'number'
             ? data.ai_confidence
             : coffeePreferences?.ai_confidence,
+        updated_at:
+          typeof data?.updated_at === 'string'
+            ? data.updated_at
+            : coffeePreferences?.updated_at,
+        last_recalculated_at:
+          typeof data?.last_recalculated_at === 'string'
+            ? data.last_recalculated_at
+            : coffeePreferences?.last_recalculated_at,
       });
       if (snapshot) {
         setPreferenceSnapshot(snapshot);
@@ -1443,7 +1482,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       setOverlayText('Analyzujem...');
       setOverlayVisible(true);
 
-      const tasteProfile = resolveTasteProfile(profile, preferenceSnapshotVector);
+      const tasteProfile = resolveTasteProfile(profile, preferenceSnapshotProfile);
       const result = await processOCR(base64image, {
         imagePath: extra?.imagePath,
         tasteProfile,

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -368,6 +368,24 @@ const mapOcrTasteVector = (vector: TasteProfileVector): TasteProfileVector => ({
   body: vector.body,
 });
 
+const extractTasteProfileTimestamps = (
+  profile?: TasteProfileVector | UserTasteProfile | null,
+): { updatedAt: string | null; lastRecalculatedAt: string | null } => {
+  if (!profile || typeof profile !== 'object') {
+    return { updatedAt: null, lastRecalculatedAt: null };
+  }
+  const record = profile as Record<string, unknown>;
+  const updatedAt =
+    typeof record.updatedAt === 'string' && record.updatedAt.trim().length > 0
+      ? record.updatedAt
+      : null;
+  const lastRecalculatedAt =
+    typeof record.lastRecalculatedAt === 'string' && record.lastRecalculatedAt.trim().length > 0
+      ? record.lastRecalculatedAt
+      : null;
+  return { updatedAt, lastRecalculatedAt };
+};
+
 const mapTasteProfilePayload = (
   profile?: TasteProfileVector | UserTasteProfile | null,
 ): Record<string, unknown> | null => {
@@ -408,12 +426,15 @@ const mapTasteProfilePayload = (
     };
   }
 
+  const { updatedAt, lastRecalculatedAt } = extractTasteProfileTimestamps(profile);
   return {
     taste_vector: ocrTasteVector,
     sweetness: ocrTasteVector.sweetness,
     acidity: ocrTasteVector.acidity,
     bitterness: ocrTasteVector.bitterness,
     body: ocrTasteVector.body,
+    ...(updatedAt ? { updated_at: updatedAt } : {}),
+    ...(lastRecalculatedAt ? { last_recalculated_at: lastRecalculatedAt } : {}),
   };
 };
 
@@ -1333,16 +1354,18 @@ export const processOCR = async (
                 coffee_attributes: coffeeAttributes,
               };
               const payload: Record<string, unknown> = { ...basePayload };
-              const isLocalTasteProfile =
-                Boolean(options?.tasteProfile) &&
-                options?.tasteProfile &&
-                !('preferences' in options.tasteProfile);
               if (options?.tasteProfile) {
                 const tasteProfilePayload = mapTasteProfilePayload(options.tasteProfile);
                 if (tasteProfilePayload) {
+                  const { updatedAt, lastRecalculatedAt } = extractTasteProfileTimestamps(
+                    options.tasteProfile,
+                  );
+                  const hasServerTimestamps = Boolean(updatedAt || lastRecalculatedAt);
                   payload.taste_profile = tasteProfilePayload;
                   tasteProfileSent = true;
-                  if (isLocalTasteProfile) {
+                  if (hasServerTimestamps) {
+                    payload.taste_profile_source = 'server';
+                  } else {
                     payload.taste_profile_source = 'client';
                   }
                 }


### PR DESCRIPTION
### Motivation
- Ensure `updated_at` and `last_recalculated_at` from `user_taste_profiles_with_completion` are exposed to the frontend so OCR/evaluation can make informed decisions about profile currency.
- Persist server-provided profile timestamps in the scanner snapshot so local OCR evaluation can distinguish server-backed profiles from purely local ones.
- Include profile timestamps in OCR evaluation payloads so the backend can validate staleness and reconcile profile sources.
- Mark the taste profile source as `server` when server timestamps exist and `client` for local-only profiles to avoid mis-attribution.

### Description
- Added `updated_at` and `last_recalculated_at` to `serializeTasteProfile` / `buildProfileResponse` in `server/routes/profile.js` so the profile API returns those fields.
- Extended `CoffeeTasteScanner` snapshot types and `extractPreferenceSnapshot` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to read and store `updated_at`/`last_recalculated_at`, and use that augmented snapshot when resolving the taste profile for OCR.
- Added `extractTasteProfileTimestamps` helper and updated `mapTasteProfilePayload` in `src/services/ocrServices.ts` to include `updated_at`/`last_recalculated_at` in the `taste_profile` payload when present.
- Set `taste_profile_source` to `'server'` when server timestamps are present, otherwise to `'client'`, and ensured `taste_profile` is still included for both profile shapes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623b5a47a4832ab93d19fd40798308)