### PR TITLE
Include scan taste_profile and coffee_attributes in brew recipe request

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -974,11 +974,18 @@ router.post('/api/ocr/brew-recipe', async (req, res) => {
 
   const tasteProfileSummary = formatTasteProfileSummary(tasteProfile);
   const coffeeSummary = formatCoffeeAttributesSummary(coffeeAttributes);
+  const correctedText =
+    typeof coffeeAttributes?.corrected_text === 'string'
+      ? coffeeAttributes.corrected_text.trim()
+      : '';
+  const correctedTextSnippet =
+    correctedText.length > 0 ? correctedText.slice(0, 600) : '';
   const promptSections = [
     `Priprav detailný recept na kávu pomocou metódy ${method}.`,
     `Používateľ preferuje ${taste || 'vyvážená'} chuť.`,
     tasteProfileSummary ? `Chuťový profil používateľa: ${tasteProfileSummary}.` : null,
     coffeeSummary ? `Profil kávy: ${coffeeSummary}.` : null,
+    correctedTextSnippet ? `Text z etikety: "${correctedTextSnippet}".` : null,
     'Uveď ideálny pomer kávy k vode, teplotu vody a ďalšie dôležité kroky. Odpovedz stručne.',
   ].filter(Boolean);
   const prompt = promptSections.join(' ');

--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -211,11 +211,19 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
     if (!scanResult) {
       return null;
     }
+    const structuredMetadata = scanResult.structuredMetadata ?? null;
     const coffeeAttributes: Record<string, unknown> = {
       corrected_text: editedText || scanResult.corrected || scanResult.original,
     };
-    if (scanResult.structuredMetadata) {
-      coffeeAttributes.structured_metadata = scanResult.structuredMetadata;
+    if (structuredMetadata) {
+      coffeeAttributes.structured_metadata = structuredMetadata;
+      coffeeAttributes.origin = structuredMetadata.origin ?? null;
+      coffeeAttributes.roast_level = structuredMetadata.roastLevel ?? null;
+      coffeeAttributes.processing = structuredMetadata.processing ?? null;
+      coffeeAttributes.flavor_notes = structuredMetadata.flavorNotes ?? null;
+      coffeeAttributes.varietals = structuredMetadata.varietals ?? null;
+      coffeeAttributes.roast_date = structuredMetadata.roastDate ?? null;
+      coffeeAttributes.roaster = structuredMetadata.roaster ?? null;
     }
     return coffeeAttributes;
   }, [editedText, scanResult]);

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -928,17 +928,22 @@ export const getBrewRecipe = async (
   try {
     const tasteProfilePayload = mapTasteProfilePayload(options?.tasteProfile);
     const coffeeAttributes = options?.coffeeAttributes ?? null;
+    const payload: Record<string, unknown> = {
+      method,
+      taste,
+    };
+    if (tasteProfilePayload) {
+      payload.taste_profile = tasteProfilePayload;
+    }
+    if (coffeeAttributes) {
+      payload.coffee_attributes = coffeeAttributes;
+    }
     const response = await loggedFetch(`${API_URL}/ocr/brew-recipe`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        method,
-        taste,
-        ...(tasteProfilePayload ? { taste_profile: tasteProfilePayload } : {}),
-        ...(coffeeAttributes ? { coffee_attributes: coffeeAttributes } : {}),
-      }),
+      body: JSON.stringify(payload),
     });
     const data = await response.json();
     console.log('📥 [BE] Brew recipe response:', data);


### PR DESCRIPTION
### Motivation
- Enrich AI-generated brew recipes with context from the latest OCR scan by sending the user's `taste_profile` and parsed `coffee_attributes` so recipes better reflect the coffee and user preferences.
- Provide the backend a short snippet of the corrected scan text to ground the recipe prompt when available.
- Maintain backward compatibility when the new fields are missing or incomplete so existing flows are unaffected.

### Description
- Update `buildCoffeeAttributes` in `src/screens/CoffeeReceipeScanner/index.tsx` to include `structured_metadata` and map its fields into `origin`, `roast_level`, `processing`, `flavor_notes`, `varietals`, `roast_date`, and `roaster` when present.
- Modify `getBrewRecipe` in `src/services/ocrServices.ts` to build a consolidated `payload` containing `method`, `taste`, and optional `taste_profile` and `coffee_attributes` before POSTing to the server.
- Extend the server handler `POST /api/ocr/brew-recipe` in `server/routes/ocr.js` to safely read `coffee_attributes.corrected_text`, include a truncated `Text z etikety` snippet in the OpenAI prompt, and continue using existing `taste_profile` / `coffee_attributes` summaries while guarding against missing data.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962bccd1530832a93eabd4782a15315)