### PR TITLE
Handle roast/processing-only coffee data in OCR evaluation prompt

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1392,6 +1392,10 @@ PRAVIDLÁ:
 - Ak chýba alebo je neúplný chuťový profil → status="profile_missing", verdict=null.
 - Ak chýbajú kľúčové atribúty kávy → status="insufficient_coffee_data", verdict=null.
 - Ak sú dáta dostatočné → status="ok" a verdict je "suitable" | "not_suitable" | "uncertain".
+- Ak sú k dispozícii len roast_level a/alebo processing (bez pôvodu, odrôd, chuťových tónov),
+  zhrň len všeobecný charakter (napr. vyššia acidita pri light/omni roaste),
+  nezadávaj konkrétne chuťové tóny, explicitne priznaj neistotu a nastav nižší confidence.
+- V prípade obmedzených údajov vždy uveď v coffee_profile_summary alebo disclaimer, že hodnotenie je orientačné.
 - Každé pole verdict_explanation musí byť presne jedna veta v tomto formáte:
   - user_preferences_summary začína "Tvoje preferencie:" a stručne zhrnie chuťový profil.
   - coffee_profile_summary začína "Profil kávy:" a stručne zhrnie profil kávy.


### PR DESCRIPTION
### Motivation
- Allow the AI evaluation to still provide useful guidance when only `roast_level` and/or `processing` are available while avoiding overconfident guesses.
- Prevent the model from inventing specific flavor notes when only coarse roast/processing signals exist.
- Make the AI explicitly mark uncertainty and lower the reported `confidence` in limited-data cases.
- Ensure the UI can surface a clear limited-data message from the evaluation (`coffee_profile_summary` or `disclaimer`).

### Description
- Updated the user/system prompts used by the `/api/ocr/evaluate` handler in `server/routes/ocr.js` to add rules for roast/processing-only inputs. 
- New prompt rules instruct the model to summarize only general character (e.g., higher acidity for light roasts), avoid listing specific tasting notes, explicitly admit uncertainty, and lower `confidence` when data are limited. 
- Added requirement that limited-data notices appear in `coffee_profile_summary` or `disclaimer` so the front-end can show the appropriate UI copy. 
- Kept the strict JSON schema and fallback behavior intact so malformed or non-`ok` AI responses still trigger deterministic fallbacks.

### Testing
- No automated tests were executed as part of this change.
- Existing automated test suites were not modified by this PR and were not run here.
- Runtime behavior relies on the updated prompt sent to the AI; validation still uses the existing strict JSON validation logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b9cd8f6c832a95cfef13dc0e1be3)