### PR TITLE
Ensure OCR evaluate uses auth token without DB save

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1145,7 +1145,9 @@ export const processOCR = async (
     let token: string | null = null;
     const shouldPersistScan =
       isCoffee && (Boolean(detectionLabels?.length) || Boolean(initialStructuredMetadata));
+    const shouldEvaluate = isCoffee !== false && hasReadableText;
     if (shouldPersistScan) {
+      await ensureOnline();
       token = await getAuthToken();
       if (!token) {
         throw new Error('Nie si prihlásený');
@@ -1289,6 +1291,10 @@ export const processOCR = async (
           rawStructuredResponse = metadataRaw ?? null;
         }
       }
+    }
+    if (shouldEvaluate && !token) {
+      await ensureOnline();
+      token = await getAuthToken();
     }
 
     const fallbackEvaluation: CoffeeEvaluationResult = {


### PR DESCRIPTION
### Motivation
- Ensure `/api/ocr/evaluate` is called with a valid auth token even when the scan is not persisted to the DB.
- Avoid requesting an auth token when the device is offline or when the scan is determined to be non-coffee.
- Reduce duplicated/token-misuse logic by centralizing when `getAuthToken` is requested for save vs evaluate.

### Description
- Introduced `shouldEvaluate = isCoffee !== false && hasReadableText` and use it to decide when evaluation needs a token.
- When `shouldPersistScan` is true, call `await ensureOnline()` and fetch `token` via `getAuthToken` before saving the scan and use it for the `/ocr/save` call.
- If evaluation will run (`shouldEvaluate`) and there is no `token` from the save step, call `await ensureOnline()` and fetch `token` before calling `/ocr/evaluate`.
- Preserved the existing skip branches for non-coffee and empty-text so tokens are not requested in those paths.

### Testing
- No automated tests were executed for this change.
- Static type checks or runtime verification were not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962494ce314832abf59bb93625b7fa5)