### PR TITLE
Ensure taste profile timestamps and source handling

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -1343,7 +1343,7 @@ router.post('/api/ocr/evaluate', async (req, res) => {
       requestTasteProfile?.updated_at ?? requestTasteProfile?.last_recalculated_at ?? null;
     const requestHasTimestamp = Boolean(requestUpdatedAtRaw);
     const allowTimestamplessProfile =
-      Boolean(requestTasteProfile) && (!dbPreferences || requestTasteProfileSource === 'client');
+      Boolean(requestTasteProfile) && !dbPreferences;
     if (requestTasteProfile && !requestHasTimestamp && !allowTimestamplessProfile) {
       console.warn('⚠️ [OCR] taste_profile missing timestamp; using DB profile.', {
         uid,

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -412,6 +412,26 @@ const extractTasteProfileTimestamps = (
   return { updatedAt, lastRecalculatedAt };
 };
 
+const isServerTasteProfile = (
+  profile?: TasteProfileVector | UserTasteProfile | null,
+): boolean => {
+  if (!profile || typeof profile !== 'object') {
+    return false;
+  }
+  if ('preferences' in profile) {
+    return true;
+  }
+  const record = profile as Record<string, unknown>;
+  return (
+    typeof record.userId === 'string' ||
+    typeof record.user_id === 'string' ||
+    typeof record.updatedAt === 'string' ||
+    typeof record.updated_at === 'string' ||
+    typeof record.lastRecalculatedAt === 'string' ||
+    typeof record.last_recalculated_at === 'string'
+  );
+};
+
 const mapTasteProfilePayload = (
   profile?: TasteProfileVector | UserTasteProfile | null,
 ): Record<string, unknown> | null => {
@@ -453,14 +473,23 @@ const mapTasteProfilePayload = (
   }
 
   const { updatedAt, lastRecalculatedAt } = extractTasteProfileTimestamps(profile);
+  const hasServerOrigin = isServerTasteProfile(profile);
+  const timestampPayload = hasServerOrigin
+    ? {
+        updated_at: updatedAt,
+        last_recalculated_at: lastRecalculatedAt,
+      }
+    : {
+        ...(updatedAt ? { updated_at: updatedAt } : {}),
+        ...(lastRecalculatedAt ? { last_recalculated_at: lastRecalculatedAt } : {}),
+      };
   return {
     taste_vector: ocrTasteVector,
     sweetness: ocrTasteVector.sweetness,
     acidity: ocrTasteVector.acidity,
     bitterness: ocrTasteVector.bitterness,
     body: ocrTasteVector.body,
-    ...(updatedAt ? { updated_at: updatedAt } : {}),
-    ...(lastRecalculatedAt ? { last_recalculated_at: lastRecalculatedAt } : {}),
+    ...timestampPayload,
   };
 };
 
@@ -1435,13 +1464,9 @@ export const processOCR = async (
               if (options?.tasteProfile) {
                 const tasteProfilePayload = mapTasteProfilePayload(options.tasteProfile);
                 if (tasteProfilePayload) {
-                  const { updatedAt, lastRecalculatedAt } = extractTasteProfileTimestamps(
-                    options.tasteProfile,
-                  );
-                  const hasServerTimestamps = Boolean(updatedAt || lastRecalculatedAt);
                   payload.taste_profile = tasteProfilePayload;
                   tasteProfileSent = true;
-                  if (hasServerTimestamps) {
+                  if (isServerTasteProfile(options.tasteProfile)) {
                     payload.taste_profile_source = 'server';
                   } else {
                     payload.taste_profile_source = 'client';


### PR DESCRIPTION
### Motivation
- Ensure taste profiles that originate from the server always include timestamp fields so the OCR evaluation backend can compare freshness.
- Mark locally-constructed taste profiles as `client` and avoid sending server-only timestamp semantics for local profiles.
- Prevent the backend from accepting client-sourced timestampless profiles when a DB profile already exists to avoid accidental overwrites.

### Description
- Add `isServerTasteProfile` helper and use it in `src/services/ocrServices.ts` to detect server-origin profiles and decide payload content.
- Modify `mapTasteProfilePayload` in `src/services/ocrServices.ts` to always include `updated_at`/`last_recalculated_at` keys for server-origin profiles and only include them conditionally for local profiles.
- Set `payload.taste_profile_source` based on `isServerTasteProfile` instead of inferring from timestamps in `src/services/ocrServices.ts`.
- Change backend logic in `server/routes/ocr.js` so timestampless client-sourced profiles are ignored when a DB profile exists by tightening `allowTimestamplessProfile`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cdf225fc832a8c5adbbc886e15c7)