### PR TITLE
Normalize OCR payload keys to snake_case

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1374,6 +1374,7 @@ router.post('/api/ocr/evaluate', async (req, res) => {
     // inside `coffee_attributes.corrected_text` for downstream normalization.
     // Accept structured metadata from the FE (or any upstream source) to ground the explanation.
     const structured = structured_metadata || structuredMetadata || {};
+    const structuredRecord = structured && typeof structured === 'object' ? structured : {};
     coffeeAttributes =
       coffee_attributes && typeof coffee_attributes === 'object'
         ? coffee_attributes
@@ -1383,27 +1384,34 @@ router.post('/api/ocr/evaluate', async (req, res) => {
           };
 
     const derivedAttributes = extractCoffeeAttributesFromText(corrected_text);
-    const mergedStructuredMetadata = {
-      ...structured,
+    // Expected format: snake_case keys (camelCase accepted only as a fallback).
+    const normalizedStructured = {
       brand:
-        structured.brand ??
-        structured.roaster ??
-        structured.roaster_name ??
-        structured.roastery ??
-        derivedAttributes.brand,
+        structuredRecord.brand ??
+        structuredRecord.roaster ??
+        structuredRecord.roaster_name ??
+        structuredRecord.roastery ??
+        null,
       roaster:
-        structured.roaster ??
-        structured.roaster_name ??
-        structured.roastery ??
-        structured.brand ??
-        derivedAttributes.brand,
-      origin: structured.origin ?? derivedAttributes.origin,
-      roast_level: structured.roast_level ?? derivedAttributes.roast_level,
-      roastLevel: structured.roastLevel ?? derivedAttributes.roast_level,
-      flavor_notes: structured.flavor_notes ?? derivedAttributes.flavor_notes,
-      flavorNotes: structured.flavorNotes ?? derivedAttributes.flavor_notes,
-      processing: structured.processing ?? derivedAttributes.processing,
-      varietals: structured.varietals ?? derivedAttributes.varietals,
+        structuredRecord.roaster ??
+        structuredRecord.roaster_name ??
+        structuredRecord.roastery ??
+        structuredRecord.brand ??
+        null,
+      origin: structuredRecord.origin ?? null,
+      roast_level: structuredRecord.roast_level ?? structuredRecord.roastLevel ?? null,
+      flavor_notes: structuredRecord.flavor_notes ?? structuredRecord.flavorNotes ?? null,
+      processing: structuredRecord.processing ?? null,
+      varietals: structuredRecord.varietals ?? null,
+    };
+    const mergedStructuredMetadata = {
+      brand: normalizedStructured.brand ?? derivedAttributes.brand,
+      roaster: normalizedStructured.roaster ?? derivedAttributes.brand,
+      origin: normalizedStructured.origin ?? derivedAttributes.origin,
+      roast_level: normalizedStructured.roast_level ?? derivedAttributes.roast_level,
+      flavor_notes: normalizedStructured.flavor_notes ?? derivedAttributes.flavor_notes,
+      processing: normalizedStructured.processing ?? derivedAttributes.processing,
+      varietals: normalizedStructured.varietals ?? derivedAttributes.varietals,
     };
     coffeeAttributes = {
       ...coffeeAttributes,
@@ -1428,13 +1436,11 @@ router.post('/api/ocr/evaluate', async (req, res) => {
         coffeeAttributes.roast_level ??
         coffeeAttributes.roastLevel ??
         mergedStructuredMetadata.roast_level ??
-        mergedStructuredMetadata.roastLevel ??
         derivedAttributes.roast_level,
       flavor_notes:
         coffeeAttributes.flavor_notes ??
         coffeeAttributes.flavorNotes ??
         mergedStructuredMetadata.flavor_notes ??
-        mergedStructuredMetadata.flavorNotes ??
         derivedAttributes.flavor_notes,
       processing:
         coffeeAttributes.processing ??

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -146,6 +146,27 @@ const safeParseJSON = <T>(value: unknown): T | null => {
   }
 };
 
+const toSnakeCaseKey = (key: string): string =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
+
+const normalizeKeysToSnakeCase = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeKeysToSnakeCase(item));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  return Object.keys(record).reduce<Record<string, unknown>>((acc, key) => {
+    acc[toSnakeCaseKey(key)] = normalizeKeysToSnakeCase(record[key]);
+    return acc;
+  }, {});
+};
+
 const normalizeEvaluationStatus = (value: unknown): CoffeeEvaluationStatus => {
   if (value === 'ok' || value === 'profile_missing' || value === 'insufficient_coffee_data') {
     return value;
@@ -852,7 +873,7 @@ const fixTextWithAI = async (ocrText: string): Promise<string> => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ text: ocrText }),
+      body: JSON.stringify(normalizeKeysToSnakeCase({ text: ocrText })),
     });
 
     const data = await response.json();
@@ -885,7 +906,7 @@ export const suggestBrewingMethods = async (
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ text: coffeeText }),
+      body: JSON.stringify(normalizeKeysToSnakeCase({ text: coffeeText })),
     });
     const data = await response.json();
     console.log('📥 [BE] Brewing methods response:', data);
@@ -943,7 +964,7 @@ export const getBrewRecipe = async (
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(normalizeKeysToSnakeCase(payload)),
     });
     const data = await response.json();
     console.log('📥 [BE] Brew recipe response:', data);
@@ -1086,7 +1107,7 @@ export const processOCR = async (
     const ocrResponse = await loggedFetch(`${API_HOST}/ocr`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ base64image }),
+      body: JSON.stringify(normalizeKeysToSnakeCase({ base64image })),
     });
 
     if (!ocrResponse.ok) {
@@ -1189,7 +1210,8 @@ export const processOCR = async (
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(savePayload),
+        // Expect snake_case keys for OCR payloads (manual QA: verify request body format).
+        body: JSON.stringify(normalizeKeysToSnakeCase(savePayload)),
       });
 
       if (saveResponse.ok) {
@@ -1426,7 +1448,7 @@ export const processOCR = async (
                     'Content-Type': 'application/json',
                   },
                   // Send structured metadata to help the backend ground the evaluation in actual coffee attributes.
-                  body: JSON.stringify(payload),
+                  body: JSON.stringify(normalizeKeysToSnakeCase(payload)),
                 },
               );
 
@@ -1443,7 +1465,7 @@ export const processOCR = async (
                       Authorization: `Bearer ${token}`,
                       'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify(retryPayload),
+                    body: JSON.stringify(normalizeKeysToSnakeCase(retryPayload)),
                   },
                 );
                 if (retryResult.response) {
@@ -1701,7 +1723,7 @@ export const markCoffeePurchased = async (
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(normalizeKeysToSnakeCase(body)),
   });
 };
 
@@ -1729,7 +1751,7 @@ export const confirmStructuredScan = async (
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(payload ?? {}),
+      body: JSON.stringify(normalizeKeysToSnakeCase(payload ?? {})),
     }
   );
 
@@ -1783,10 +1805,12 @@ export const rateOCRResult = async (scanId: string, rating: number): Promise<boo
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        coffee_id: scanId,
-        rating: rating,
-      }),
+      body: JSON.stringify(
+        normalizeKeysToSnakeCase({
+          coffee_id: scanId,
+          rating: rating,
+        })
+      ),
     });
 
     console.log('📥 [BE] Rate status:', response.status);


### PR DESCRIPTION
### Motivation
- Ensure the frontend sends OCR-related payloads in a single, predictable naming convention to avoid backend normalization bugs and ambiguity.
- Prefer `snake_case` as the canonical format for OCR structured metadata while still accepting legacy `camelCase` as a fallback on the server.
- Reduce duplication/fragility by normalizing nested keys recursively before any `JSON.stringify` outbound call.
- Add an in-code note documenting the expected payload format for manual QA and future maintenance.

### Description
- Added `toSnakeCaseKey` and `normalizeKeysToSnakeCase` helpers to `src/services/ocrServices.ts` to recursively convert object and array keys to `snake_case`.
- Applied `normalizeKeysToSnakeCase(...)` to all outgoing OCR-related requests in `src/services/ocrServices.ts` including `fix-text`, `brewing-methods`, `brew-recipe`, `processOCR`/Google Vision, `/ocr/save`, `/ocr/evaluate` (and retry), `/ocr/purchase`, `/ocr/structured/confirm`, and rating payloads.
- Updated `server/routes/ocr.js` merge logic to prefer snake_case keys when deriving `mergedStructuredMetadata` by normalizing the incoming structured record and treating camelCase keys as a fallback.
- Added small comments in both client and server code indicating that `snake_case` is expected for OCR payloads and that camelCase is accepted only as a fallback.

### Testing
- No automated tests were executed as part of this change.
- Changes were limited to payload normalization and server-side merge behavior and validated via static code inspection and local commits.
- Further verification should include running the app and exercising OCR flows and existing backend tests in CI to ensure no regressions occur.
- Recommend adding unit tests for `normalizeKeysToSnakeCase` and integration tests for OCR endpoints in a follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962be0293d0832ab4eef44fa1c0625d)