### PR TITLE
Add structured uncertainty signals to OCR flow

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1259,9 +1259,14 @@ router.post('/api/ocr/save', async (req, res) => {
       ),
       confidenceFlags:
         confidenceFlags && typeof confidenceFlags === 'object' ? confidenceFlags : null,
+      uncertaintyFlags:
+        uncertaintyFlags && typeof uncertaintyFlags === 'object' ? uncertaintyFlags : null,
     };
     const hasStructuredPayload = Object.entries(storedStructuredMetadata).some(([key, value]) => {
       if (key === 'confidenceFlags') {
+        return value !== null;
+      }
+      if (key === 'uncertaintyFlags') {
         return value !== null;
       }
       if (Array.isArray(value)) {
@@ -1280,6 +1285,11 @@ router.post('/api/ocr/save', async (req, res) => {
         storedStructuredMetadata.confidenceFlags &&
         typeof storedStructuredMetadata.confidenceFlags === 'object'
           ? storedStructuredMetadata.confidenceFlags
+          : null,
+      structured_uncertainty:
+        storedStructuredMetadata.uncertaintyFlags &&
+        typeof storedStructuredMetadata.uncertaintyFlags === 'object'
+          ? storedStructuredMetadata.uncertaintyFlags
           : null,
     });
   } catch (err) {

--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -73,6 +73,7 @@ interface ScanResult {
   detectionLabels?: string[];
   detectionConfidence?: number;
   structuredMetadata?: StructuredCoffeeMetadata | null;
+  structuredUncertainty?: Record<string, unknown> | null;
 }
 
 interface BrewScannerProps {
@@ -259,6 +260,15 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    if (scanResult?.structuredUncertainty) {
+      console.info('CoffeeReceipeScanner: structured uncertainty signals', {
+        scanId: scanResult.scanId,
+        uncertainty: scanResult.structuredUncertainty,
+      });
+    }
+  }, [scanResult]);
 
   const closeNonCoffeeModal = () => {
     setNonCoffeeModalVisible(false);

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -85,6 +85,7 @@ interface ScanResult {
   detectionConfidence?: number;
   structuredMetadata?: StructuredCoffeeMetadata | null;
   structuredConfidence?: Record<string, unknown> | null;
+  structuredUncertainty?: Record<string, unknown> | null;
   structuredRaw?: unknown;
   evaluation?: CoffeeEvaluationResult | null;
   tasteProfileSent?: boolean;
@@ -1077,6 +1078,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         ...result,
         structuredMetadata: result.structuredMetadata ?? null,
         structuredConfidence: result.structuredConfidence ?? null,
+        structuredUncertainty: result.structuredUncertainty ?? null,
         structuredRaw,
         evaluation: result.evaluation ?? null,
       };
@@ -1091,6 +1093,15 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     },
     [],
   );
+
+  useEffect(() => {
+    if (scanResult?.structuredUncertainty) {
+      console.info('CoffeeTasteScanner: structured uncertainty signals', {
+        scanId: scanResult.scanId,
+        uncertainty: scanResult.structuredUncertainty,
+      });
+    }
+  }, [scanResult]);
 
   useEffect(() => {
     if (!hasPermission) {


### PR DESCRIPTION
### Motivation
- Surface per-field uncertainty signals produced during OCR so the frontend can visualize or log model uncertainty alongside confidence.
- Return `structured_uncertainty` from the OCR save endpoint to make uncertainty available to clients the same way `structured_confidence` is returned.
- Propagate uncertainty through the scanner flow so UI components can consume and inspect uncertainty signals for QA and future visualization.

### Description
- Backend: `server/routes/ocr.js` now includes `uncertaintyFlags` in `storedStructuredMetadata` and returns `structured_uncertainty` in the `POST /api/ocr/save` JSON response when present. 
- Frontend: ensured the OCR result shape includes `structuredUncertainty` on `ScanResult` and propagated it when normalizing scan results (added to `CoffeeTasteScanner` normalizer). 
- UI: added console logging of `structuredUncertainty` in `CoffeeTasteScanner.tsx` and `CoffeeReceipeScanner/index.tsx` to surface uncertainty signals for QA. 
- Verified that `src/services/ocrServices.ts` reads `saveData.structured_uncertainty` into the client-side `structuredUncertainty` field so the value is available to the scanners.

### Testing
- No automated tests were executed for this change.
- Changes were limited to adding returned payload fields and logging, and rely on existing OCR save/consume paths for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c3f0ea74832a9a020712d446179e)