### PR TITLE
Align quiz preference scale with 0–10 profile values

### DIFF
--- a/src/services/TasteProfileQuizEngine.ts
+++ b/src/services/TasteProfileQuizEngine.ts
@@ -414,10 +414,10 @@ export class TasteProfileQuizEngine {
 
     const strength = answersById.get('strength-slider');
     if (strength && typeof strength.value === 'number') {
-      const normalized = Number(strength.value) / 10;
+      const strengthValue = Number(strength.value);
       vector.body = Math.min(
-        1,
-        Math.max(0, vector.body * 0.6 + normalized * 0.4),
+        10,
+        Math.max(0, vector.body * 0.6 + strengthValue * 0.4),
       );
     }
 


### PR DESCRIPTION
### Motivation
- Fix inconsistent scaling where `mergeAnswersIntoProfile` converted the strength slider to 0–1 while the stored `TasteProfileVector` uses 0–10.
- Ensure `TasteProfileVector` numeric range is consistent between the quiz engine and `PreferenceLearningEngine` to avoid skewed blending.
- Prevent the previous clamp to `1` from reducing the intended influence of the slider on `body` preference.

### Description
- Updated `src/services/TasteProfileQuizEngine.ts` in `mergeAnswersIntoProfile` to use the raw slider value (`strengthValue`) instead of normalizing to 0–1.
- Replaced the previous `normalized = value / 10` + clamp-to-`1` logic with a direct blend into `vector.body` and clamped to the 0–10 range.
- Inspected usages of `TasteProfileVector` in `PreferenceLearningEngine` and `types/Personalization.ts` and left them unchanged because they already operate on the 0–10 scale.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cc523464832a8bafd21b6073dc08)