### PR TITLE
Document 0–10 taste_profile scale for /ocr/evaluate

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -1455,6 +1455,7 @@ export const processOCR = async (
               }
               // Manual QA: submit the questionnaire flow (TasteProfileVector) and confirm
               // `/ocr/evaluate` receives `taste_profile` with only taste_vector + sweetness/acidity/bitterness/body.
+              // Contract: `taste_profile.taste_vector` values are on a 0–10 scale across FE/BE (no 0–1 normalization).
               // Extra dimensions (intensity/experimentalism) are intentionally dropped for OCR evaluation.
               const evaluationResult = await loggedFetchWithStatusRetry(
                 `${API_URL}/ocr/evaluate`,


### PR DESCRIPTION
### Motivation
- Clarify the expected numeric scale for taste profile vectors sent to the OCR evaluation endpoint to avoid ambiguity between 0–1 and 0–10 representations.
- Ensure frontend and backend agree on the taste vector contract used during `/ocr/evaluate` requests.
- Prevent accidental normalization of `taste_profile.taste_vector` to a 0–1 scale in the OCR evaluation flow.

### Description
- Added an explicit contract comment in `src/services/ocrServices.ts` near the `/ocr/evaluate` request stating that `taste_profile.taste_vector` values use a 0–10 scale.
- Left existing payload construction and `mapTasteProfilePayload` logic intact, documenting the scale rather than changing runtime behavior.
- The comment clarifies that extra taste dimensions are intentionally omitted for OCR evaluation and that no 0–1 normalization should occur for this endpoint.

### Testing
- No automated tests were run for this change.
- Change is comment-only and does not modify runtime logic or API call structure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637ed571e4832aaf0098d3e705daa6)