### PR TITLE
Include taste_profile and coffee_attributes in brew-recipe requests and prompts

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -275,6 +275,83 @@ const parseDelimitedList = (value) => {
   return items.length > 0 ? items : null;
 };
 
+const resolveTasteVector = (profile) => {
+  if (!profile || typeof profile !== 'object') {
+    return null;
+  }
+  if (profile.taste_vector && typeof profile.taste_vector === 'object') {
+    return profile.taste_vector;
+  }
+  if (profile.preferences && typeof profile.preferences === 'object') {
+    return profile.preferences;
+  }
+  return profile;
+};
+
+const formatTasteProfileSummary = (profile) => {
+  const vector = resolveTasteVector(profile);
+  if (!vector || typeof vector !== 'object') {
+    return null;
+  }
+  const { sweetness, acidity, bitterness, body } = vector;
+  const values = [sweetness, acidity, bitterness, body];
+  if (!values.some((value) => typeof value === 'number' && Number.isFinite(value))) {
+    return null;
+  }
+  const formatValue = (value) =>
+    typeof value === 'number' && Number.isFinite(value) ? `${value}/10` : 'neznáme';
+  return `sladkosť ${formatValue(sweetness)}, acidita ${formatValue(
+    acidity
+  )}, horkosť ${formatValue(bitterness)}, telo ${formatValue(body)}`;
+};
+
+const formatCoffeeAttributesSummary = (attributes) => {
+  if (!attributes || typeof attributes !== 'object') {
+    return null;
+  }
+  const structured =
+    attributes.structured_metadata && typeof attributes.structured_metadata === 'object'
+      ? attributes.structured_metadata
+      : {};
+
+  const getValue = (record, keys) =>
+    keys.reduce((acc, key) => (acc !== undefined ? acc : record?.[key]), undefined);
+
+  const origin = getValue(attributes, ['origin']) ?? getValue(structured, ['origin']);
+  const roastLevel =
+    getValue(attributes, ['roast_level', 'roastLevel']) ??
+    getValue(structured, ['roast_level', 'roastLevel']);
+  const processing =
+    getValue(attributes, ['processing']) ?? getValue(structured, ['processing']);
+  const roaster =
+    getValue(attributes, ['roaster', 'roastery', 'brand']) ??
+    getValue(structured, ['roaster', 'roastery', 'brand']);
+  const flavorNotes =
+    getValue(attributes, ['flavor_notes', 'flavorNotes']) ??
+    getValue(structured, ['flavor_notes', 'flavorNotes']);
+  const varietals =
+    getValue(attributes, ['varietals']) ?? getValue(structured, ['varietals']);
+
+  const summaryBits = [
+    origin ? `pôvod ${origin}` : null,
+    roastLevel ? `praženie ${roastLevel}` : null,
+    processing ? `spracovanie ${processing}` : null,
+    roaster ? `pražiareň ${roaster}` : null,
+    Array.isArray(flavorNotes) && flavorNotes.length > 0
+      ? `tóny ${flavorNotes.join(', ')}`
+      : typeof flavorNotes === 'string' && flavorNotes.trim().length > 0
+      ? `tóny ${flavorNotes}`
+      : null,
+    Array.isArray(varietals) && varietals.length > 0
+      ? `odrody ${varietals.join(', ')}`
+      : typeof varietals === 'string' && varietals.trim().length > 0
+      ? `odrody ${varietals}`
+      : null,
+  ].filter(Boolean);
+
+  return summaryBits.length > 0 ? summaryBits.join(', ') : null;
+};
+
 const extractCoffeeAttributesFromText = (text) => {
   if (!text || typeof text !== 'string') {
     return {
@@ -823,7 +900,8 @@ router.post('/api/ocr/brewing-methods', async (req, res) => {
  * Vygeneruje recept na kávu podľa zvolenej metódy a preferovanej chuti.
  */
 router.post('/api/ocr/brew-recipe', async (req, res) => {
-  const { method, taste } = req.body ?? {};
+  const { method, taste, taste_profile: tasteProfile, coffee_attributes: coffeeAttributes } =
+    req.body ?? {};
   if (!method || typeof method !== 'string') {
     return res.status(400).json({ error: 'Chýba metóda prípravy' });
   }
@@ -832,9 +910,16 @@ router.post('/api/ocr/brew-recipe', async (req, res) => {
     return res.status(200).json({ recipe: '' });
   }
 
-  const prompt = `Priprav detailný recept na kávu pomocou metódy ${method}. Používateľ preferuje ${
-    taste || 'vyvážená'
-  } chuť. Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.`;
+  const tasteProfileSummary = formatTasteProfileSummary(tasteProfile);
+  const coffeeSummary = formatCoffeeAttributesSummary(coffeeAttributes);
+  const promptSections = [
+    `Priprav detailný recept na kávu pomocou metódy ${method}.`,
+    `Používateľ preferuje ${taste || 'vyvážená'} chuť.`,
+    tasteProfileSummary ? `Chuťový profil používateľa: ${tasteProfileSummary}.` : null,
+    coffeeSummary ? `Profil kávy: ${coffeeSummary}.` : null,
+    'Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.',
+  ].filter(Boolean);
+  const prompt = promptSections.join(' ');
 
   try {
     console.log('📤 [OpenAI] Recipe prompt meta:', {

--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -42,7 +42,8 @@ import {
   isCoffeeRelatedText,
 } from './services';
 import type { RecipeHistory } from './services';
-import { BrewContext } from '../../types/Personalization';
+import type { StructuredCoffeeMetadata } from '../../services/ocrServices';
+import { BrewContext, UserTasteProfile } from '../../types/Personalization';
 import { usePersonalization } from '../../hooks/usePersonalization';
 import { showToast } from '../../utils/toast';
 
@@ -71,6 +72,7 @@ interface ScanResult {
   nonCoffeeReason?: string;
   detectionLabels?: string[];
   detectionConfidence?: number;
+  structuredMetadata?: StructuredCoffeeMetadata | null;
 }
 
 interface BrewScannerProps {
@@ -144,7 +146,7 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
   onRecipeHistoryPress,
   onSeeAllRecipes,
 }) => {
-  const { coffeeDiary: personalizationDiary, refreshInsights } = usePersonalization();
+  const { coffeeDiary: personalizationDiary, refreshInsights, profile } = usePersonalization();
   const diary = personalizationDiary ;
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [editedText, setEditedText] = useState<string>('');
@@ -192,6 +194,31 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
     }
     showToast('Pripravujeme prehľad receptov.');
   }, [onSeeAllRecipes]);
+
+  const resolveTasteProfileForRecipe = useCallback(async (): Promise<UserTasteProfile | null> => {
+    if (profile) {
+      return profile;
+    }
+    try {
+      return await preferenceEngine.getProfile();
+    } catch (error) {
+      console.warn('CoffeeReceipeScanner: failed to resolve taste profile', error);
+      return null;
+    }
+  }, [profile]);
+
+  const buildCoffeeAttributes = useCallback((): Record<string, unknown> | null => {
+    if (!scanResult) {
+      return null;
+    }
+    const coffeeAttributes: Record<string, unknown> = {
+      corrected_text: editedText || scanResult.corrected || scanResult.original,
+    };
+    if (scanResult.structuredMetadata) {
+      coffeeAttributes.structured_metadata = scanResult.structuredMetadata;
+    }
+    return coffeeAttributes;
+  }, [editedText, scanResult]);
 
   const nonCoffeeConfidence = useMemo(() => {
     if (typeof nonCoffeeDetails.confidence !== 'number') {
@@ -436,9 +463,15 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
     try {
       setOverlayText('Generujem recept...');
       setOverlayVisible(true);
+      const tasteProfile = await resolveTasteProfileForRecipe();
+      const coffeeAttributes = buildCoffeeAttributes();
       const recipe = await getBrewRecipe(
         selectedMethod,
-        tastePreference || 'vyvážená'
+        tastePreference || 'vyvážená',
+        {
+          tasteProfile,
+          coffeeAttributes,
+        }
       );
 
       setGeneratedRecipe(recipe);

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -919,9 +919,15 @@ export const suggestBrewingMethods = async (
  */
 export const getBrewRecipe = async (
   method: string,
-  taste: string
+  taste: string,
+  options?: {
+    tasteProfile?: TasteProfileVector | UserTasteProfile | null;
+    coffeeAttributes?: Record<string, unknown> | null;
+  }
 ): Promise<string> => {
   try {
+    const tasteProfilePayload = mapTasteProfilePayload(options?.tasteProfile);
+    const coffeeAttributes = options?.coffeeAttributes ?? null;
     const response = await loggedFetch(`${API_URL}/ocr/brew-recipe`, {
       method: 'POST',
       headers: {
@@ -930,6 +936,8 @@ export const getBrewRecipe = async (
       body: JSON.stringify({
         method,
         taste,
+        ...(tasteProfilePayload ? { taste_profile: tasteProfilePayload } : {}),
+        ...(coffeeAttributes ? { coffee_attributes: coffeeAttributes } : {}),
       }),
     });
     const data = await response.json();


### PR DESCRIPTION
### Motivation
- Enrich brew recipe generation with user taste profile and structured coffee attributes so AI can produce more personalized recipes.
- Surface preference snapshot or stored profile from personalization and structured metadata from OCR scans into the recipe request flow.
- Incorporate taste and coffee summaries on the backend prompt to ground the AI output in both user and coffee context.
- Maintain backward compatibility when either field is missing so existing behavior stays unchanged.

### Description
- Frontend: extended `getBrewRecipe` in `src/services/ocrServices.ts` to accept an `options` object with `tasteProfile` and `coffeeAttributes`, map the taste profile payload, and include these fields in the POST body to `/ocr/brew-recipe` when present.
- Frontend: updated `src/screens/CoffeeReceipeScanner/index.tsx` to resolve a taste profile (from `usePersonalization().profile` or `preferenceEngine.getProfile()`), build a `coffeeAttributes` payload from the current scan (corrected text + structured metadata), and pass both to `getBrewRecipe` when generating a recipe.
- Backend: updated `server/routes/ocr.js` `/api/ocr/brew-recipe` handler to accept `taste_profile` and `coffee_attributes`, added helper formatters (`resolveTasteVector`, `formatTasteProfileSummary`, `formatCoffeeAttributesSummary`) and composed the OpenAI prompt to include user taste and coffee summaries when provided.
- Backwards compatibility: request handlers and prompt construction guard against missing fields and fall back to previous prompt/content when `taste_profile` or `coffee_attributes` are absent.

### Testing
- No automated tests were executed as part of this change.
- Code changes were committed and the modified files are `src/services/ocrServices.ts`, `src/screens/CoffeeReceipeScanner/index.tsx`, and `server/routes/ocr.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624a6fc104832a9e94c215719283ac)