### PR TITLE
Normalize taste vector scaling for radar scores

### DIFF
--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -71,7 +71,10 @@ function safeNumber(value: unknown, fallback: number = DEFAULT_SCORE): number {
  * @returns {number|null} Clamped number when valid, otherwise null.
  */
 function parseVectorNumber(value: unknown): number | null {
-  const normalize = (input: number): number => clamp(input);
+  const normalize = (input: number): number => {
+    const scaled = input <= 1 ? input * 10 : input;
+    return clamp(scaled);
+  };
 
   if (typeof value === 'number' && Number.isFinite(value)) {
     return normalize(value);


### PR DESCRIPTION
### Motivation

- Fix inconsistent scaling between parsed taste vector entries and radar score normalization so summaries and charts show the same 0–10 range.
- Ensure values provided in 0–1 form are interpreted as 0–10 (same behavior as `normalizeTasteVectorScore`).

### Description

- Updated `parseVectorNumber` in `src/utils/tasteProfile.ts` to scale inputs `<= 1` by `* 10` before clamping.
- Kept existing `normalizeTasteVectorScore` behavior and aligned `parseVectorNumber` with it so `normalizeCoffeePreferenceSnapshot` produces consistently scaled `tasteVector` values.
- This change affects downstream consumers such as `HomeScreen` and `UserProfile` which build radar charts from the normalized vectors.

### Testing

- No automated tests were run for this change.
- The change is limited to parsing/scaling logic in `src/utils/tasteProfile.ts` and was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cd7015b0832a8bf528dc212bad89)