### PR TITLE
Add taste profile timestamps to OCR flow

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -238,6 +238,8 @@ const serializeTasteProfile = (taste) => {
       acidity: Number(taste.acidity),
       bitterness: Number(taste.bitterness),
       body: Number(taste.body),
+      updated_at: taste.updated_at ?? null,
+      last_recalculated_at: taste.last_recalculated_at ?? null,
       ai_raw_response: taste.ai_raw_response ?? null,
       flavor_notes: taste.flavor_notes,
       milk_preferences: taste.milk_preferences,

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -171,6 +171,10 @@ const extractPreferenceSnapshot = (
   if (!payload) {
     return null;
   }
+  const coffeePreferences =
+    payload.coffee_preferences && typeof payload.coffee_preferences === 'object'
+      ? (payload.coffee_preferences as Record<string, unknown>)
+      : null;
   const aiRecommendation =
     typeof payload.ai_recommendation === 'string' ? payload.ai_recommendation : null;
   const consistencyScore =
@@ -186,12 +190,16 @@ const extractPreferenceSnapshot = (
   const updatedAt =
     typeof payload.updated_at === 'string'
       ? payload.updated_at
+      : typeof coffeePreferences?.updated_at === 'string'
+        ? coffeePreferences.updated_at
       : typeof payload.updatedAt === 'string'
         ? payload.updatedAt
         : null;
   const lastRecalculatedAt =
     typeof payload.last_recalculated_at === 'string'
       ? payload.last_recalculated_at
+      : typeof coffeePreferences?.last_recalculated_at === 'string'
+        ? coffeePreferences.last_recalculated_at
       : typeof payload.lastRecalculatedAt === 'string'
         ? payload.lastRecalculatedAt
         : null;

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -399,10 +399,15 @@ const extractTasteProfileTimestamps = (
   const updatedAt =
     typeof record.updatedAt === 'string' && record.updatedAt.trim().length > 0
       ? record.updatedAt
+      : typeof record.updated_at === 'string' && record.updated_at.trim().length > 0
+        ? record.updated_at
       : null;
   const lastRecalculatedAt =
     typeof record.lastRecalculatedAt === 'string' && record.lastRecalculatedAt.trim().length > 0
       ? record.lastRecalculatedAt
+      : typeof record.last_recalculated_at === 'string'
+        && record.last_recalculated_at.trim().length > 0
+        ? record.last_recalculated_at
       : null;
   return { updatedAt, lastRecalculatedAt };
 };


### PR DESCRIPTION
### Motivation
- Ensure `coffee_preferences` mirrors top-level timestamps so the frontend and OCR path carry the same `updated_at` and `last_recalculated_at` metadata.
- Allow the scanner to read nested preference timestamps when building a preference snapshot for OCR evaluation.
- Let the OCR service detect server-sourced timestamps so `taste_profile_source` remains `"server"` and the backend can validate profile staleness.
- Avoid spurious `409` responses by preserving timestamp metadata through the OCR evaluation flow.

### Description
- Updated `serializeTasteProfile` in `server/routes/profile.js` to include `updated_at` and `last_recalculated_at` inside `coffee_preferences`.
- Updated `extractPreferenceSnapshot` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to read `coffee_preferences.updated_at` and `coffee_preferences.last_recalculated_at` when present.
- Extended `extractTasteProfileTimestamps` in `src/services/ocrServices.ts` to accept snake_case `updated_at` and `last_recalculated_at` when extracting timestamps.
- Preserved existing OCR payload behavior that sets `taste_profile_source: "server"` when timestamps are available and falls back to retry without the profile on `409`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c2d8acdc832a92fbb1d43d172f2e)