### PR TITLE
Ensure OCR evaluate requests have auth token

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1160,13 +1160,14 @@ export const processOCR = async (
         Boolean(initialStructuredMetadata) ||
         hasCoffeeTextSignals);
     const shouldEvaluate = isCoffee !== false && hasReadableText;
-    if (shouldPersistScan) {
+    if (shouldEvaluate || shouldPersistScan) {
       await ensureOnline();
       token = await getAuthToken();
       if (!token) {
         throw new Error('Nie si prihlásený');
       }
-
+    }
+    if (shouldPersistScan) {
       const savePayload: Record<string, unknown> = {
         original_text: originalText,
         corrected_text: trimmedCorrectedText,
@@ -1306,11 +1307,6 @@ export const processOCR = async (
         }
       }
     }
-    if (shouldEvaluate && !token) {
-      await ensureOnline();
-      token = await getAuthToken();
-    }
-
     const fallbackEvaluation: CoffeeEvaluationResult = {
       status: 'unknown',
       verdict: null,


### PR DESCRIPTION
### Motivation
- Ensure the `/api/ocr/evaluate` request always has a valid auth token when a scan will be evaluated (i.e. `isCoffee === true` and `hasReadableText`).
- Centralize token acquisition to avoid redundant `getAuthToken()` calls and duplicate `ensureOnline()` checks.
- Prevent evaluation failures caused by missing authentication and make network readiness checks consistent.

### Description
- Pre-fetch `token` and call `ensureOnline()` when `shouldEvaluate || shouldPersistScan` before either save or evaluate flows by assigning `token = await getAuthToken()` once.  
- Remove the duplicated token lookup inside the `shouldPersistScan` block and the separate conditional token fetch before evaluation.  
- Preserve existing behavior of sending `Authorization: Bearer ${token}` to `POST ${API_URL}/ocr/evaluate` and `POST ${API_URL}/ocr/save`.

### Testing
- No automated tests were executed for this change.
- All modified code was compiled and committed locally during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628be237c0832aa5d635f2f38dee0b)