### PR TITLE
Add `ai_raw_response` column to core `user_taste_profiles` schema

### DIFF
--- a/db/migrations/schema/02_create_tables_core.sql
+++ b/db/migrations/schema/02_create_tables_core.sql
@@ -44,6 +44,7 @@ CREATE TABLE public.user_taste_profiles (
   consistency_score numeric(4,3) NOT NULL DEFAULT 1,
   ai_recommendation text,
   manual_input text,
+  ai_raw_response jsonb,
   last_recalculated_at timestamptz NOT NULL DEFAULT now(),
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()


### PR DESCRIPTION
### Motivation
- Ensure fresh database schema includes storage for raw AI responses used for debugging and analytics. 
- The server code already reads/writes `ai_raw_response` in profile endpoints, but the base schema lacked the column for new installs. 

### Description
- Added `ai_raw_response jsonb` to `db/migrations/schema/02_create_tables_core.sql` so new databases create the column by default. 
- No changes were required in `server/routes/profile.js` because `serializeTasteProfile` and the `PUT /api/profile` logic already map `ai_raw_response` to/from the DB. 

### Testing
- This is a schema-only change and no automated tests were executed. 
- No runtime test failures were observed during the edit and validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962bee4c438832aade9f020e15d1e1d)