### PR TITLE
Persist long coffee-related text-only OCR scans and add `scan_quality` flag

### DIFF
--- a/db/migrations/schema/14_add_scan_event_scan_quality.sql
+++ b/db/migrations/schema/14_add_scan_event_scan_quality.sql
@@ -1,0 +1,3 @@
+-- Add scan quality flag for OCR scan events.
+ALTER TABLE public.scan_events
+  ADD COLUMN IF NOT EXISTS scan_quality text;

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1102,6 +1102,24 @@ router.post('/api/ocr/save', async (req, res) => {
     const normalizeJsonField = (value) =>
       value === undefined || value === null ? null : JSON.stringify(value);
 
+    const normalizedOriginInput = normalizeTextField(origin);
+    const normalizedRoastLevelInput = normalizeTextField(roast_level);
+    const normalizedFlavorNotesInput = normalizeArrayField(flavor_notes);
+    const normalizedProcessingInput = normalizeTextField(processing);
+    const normalizedRoastDateInput = normalizeTextField(roast_date);
+    const normalizedVarietalsInput = normalizeArrayField(varietals);
+    const normalizedThumbnailInput = normalizeTextField(thumbnail_url);
+    const hasStructuredMetadataInput = structured && Object.keys(structured).length > 0;
+    const isTextOnlyScan =
+      !hasStructuredMetadataInput &&
+      !normalizedOriginInput &&
+      !normalizedRoastLevelInput &&
+      !normalizedFlavorNotesInput &&
+      !normalizedProcessingInput &&
+      !normalizedRoastDateInput &&
+      !normalizedVarietalsInput &&
+      !normalizedThumbnailInput;
+
     const prefResult = await db.query(
       `SELECT * FROM user_taste_profiles_with_completion WHERE user_id = $1 LIMIT 1`,
       [uid]
@@ -1118,22 +1136,25 @@ router.post('/api/ocr/save', async (req, res) => {
     const coffeeName = extractCoffeeName(corrected_text || original_text);
 
     const resolvedOrigin = normalizeTextField(
-      origin ?? structured.origin ?? derivedAttributes.origin
+      normalizedOriginInput ?? structured.origin ?? derivedAttributes.origin
     );
     const resolvedRoastLevel = normalizeTextField(
-      roast_level ?? structured.roast_level ?? structured.roastLevel ?? derivedAttributes.roast_level
+      normalizedRoastLevelInput ??
+        structured.roast_level ??
+        structured.roastLevel ??
+        derivedAttributes.roast_level
     );
     const resolvedFlavorNotes = normalizeJsonField(
-      flavor_notes ??
+      normalizedFlavorNotesInput ??
         structured.flavor_notes ??
         structured.flavorNotes ??
         derivedAttributes.flavor_notes
     );
     const resolvedProcessing = normalizeTextField(
-      processing ?? structured.processing ?? derivedAttributes.processing
+      normalizedProcessingInput ?? structured.processing ?? derivedAttributes.processing
     );
     const resolvedVarietals = normalizeJsonField(
-      varietals ?? structured.varietals ?? derivedAttributes.varietals
+      normalizedVarietalsInput ?? structured.varietals ?? derivedAttributes.varietals
     );
 
     const result = await db.query(
@@ -1154,6 +1175,7 @@ router.post('/api/ocr/save', async (req, res) => {
         thumbnail_url,
         structured_confidence,
         structured_uncertainty,
+        scan_quality,
         match_score,
         is_recommended,
         detected_at,
@@ -1178,6 +1200,7 @@ router.post('/api/ocr/save', async (req, res) => {
         $13::jsonb,
         $14,
         $15,
+        $16,
         now(),
         now()
       )
@@ -1191,11 +1214,16 @@ router.post('/api/ocr/save', async (req, res) => {
         resolvedRoastLevel,
         resolvedFlavorNotes,
         resolvedProcessing,
-        normalizeTextField(roast_date ?? structured.roast_date ?? structured.roastDate),
+        normalizeTextField(
+          normalizedRoastDateInput ?? structured.roast_date ?? structured.roastDate
+        ),
         resolvedVarietals,
-        normalizeTextField(thumbnail_url ?? structured.thumbnail_url ?? structured.thumbnailUrl),
+        normalizeTextField(
+          normalizedThumbnailInput ?? structured.thumbnail_url ?? structured.thumbnailUrl
+        ),
         normalizeJsonField(confidenceFlags),
         normalizeJsonField(uncertaintyFlags),
+        isTextOnlyScan ? 'text_only' : null,
         matchPercentage,
         isRecommended,
       ]

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1180,8 +1180,15 @@ export const processOCR = async (
     const hasCoffeeTextSignals =
       hasReadableText &&
       (isCoffeeRelatedText(trimmedCorrectedText) || isCoffeeRelatedText(originalText));
+    const minTextOnlyLength = 40;
+    const hasTextOnlyCoffeeSignal =
+      !detectionLabels?.length &&
+      !initialStructuredMetadata &&
+      trimmedCorrectedText.length >= minTextOnlyLength &&
+      isCoffeeRelatedText(trimmedCorrectedText);
     const shouldPersistScan =
       hasCoffeeTextSignals ||
+      hasTextOnlyCoffeeSignal ||
       (isCoffee &&
         (Boolean(detectionLabels?.length) || Boolean(initialStructuredMetadata)));
     const shouldEvaluate = isCoffee !== false && hasReadableText;


### PR DESCRIPTION
### Motivation
- Allow OCR scans to be saved even when detection `labels` or structured metadata are missing if the corrected text is long and coffee-related. 
- Surface these "text-only" scans in the backend so they can be distinguished from scans with structured payloads. 
- Ensure downstream features (history, recommendations) can still use text-only scans for matching and analytics. 

### Description
- Updated `src/services/ocrServices.ts` to introduce a `minTextOnlyLength` (40) and `hasTextOnlyCoffeeSignal` so long, coffee-related corrected text will mark `shouldPersistScan` even when `labels` and `structured_metadata` are absent. 
- Updated `server/routes/ocr.js` to normalize incoming fields, detect `isTextOnlyScan`, and write a new `scan_quality` value (`'text_only'`) when appropriate. 
- Added a migration `db/migrations/schema/14_add_scan_event_scan_quality.sql` to add the `scan_quality` column to the `scan_events` table. 
- Adjusted resolved field selection to prefer normalized direct inputs before falling back to `structured` or derived attributes. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962bf79810c832a9e33ab2314245786)