### PR TITLE
Persist coffee scans when corrected/original OCR text contains coffee signals

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1143,8 +1143,14 @@ export const processOCR = async (
     let rawStructuredResponse: unknown = null;
 
     let token: string | null = null;
+    const hasCoffeeTextSignals =
+      hasReadableText &&
+      (isCoffeeRelatedText(trimmedCorrectedText) || isCoffeeRelatedText(originalText));
     const shouldPersistScan =
-      isCoffee && (Boolean(detectionLabels?.length) || Boolean(initialStructuredMetadata));
+      isCoffee &&
+      (Boolean(detectionLabels?.length) ||
+        Boolean(initialStructuredMetadata) ||
+        hasCoffeeTextSignals);
     const shouldEvaluate = isCoffee !== false && hasReadableText;
     if (shouldPersistScan) {
       await ensureOnline();


### PR DESCRIPTION
### Motivation
- Ensure OCR scans are persisted when the corrected or original text contains coffee-related signals even if label detection returned no labels.
- Allow saving scans when `isCoffee === true` and text contains readable coffee signals so user-provided or AI-corrected text can trigger persistence.
- Preserve existing behavior for non-coffee scans and for scans already accompanied by labels or structured metadata.

### Description
- Introduced a `hasCoffeeTextSignals` boolean that requires `hasReadableText` and uses `isCoffeeRelatedText` on `corrected` and `original` text. 
- Updated the `shouldPersistScan` condition to include `hasCoffeeTextSignals` alongside existing checks for `detectionLabels` and `initialStructuredMetadata`. 
- No other control flow or external API calls were changed; the modification is local to `processOCR` in `src/services/ocrServices.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696249fcaf28832a85203dab2228b6e8)