### PR TITLE
Ensure `ai_recommendation` is always nested in `coffee_preferences` and add FE fallback

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -223,7 +223,9 @@ const serializeTasteProfile = (taste) => {
       is_complete: false,
       updated_at: null,
       last_recalculated_at: null,
-      coffee_preferences: null,
+      coffee_preferences: {
+        ai_recommendation: null,
+      },
     };
   }
 

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -52,6 +52,10 @@ interface Question {
 }
 
 interface ProfilePayload {
+  /**
+   * BE kontrakt: ai_recommendation je primárne v coffee_preferences.
+   * Legacy fallback: top-level ai_recommendation môže byť ešte prítomné.
+   */
   coffee_preferences?: {
     taste_vector?: TasteVector;
     quiz_answers?: Record<string, string>;
@@ -247,10 +251,12 @@ const CoffeePreferenceForm = ({
         if (data.coffee_preferences?.quiz_answers) {
           setAnswers(data.coffee_preferences.quiz_answers);
         }
+        const storedAiRecommendation =
+          data.coffee_preferences?.ai_recommendation ?? data.ai_recommendation;
         setPreviousProfile({
           quiz_answers: data.coffee_preferences?.quiz_answers,
           taste_vector: normalizedTasteVector,
-          ai_recommendation: data.coffee_preferences?.ai_recommendation,
+          ai_recommendation: storedAiRecommendation,
           consistency_score:
             data.coffee_preferences?.consistency_score ??
             data.coffee_preferences?.ai_confidence,


### PR DESCRIPTION
### Motivation
- Guarantee `ai_recommendation` is present inside `coffee_preferences` in the profile response so clients that expect nested preferences won't break.
- Preserve backwards compatibility with legacy top-level `ai_recommendation` values returned by the API.
- Make the frontend contract explicit in `CoffeePreferenceForm.tsx` so the code documents where `ai_recommendation` should be read from.

### Description
- Update `serializeTasteProfile` in `server/routes/profile.js` to return `coffee_preferences: { ai_recommendation: null }` when no taste profile exists, ensuring the nested key is always present.
- Add a contract comment to the `ProfilePayload` interface in `src/components/personalization/CoffeePreferenceForm.tsx` clarifying that `ai_recommendation` is primarily nested.
- Add a frontend fallback `storedAiRecommendation = data.coffee_preferences?.ai_recommendation ?? data.ai_recommendation` and use it when populating `previousProfile` so the nested value is preferred but the top-level legacy field is used if needed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637e485914832a882075a1e5dcec1f)