### PR TITLE
Set OpenAI temperature to 0 for taste-profile generation (FE + server)

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -379,7 +379,7 @@ router.post('/api/profile/taste-profile', async (req, res) => {
           { role: 'system', content: system_prompt },
           { role: 'user', content: user_prompt },
         ],
-        temperature: typeof temperature === 'number' ? temperature : 0.2,
+        temperature: typeof temperature === 'number' ? temperature : 0,
         response_format: {
           type: 'json_schema',
           json_schema: {

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -463,7 +463,7 @@ Rules for deltas:
 ${TASTE_AI_SCHEMA_PROMPT}`;
 
       console.log('📤 [BE] prefs prompt:', userPrompt);
-      const aiResponse = await callOpenAIJsonSchema(systemPrompt, userPrompt, 0.2);
+      const aiResponse = await callOpenAIJsonSchema(systemPrompt, userPrompt, 0);
 
       const { response: parsedResponse, warnings } = parseTasteAIResponse(
         aiResponse,

--- a/src/components/personalization/EditPreferences.tsx
+++ b/src/components/personalization/EditPreferences.tsx
@@ -160,7 +160,7 @@ Rules for deltas:
 ${TASTE_AI_SCHEMA_PROMPT}`;
 
       console.log('📤 [BE] prompt:', prompt);
-      const aiResponse = await callOpenAIJsonSchema(systemPrompt, prompt, 0.3);
+      const aiResponse = await callOpenAIJsonSchema(systemPrompt, prompt, 0);
 
       // Validate and coerce the structured JSON so invalid output does not break the UI.
       const { response: parsedResponse, warnings } = parseTasteAIResponse(


### PR DESCRIPTION
### Motivation
- Ensure deterministic and consistent AI-generated taste profiles by removing sampling randomness from personalization flows.
- Reduce variability between requests when generating `taste_vector` and `ai_recommendation` outputs.
- Make frontend and server behavior aligned so client-side defaults match server defaults.

### Description
- Set the `temperature` argument to `0` for `callOpenAIJsonSchema` calls in `src/components/personalization/CoffeePreferenceForm.tsx` and `src/components/personalization/EditPreferences.tsx`.
- Default the server-side temperature to `0` in `server/routes/profile.js` when no explicit `temperature` is provided in the request body.
- Kept existing validation for an explicitly provided `temperature` (still must be a number between `0` and `1`).

### Testing
- No automated tests were run for this change.
- Manual compilation or runtime checks were not recorded as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a3e61e6c832a94c852c0e2f13b0c)