### PR TITLE
Persist AI raw response for taste profiles (DB + backend + FE)

### DIFF
--- a/db/migrations/schema/13_add_ai_raw_response.sql
+++ b/db/migrations/schema/13_add_ai_raw_response.sql
@@ -1,0 +1,63 @@
+-- Add raw AI response storage to taste profiles and refresh completion view.
+DO $$ BEGIN
+  IF to_regclass('public.user_taste_profiles') IS NOT NULL THEN
+    ALTER TABLE public.user_taste_profiles
+      ADD COLUMN IF NOT EXISTS ai_raw_response jsonb;
+
+    EXECUTE $view$
+      DROP VIEW IF EXISTS public.user_taste_profiles_with_completion;
+      CREATE VIEW public.user_taste_profiles_with_completion AS
+      SELECT
+        utp.user_id,
+        utp.sweetness,
+        utp.acidity,
+        utp.bitterness,
+        utp.body,
+        utp.flavor_notes,
+        utp.milk_preferences,
+        utp.caffeine_sensitivity,
+        utp.preferred_strength,
+        utp.seasonal_adjustments,
+        utp.preference_confidence,
+        utp.quiz_version,
+        utp.quiz_answers,
+        utp.taste_vector,
+        utp.consistency_score,
+        utp.ai_recommendation,
+        utp.manual_input,
+        utp.ai_raw_response,
+        utp.last_recalculated_at,
+        utp.created_at,
+        utp.updated_at,
+        (
+          COALESCE(utp.is_complete, false)
+          OR
+          (
+            (
+              utp.quiz_answers IS NOT NULL
+              AND jsonb_typeof(utp.quiz_answers) = 'object'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_object_keys(utp.quiz_answers)
+                LIMIT 1
+              )
+            )
+            OR
+            (
+              utp.taste_vector IS NOT NULL
+              AND jsonb_typeof(utp.taste_vector) = 'object'
+              AND jsonb_typeof(utp.taste_vector->'sweetness') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'acidity') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'bitterness') = 'number'
+              AND jsonb_typeof(utp.taste_vector->'body') = 'number'
+              AND (utp.taste_vector->>'sweetness')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'acidity')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'bitterness')::numeric BETWEEN 0 AND 10
+              AND (utp.taste_vector->>'body')::numeric BETWEEN 0 AND 10
+            )
+          )
+        ) AS is_complete
+      FROM public.user_taste_profiles utp
+    $view$;
+  END IF;
+END $$;

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -238,6 +238,7 @@ const serializeTasteProfile = (taste) => {
       acidity: Number(taste.acidity),
       bitterness: Number(taste.bitterness),
       body: Number(taste.body),
+      ai_raw_response: taste.ai_raw_response ?? null,
       flavor_notes: taste.flavor_notes,
       milk_preferences: taste.milk_preferences,
       caffeine_sensitivity: taste.caffeine_sensitivity,
@@ -648,6 +649,8 @@ router.put('/api/profile', async (req, res) => {
       [uid]
     );
     const existing = existingResult.rows[0] ?? null;
+    const resolvedAiRawResponse =
+      prefs.ai_raw_response ?? req.body?.ai_raw_response ?? existing?.ai_raw_response ?? null;
     const flavorNotes = flavor_notes ?? prefs.flavor_notes ?? existing?.flavor_notes ?? {};
     const milkPrefs = milk_preferences ?? prefs.milk_preferences ?? existing?.milk_preferences ?? {};
 
@@ -761,9 +764,10 @@ router.put('/api/profile', async (req, res) => {
         consistency_score,
         ai_recommendation,
         manual_input,
+        ai_raw_response,
         last_recalculated_at,
         updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,'medium'),COALESCE($9,'balanced'),'[]',$10,$11,$12,$13,$14,$15,$16,$17,now(),now())
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,'medium'),COALESCE($9,'balanced'),'[]',$10,$11,$12,$13,$14,$15,$16,$17,$18,now(),now())
       ON CONFLICT (user_id) DO UPDATE SET
         sweetness = EXCLUDED.sweetness,
         acidity = EXCLUDED.acidity,
@@ -781,6 +785,7 @@ router.put('/api/profile', async (req, res) => {
         consistency_score = EXCLUDED.consistency_score,
         ai_recommendation = EXCLUDED.ai_recommendation,
         manual_input = EXCLUDED.manual_input,
+        ai_raw_response = EXCLUDED.ai_raw_response,
         last_recalculated_at = now(),
         updated_at = now()`,
       [
@@ -801,6 +806,7 @@ router.put('/api/profile', async (req, res) => {
         resolvedConsistencyScore,
         resolvedAiRecommendation,
         resolvedManualInput,
+        resolvedAiRawResponse,
       ]
     );
 

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -336,7 +336,12 @@ const CoffeePreferenceForm = ({
     quizAnswers: Record<string, string>,
     variant: 'concise' | 'deep',
     priorProfile: typeof previousProfile,
-  ): Promise<{ tasteVector: TasteVector; confidence: number; profileText: string }> => {
+  ): Promise<{
+    tasteVector: TasteVector;
+    confidence: number;
+    profileText: string;
+    aiRawResponse: string | null;
+  }> => {
     const fallbackResponse = buildFallbackAIResponse(fallbackVector);
 
     try {
@@ -468,6 +473,11 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
         console.warn('⚠️  AI response validation warnings:', warnings);
       }
 
+      const canStoreRawResponse =
+        typeof aiResponse === 'string' &&
+        aiResponse.trim().length > 0 &&
+        !warnings.includes('AI response JSON parse failed');
+
       const tasteVector = normalizeTasteVectorTo10(parsedResponse.taste_vector);
       const confidence = parsedResponse.confidence;
       const profileText = buildRecommendationText(parsedResponse);
@@ -476,6 +486,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
         tasteVector,
         confidence,
         profileText,
+        aiRawResponse: canStoreRawResponse ? aiResponse : null,
       };
     } catch (err) {
       console.error('AI error:', err);
@@ -483,6 +494,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
         tasteVector: normalizeTasteVectorTo10(fallbackResponse.taste_vector),
         confidence: fallbackResponse.confidence,
         profileText: buildRecommendationText(fallbackResponse),
+        aiRawResponse: null,
       };
     }
   };
@@ -500,7 +512,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
     setIsLoading(true);
     const fallbackTasteVector = calculateTasteVector(answers);
 
-    const { tasteVector, confidence, profileText } = await generateAIRecommendation(
+    const { tasteVector, confidence, profileText, aiRawResponse } = await generateAIRecommendation(
       fallbackTasteVector,
       answers,
       responseVariant,
@@ -514,6 +526,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
       taste_vector: mapTasteVectorForStorage(tasteVector),
       consistency_score: confidence,
       ai_confidence: confidence,
+      ai_raw_response: aiRawResponse,
     };
 
     try {


### PR DESCRIPTION
### Motivation
- Capture and persist the original AI JSON response for taste profiles to aid debugging and analytics. 
- Ensure the raw AI response is stored alongside existing profile fields and survives partial updates. 
- Allow the frontend to send the original AI response string to the backend for inspection and future analysis. 

### Description
- Added a migration `db/migrations/schema/13_add_ai_raw_response.sql` to add `ai_raw_response jsonb` to `user_taste_profiles` and refresh the `user_taste_profiles_with_completion` view. 
- Updated `server/routes/profile.js` to include `ai_raw_response` in `serializeTasteProfile`, to resolve `resolvedAiRawResponse` from `coffee_preferences` or top-level `ai_raw_response`, and to persist it in the `INSERT ... ON CONFLICT` upsert. 
- Updated `src/components/personalization/CoffeePreferenceForm.tsx` to capture the original AI response (`aiRawResponse`) from `generateAIRecommendation`, validate whether it parsed successfully, and include it as `ai_raw_response` inside the `coffee_preferences` payload sent to `PUT /api/profile`. 

### Testing
- No automated tests were run as part of this change. 
- Basic local build/commit operations succeeded (code compiled and changes were committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628a397d8c832a802114d5a8b20cdd)