### PR TITLE
Expand OCR scan persistence for coffee-related text

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1155,10 +1155,9 @@ export const processOCR = async (
       hasReadableText &&
       (isCoffeeRelatedText(trimmedCorrectedText) || isCoffeeRelatedText(originalText));
     const shouldPersistScan =
-      isCoffee &&
-      (Boolean(detectionLabels?.length) ||
-        Boolean(initialStructuredMetadata) ||
-        hasCoffeeTextSignals);
+      hasCoffeeTextSignals ||
+      (isCoffee &&
+        (Boolean(detectionLabels?.length) || Boolean(initialStructuredMetadata)));
     const shouldEvaluate = isCoffee !== false && hasReadableText;
     if (shouldEvaluate || shouldPersistScan) {
       await ensureOnline();


### PR DESCRIPTION
### Motivation
- Improve data available to backend AI evaluation by persisting more OCR scans when the OCR text itself is clearly coffee-related.
- Ensure scans are saved even if label detection or structured metadata are absent, so `evaluate` has more examples to work with.
- Preserve existing persistence behavior when detection labels or `structured_metadata` are present.

### Description
- Update the `shouldPersistScan` logic in `src/services/ocrServices.ts` to prefer text-based signals when deciding to persist scans.
- The new condition persists when `hasCoffeeTextSignals` is true or when `isCoffee` is true and either detection labels or `initialStructuredMetadata` exist.
- The change relies on existing `isCoffeeRelatedText` and `hasCoffeeTextSignals` checks and does not alter other evaluation flows.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a31e337c832ab7a83b0fafd3b5ae)