### PR TITLE
Normalize profile payloads and responses

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -15,6 +15,7 @@ import { getColors } from '../../theme/colors';
 import AIResponseDisplay from './AIResponseDisplay';
 import { BOTTOM_NAV_CONTENT_OFFSET } from '../navigation/BottomNav';
 import { API_URL } from '../../services/api';
+import { normalizeKeysToSnakeCase, normalizeProfileResponse } from '../../utils/normalize';
 import {
   TasteVector,
   buildFallbackAIResponse,
@@ -48,6 +49,23 @@ interface Question {
   title: string;
   subtitle: string;
   options: QuestionOption[];
+}
+
+interface ProfilePayload {
+  coffee_preferences?: {
+    taste_vector?: TasteVector;
+    quiz_answers?: Record<string, string>;
+    ai_recommendation?: string;
+    consistency_score?: number;
+    ai_confidence?: number;
+    ai_raw_response?: string | null;
+  };
+  taste_vector?: TasteVector;
+  ai_recommendation?: string;
+  ai_confidence?: number;
+  quiz_answers?: Record<string, string>;
+  consistency_score?: number;
+  ai_raw_response?: string | null;
 }
 
 /**
@@ -217,7 +235,10 @@ const CoffeePreferenceForm = ({
       });
 
       if (res.ok) {
-        const data = await res.json();
+        const data = normalizeProfileResponse(await res.json()) as ProfilePayload | null;
+        if (!data) {
+          return;
+        }
         const storedTasteVector = data.coffee_preferences?.taste_vector;
         const normalizedTasteVector = storedTasteVector
           ? normalizeTasteVectorTo10(storedTasteVector)
@@ -537,13 +558,15 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          coffee_preferences: preferences,
-          ai_recommendation: profileText,
-          ai_confidence: confidence,
-        }),
+        body: JSON.stringify(
+          normalizeKeysToSnakeCase({
+            coffee_preferences: preferences,
+            ai_recommendation: profileText,
+            ai_confidence: confidence,
+          }),
+        ),
       });
-      const resData = await res.json().catch(() => null);
+      const resData = normalizeProfileResponse(await res.json().catch(() => null)) as ProfilePayload | null;
       console.log('📥 [BE] Save response:', resData);
       if (!res.ok) throw new Error('Failed to save preferences');
       const updatedProfile = resData?.coffee_preferences ?? null;

--- a/src/components/personalization/EditPreferences.tsx
+++ b/src/components/personalization/EditPreferences.tsx
@@ -17,6 +17,7 @@ import { getColors, Colors } from '../../theme/colors';
 import { getSafeAreaTop, getSafeAreaBottom, scale, verticalScale } from '../utils/safeArea';
 import { AIResponseDisplay } from './AIResponseDisplay';
 import { API_URL } from '../../services/api';
+import { normalizeKeysToSnakeCase, normalizeProfileResponse } from '../../utils/normalize';
 import {
   DEFAULT_TASTE_VECTOR,
   buildFallbackAIResponse,
@@ -70,8 +71,11 @@ const EditPreferences = ({ onBack }: { onBack: () => void }) => {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!res.ok) throw new Error('Nepodarilo sa načítať profil');
-        const data = await res.json();
+        const data = normalizeProfileResponse(await res.json()) as ProfileData | null;
         console.log('📥 [BE] Profile:', data);
+        if (!data) {
+          throw new Error('Invalid profile response');
+        }
         setProfile(data);
         setCurrentRecommendation(data.ai_recommendation || '');
         setUserNotes('');
@@ -207,10 +211,12 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          ai_recommendation: newRecommendation,
-          manual_input: updatedManualInput,
-        }),
+        body: JSON.stringify(
+          normalizeKeysToSnakeCase({
+            ai_recommendation: newRecommendation,
+            manual_input: updatedManualInput,
+          }),
+        ),
       });
 
       if (!res.ok) throw new Error('Uloženie zlyhalo');
@@ -249,10 +255,12 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
                   Authorization: `Bearer ${token}`,
                   'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({
-                  ai_recommendation: newRecommendation,
-                  manual_input: null,
-                }),
+                body: JSON.stringify(
+                  normalizeKeysToSnakeCase({
+                    ai_recommendation: newRecommendation,
+                    manual_input: null,
+                  }),
+                ),
               });
 
               if (!res.ok) throw new Error('Reset zlyhal');

--- a/src/components/profile/EditUserProfile.tsx
+++ b/src/components/profile/EditUserProfile.tsx
@@ -16,6 +16,7 @@ import auth from '@react-native-firebase/auth';
 import { getColors, Colors } from '../../theme/colors';
 import { getSafeAreaTop, getSafeAreaBottom, scale } from '../utils/safeArea';
 import { API_URL } from '../../services/api';
+import { normalizeKeysToSnakeCase } from '../../utils/normalize';
 
 
 /**
@@ -51,11 +52,11 @@ const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
         });
 
         if (!res.ok) throw new Error('Nepodarilo sa načítať profil');
-        const data = await res.json();
+        const data = normalizeKeysToSnakeCase(await res.json()) as Record<string, unknown>;
 
-        setName(data.name || '');
-        setBio(data.bio || '');
-        setAvatarUrl(data.avatar_url || '');
+        setName((data.name as string) || '');
+        setBio((data.bio as string) || '');
+        setAvatarUrl((data.avatar_url as string) || '');
       } catch (err) {
         Alert.alert('Chyba', 'Nepodarilo sa načítať profil');
       } finally {
@@ -83,7 +84,13 @@ const EditUserProfile = ({ onBack }: { onBack: () => void }) => {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name, bio, avatar_url: avatarUrl }),
+        body: JSON.stringify(
+          normalizeKeysToSnakeCase({
+            name,
+            bio,
+            avatarUrl,
+          }),
+        ),
       });
 
       if (!res.ok) throw new Error('Nepodarilo sa uložiť profil');

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -4,6 +4,7 @@ import NetInfo from '@react-native-community/netinfo';
 import RNFS from 'react-native-fs';
 import { API_HOST, API_URL } from './api';
 import type { TasteProfileVector, UserTasteProfile } from '../types/Personalization';
+import { normalizeKeysToSnakeCase } from '../utils/normalize';
 
 
 /**
@@ -144,27 +145,6 @@ const safeParseJSON = <T>(value: unknown): T | null => {
     console.warn('Failed to parse JSON payload', error);
     return null;
   }
-};
-
-const toSnakeCaseKey = (key: string): string =>
-  key
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/[\s-]+/g, '_')
-    .toLowerCase();
-
-const normalizeKeysToSnakeCase = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map(item => normalizeKeysToSnakeCase(item));
-  }
-  if (!value || typeof value !== 'object') {
-    return value;
-  }
-
-  const record = value as Record<string, unknown>;
-  return Object.keys(record).reduce<Record<string, unknown>>((acc, key) => {
-    acc[toSnakeCaseKey(key)] = normalizeKeysToSnakeCase(record[key]);
-    return acc;
-  }, {});
 };
 
 const normalizeEvaluationStatus = (value: unknown): CoffeeEvaluationStatus => {

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,0 +1,59 @@
+const toSnakeCaseKey = (key: string): string =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
+
+export const normalizeKeysToSnakeCase = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeKeysToSnakeCase(item));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  return Object.keys(record).reduce<Record<string, unknown>>((acc, key) => {
+    acc[toSnakeCaseKey(key)] = normalizeKeysToSnakeCase(record[key]);
+    return acc;
+  }, {});
+};
+
+export const normalizeProfileResponse = (value: unknown): Record<string, unknown> | null => {
+  const normalized = normalizeKeysToSnakeCase(value);
+  if (!normalized || typeof normalized !== 'object') {
+    return null;
+  }
+
+  const record = normalized as Record<string, unknown>;
+  const existingPreferences =
+    record.coffee_preferences && typeof record.coffee_preferences === 'object'
+      ? (record.coffee_preferences as Record<string, unknown>)
+      : null;
+  const coffeePreferences: Record<string, unknown> = existingPreferences ? { ...existingPreferences } : {};
+
+  if (record.taste_vector && coffeePreferences.taste_vector == null) {
+    coffeePreferences.taste_vector = record.taste_vector;
+  }
+  if (record.ai_recommendation && coffeePreferences.ai_recommendation == null) {
+    coffeePreferences.ai_recommendation = record.ai_recommendation;
+  }
+  if (record.ai_confidence && coffeePreferences.ai_confidence == null) {
+    coffeePreferences.ai_confidence = record.ai_confidence;
+  }
+  if (record.consistency_score && coffeePreferences.consistency_score == null) {
+    coffeePreferences.consistency_score = record.consistency_score;
+  }
+  if (record.quiz_answers && coffeePreferences.quiz_answers == null) {
+    coffeePreferences.quiz_answers = record.quiz_answers;
+  }
+  if (record.ai_raw_response && coffeePreferences.ai_raw_response == null) {
+    coffeePreferences.ai_raw_response = record.ai_raw_response;
+  }
+
+  if (Object.keys(coffeePreferences).length > 0) {
+    record.coffee_preferences = coffeePreferences;
+  }
+
+  return record;
+};


### PR DESCRIPTION
### Motivation

- Ensure frontend sends `PUT /profile` payloads in snake_case and that responses are parsed into a consistent shape so backend tolerant of camelCase/snake_case differences. 
- Make `coffee_preferences`, `ai_recommendation`, `ai_confidence`, and related fields available in a single, predictable location on the profile response. 
- Reuse an existing snake_case normalizer across features to avoid duplicated logic. 
- Reduce bugs caused by mixed casing between FE and BE when saving/loading profile and preference data.

### Description

- Added `src/utils/normalize.ts` exporting `normalizeKeysToSnakeCase` and `normalizeProfileResponse` helpers to convert keys to `snake_case` and coerce `/profile` responses into a consistent `coffee_preferences` structure. 
- Updated personalization flows to normalize backend responses with `normalizeProfileResponse(...)` and to normalize outgoing `PUT /profile` bodies with `normalizeKeysToSnakeCase(...)` in `src/components/personalization/CoffeePreferenceForm.tsx`. 
- Applied the same normalization to AI preference editing in `src/components/personalization/EditPreferences.tsx` and to profile editing in `src/components/profile/EditUserProfile.tsx` so GET/PUT interactions use a consistent format. 
- Reused `normalizeKeysToSnakeCase` inside `src/services/ocrServices.ts` to keep request payload formatting consistent across services.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637d0f341c832abb4a7f91b5ced0f5)