### PR TITLE
Generate TASTE_AI_SCHEMA_PROMPT from shared schema

### DIFF
--- a/src/components/personalization/tasteAiUtils.ts
+++ b/src/components/personalization/tasteAiUtils.ts
@@ -258,24 +258,10 @@ export const TASTE_AI_RESPONSE_SCHEMA = {
   },
 };
 
-export const TASTE_AI_SCHEMA_PROMPT = `JSON schema (all fields required):
-{
-  "ai_recommendation": "string",
-  "taste_vector": {
-    "acidity": 0-1,
-    "bitterness": 0-1,
-    "sweetness": 0-1,
-    "body": 0-1,
-    "intensity": 0-1,
-    "experimentalism": 0-1
-  },
-  "confidence": 0-1,
-  "explanations": ["string", ...],
-  "next_steps": ["string", ...],
-  "deltas": ["string", ...]
-}
+const formatSchemaPrompt = (schema: unknown) =>
+  `JSON schema (all fields required):\n${JSON.stringify(schema, null, 2)}\n\nReturn JSON only.`;
 
-Return JSON only.`;
+export const TASTE_AI_SCHEMA_PROMPT = formatSchemaPrompt(TASTE_AI_RESPONSE_SCHEMA.schema);
 
 export const callOpenAIJsonSchema = async (
   systemPrompt: string,


### PR DESCRIPTION
### Motivation
- Prevent drift between the FE prompt and the canonical response schema by deriving the prompt from the schema object.
- Remove the duplicated hard-coded `TASTE_AI_SCHEMA_PROMPT` text block in the frontend.
- Make the schema the single source of truth so prompt fields always reflect `TASTE_AI_RESPONSE_SCHEMA`.

### Description
- Replaced the inline string `TASTE_AI_SCHEMA_PROMPT` with a `formatSchemaPrompt` helper that `JSON.stringify`s the schema. 
- `TASTE_AI_SCHEMA_PROMPT` is now exported as `formatSchemaPrompt(TASTE_AI_RESPONSE_SCHEMA.schema)` in `src/components/personalization/tasteAiUtils.ts`.
- This centralizes the prompt generation so the FE prompt is generated from the same `TASTE_AI_RESPONSE_SCHEMA` used for validation.

### Testing
- No automated tests were run for this change.
- Manual verification consisted of checking the generated prompt string within `tasteAiUtils.ts` during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a6856b3c832a94d6222f3fda6e86)