### PR TITLE
Unify taste profile source under coffee_preferences

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -227,29 +227,36 @@ const serializeTasteProfile = (taste) => {
     };
   }
 
-  return {
+  // coffee_preferences je jediný zdroj pravdy pre chuťový profil.
+  const coffeePreferences = {
+    sweetness: Number(taste.sweetness),
+    acidity: Number(taste.acidity),
+    bitterness: Number(taste.bitterness),
+    body: Number(taste.body),
+    updated_at: taste.updated_at ?? null,
+    last_recalculated_at: taste.last_recalculated_at ?? null,
+    ai_raw_response: taste.ai_raw_response ?? null,
+    flavor_notes: taste.flavor_notes,
+    milk_preferences: taste.milk_preferences,
+    caffeine_sensitivity: taste.caffeine_sensitivity,
+    preferred_strength: taste.preferred_strength,
+    quiz_version: taste.quiz_version ?? null,
+    quiz_answers: taste.quiz_answers ?? {},
+    consistency_score: taste.consistency_score ?? null,
+    taste_vector: taste.taste_vector ?? null,
     ai_recommendation: taste.ai_recommendation ?? null,
     manual_input: taste.manual_input ?? null,
     is_complete: taste.is_complete ?? false,
-    updated_at: taste.updated_at ?? null,
-    last_recalculated_at: taste.last_recalculated_at ?? null,
-    coffee_preferences: {
-      sweetness: Number(taste.sweetness),
-      acidity: Number(taste.acidity),
-      bitterness: Number(taste.bitterness),
-      body: Number(taste.body),
-      updated_at: taste.updated_at ?? null,
-      last_recalculated_at: taste.last_recalculated_at ?? null,
-      ai_raw_response: taste.ai_raw_response ?? null,
-      flavor_notes: taste.flavor_notes,
-      milk_preferences: taste.milk_preferences,
-      caffeine_sensitivity: taste.caffeine_sensitivity,
-      preferred_strength: taste.preferred_strength,
-      quiz_version: taste.quiz_version ?? null,
-      quiz_answers: taste.quiz_answers ?? {},
-      consistency_score: taste.consistency_score ?? null,
-      taste_vector: taste.taste_vector ?? null,
-    },
+  };
+
+  return {
+    // Legacy top-level fields mirror coffee_preferences for backwards compatibility.
+    ai_recommendation: coffeePreferences.ai_recommendation,
+    manual_input: coffeePreferences.manual_input,
+    is_complete: coffeePreferences.is_complete,
+    updated_at: coffeePreferences.updated_at,
+    last_recalculated_at: coffeePreferences.last_recalculated_at,
+    coffee_preferences: coffeePreferences,
   };
 };
 

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -229,12 +229,10 @@ const CoffeePreferenceForm = ({
         setPreviousProfile({
           quiz_answers: data.coffee_preferences?.quiz_answers,
           taste_vector: normalizedTasteVector,
-          ai_recommendation: data.coffee_preferences?.ai_recommendation ?? data.ai_recommendation,
+          ai_recommendation: data.coffee_preferences?.ai_recommendation,
           consistency_score:
             data.coffee_preferences?.consistency_score ??
-            data.coffee_preferences?.ai_confidence ??
-            data.consistency_score ??
-            data.ai_confidence,
+            data.coffee_preferences?.ai_confidence,
         });
       }
     } catch (err) {
@@ -556,7 +554,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
       setPreviousProfile({
         quiz_answers: updatedProfile?.quiz_answers ?? answers,
         taste_vector: normalizeTasteVectorTo10(updatedTasteVector),
-        ai_recommendation: resData?.ai_recommendation ?? profileText,
+        ai_recommendation: updatedProfile?.ai_recommendation ?? profileText,
         consistency_score: updatedProfile?.consistency_score ?? confidence,
       });
       onPreferencesSaved?.();

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -826,19 +826,8 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   const contextPreferenceSnapshot = useMemo(() => {
     const profileRecord = profile as unknown as {
       coffee_preferences?: Record<string, unknown> | null;
-      ai_recommendation?: string | null;
-      consistency_score?: number | null;
-      ai_confidence?: number | null;
     };
-    const nestedSnapshot = extractPreferenceSnapshot(profileRecord?.coffee_preferences ?? null);
-    if (nestedSnapshot) {
-      return nestedSnapshot;
-    }
-    return extractPreferenceSnapshot({
-      ai_recommendation: profileRecord?.ai_recommendation,
-      consistency_score: profileRecord?.consistency_score,
-      ai_confidence: profileRecord?.ai_confidence,
-    });
+    return extractPreferenceSnapshot(profileRecord?.coffee_preferences ?? null);
   }, [profile]);
 
   const preferenceSnapshotVector = useMemo(
@@ -880,31 +869,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       const data = (await response.json()) as Record<string, unknown> | null;
       const coffeePreferences =
         (data?.coffee_preferences as Record<string, unknown> | null) ?? null;
-      const snapshot = extractPreferenceSnapshot({
-        ...(coffeePreferences ?? {}),
-        ai_recommendation:
-          typeof data?.ai_recommendation === 'string'
-            ? data.ai_recommendation
-            : coffeePreferences?.ai_recommendation,
-        consistency_score:
-          typeof data?.consistency_score === 'number'
-            ? data.consistency_score
-            : typeof data?.ai_confidence === 'number'
-              ? data.ai_confidence
-              : coffeePreferences?.consistency_score ?? coffeePreferences?.ai_confidence,
-        ai_confidence:
-          typeof data?.ai_confidence === 'number'
-            ? data.ai_confidence
-            : coffeePreferences?.ai_confidence,
-        updated_at:
-          typeof data?.updated_at === 'string'
-            ? data.updated_at
-            : coffeePreferences?.updated_at,
-        last_recalculated_at:
-          typeof data?.last_recalculated_at === 'string'
-            ? data.last_recalculated_at
-            : coffeePreferences?.last_recalculated_at,
-      });
+      const snapshot = extractPreferenceSnapshot(coffeePreferences);
       if (snapshot) {
         setPreferenceSnapshot(snapshot);
       }

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -188,10 +188,9 @@ const HomeScreen: React.FC<HomeScreenProps> = ({
       }
 
       const data = await response.json();
-      const normalized = normalizeCoffeePreferenceSnapshot({
-        ...(data?.coffee_preferences ?? {}),
-        taste_vector: data?.taste_vector ?? data?.coffee_preferences?.taste_vector,
-      });
+      const normalized = normalizeCoffeePreferenceSnapshot(
+        data?.coffee_preferences ?? null,
+      );
       setTastePreferenceSnapshot(normalized);
     } catch (error) {
       console.warn('HomeScreen: failed to load taste profile', error);


### PR DESCRIPTION
### Motivation

- Consolidate the taste/profile payload so the frontend uses a single source of truth (`coffee_preferences`) instead of falling back between top-level fields and nested fields.  
- Avoid ambiguity in `taste_vector` deserialization across backend and multiple FE consumers.  
- Keep backwards compatibility by mirroring legacy top-level profile fields while making `coffee_preferences` canonical.  
- Simplify FE logic so components don't need to branch on `data.taste_vector` vs `data.coffee_preferences.taste_vector`.

### Description

- Make `coffee_preferences` the canonical serialized taste profile in `serializeTasteProfile` and mirror legacy top-level fields for compatibility by returning top-level keys that reference `coffee_preferences` values in `server/routes/profile.js`.  
- Simplify `HomeScreen` profile loading to normalize only `data.coffee_preferences` by passing `data?.coffee_preferences ?? null` into `normalizeCoffeePreferenceSnapshot` in `src/screens/HomeScreen/HomeScreen.tsx`.  
- Update `CoffeePreferenceForm` to read recommendation and confidence from `data.coffee_preferences` (prefer `coffee_preferences.ai_recommendation` and `coffee_preferences.consistency_score` / `ai_confidence`) and to persist/load `coffee_preferences` as the single source when saving in `src/components/personalization/CoffeePreferenceForm.tsx`.  
- Update `CoffeeTasteScanner` to extract the preference snapshot exclusively from `coffee_preferences` and simplify snapshot loading logic in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`.

### Testing

- No automated tests were run as part of this change.  
- Manual compile / lint checks were not executed in this rollout.  
- Existing unit tests in the repository were not executed during this change.  
- Recommend running the test suite and TypeScript checks before merging (`yarn test`, `yarn build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c553d644832abd29ba46eef9675f)