### PR TITLE
Include optional intensity and experimentalism in OCR taste profile payload

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -702,6 +702,7 @@ const isValidEvaluationResponse = (value) => {
   return true;
 };
 
+// OCR evaluation uses the 4D core; extra taste dimensions are accepted but ignored here.
 const isTasteProfileComplete = (profile) => {
   if (!profile || typeof profile !== 'object') {
     return false;

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -362,12 +362,27 @@ const extractTasteVector = (
   return profile;
 };
 
-const mapOcrTasteVector = (vector: TasteProfileVector): TasteProfileVector => ({
-  sweetness: vector.sweetness,
-  acidity: vector.acidity,
-  bitterness: vector.bitterness,
-  body: vector.body,
-});
+type ExtendedTasteVector = TasteProfileVector & {
+  intensity?: number;
+  experimentalism?: number;
+};
+
+const extractExtendedDimensions = (vector: TasteProfileVector): ExtendedTasteVector => {
+  const record = vector as Record<string, unknown>;
+  return {
+    sweetness: vector.sweetness,
+    acidity: vector.acidity,
+    bitterness: vector.bitterness,
+    body: vector.body,
+    ...(typeof record.intensity === 'number' ? { intensity: record.intensity } : {}),
+    ...(typeof record.experimentalism === 'number'
+      ? { experimentalism: record.experimentalism }
+      : {}),
+  };
+};
+
+const mapOcrTasteVector = (vector: TasteProfileVector): ExtendedTasteVector =>
+  extractExtendedDimensions(vector);
 
 const extractTasteProfileTimestamps = (
   profile?: TasteProfileVector | UserTasteProfile | null,
@@ -423,8 +438,16 @@ const mapTasteProfilePayload = (
   if (!tasteVector) {
     return null;
   }
-  // OCR evaluácia používa len 4D chuťový profil (sweetness/acidity/bitterness/body).
+  // OCR hodnotenie používa základné 4D, ale ak existujú, pošleme aj extra dimenzie.
   const ocrTasteVector = mapOcrTasteVector(tasteVector);
+  const extraDimensions = {
+    ...(typeof ocrTasteVector.intensity === 'number'
+      ? { intensity: ocrTasteVector.intensity }
+      : {}),
+    ...(typeof ocrTasteVector.experimentalism === 'number'
+      ? { experimentalism: ocrTasteVector.experimentalism }
+      : {}),
+  };
 
   if ('preferences' in profile) {
     const flavorNoteEntries = profile.flavorNotes ?? {};
@@ -436,6 +459,7 @@ const mapTasteProfilePayload = (
       acidity: ocrTasteVector.acidity,
       bitterness: ocrTasteVector.bitterness,
       body: ocrTasteVector.body,
+      ...extraDimensions,
       flavor_notes: flavorNotes,
       flavor_note_weights: flavorNoteEntries,
       milk_preferences: profile.milkPreferences,
@@ -469,6 +493,7 @@ const mapTasteProfilePayload = (
     acidity: ocrTasteVector.acidity,
     bitterness: ocrTasteVector.bitterness,
     body: ocrTasteVector.body,
+    ...extraDimensions,
     ...timestampPayload,
   };
 };
@@ -1454,9 +1479,9 @@ export const processOCR = async (
                 }
               }
               // Manual QA: submit the questionnaire flow (TasteProfileVector) and confirm
-              // `/ocr/evaluate` receives `taste_profile` with only taste_vector + sweetness/acidity/bitterness/body.
+              // `/ocr/evaluate` receives `taste_profile` with the 4D core plus optional extra dimensions when present.
               // Contract: `taste_profile.taste_vector` values are on a 0–10 scale across FE/BE (no 0–1 normalization).
-              // Extra dimensions (intensity/experimentalism) are intentionally dropped for OCR evaluation.
+              // OCR evaluation uses the 4D core (sweetness/acidity/bitterness/body); extra dims are ignored downstream.
               const evaluationResult = await loggedFetchWithStatusRetry(
                 `${API_URL}/ocr/evaluate`,
                 {


### PR DESCRIPTION
### Motivation
- Allow the frontend to include optional `intensity` and `experimentalism` dimensions when sending user taste profiles to the OCR evaluation endpoint.
- Make the FE/BE contract explicit that `taste_profile.taste_vector` values remain on a 0–10 scale and no 0–1 normalization is applied.
- Clarify that OCR evaluation is based on the 4D core (sweetness/acidity/bitterness/body) while accepting extra dimensions if present.
- Prevent dropping useful extra dimensions from the payload while keeping backward-compatible evaluation behavior.

### Description
- Added `ExtendedTasteVector` and `extractExtendedDimensions` and made `mapOcrTasteVector` return the extended vector in `src/services/ocrServices.ts`.
- Included optional `intensity` and `experimentalism` in the `taste_profile` payload (`...extraDimensions`) for both client and server-origin profiles while preserving core 4D fields.
- Updated FE comments near `mapTasteProfilePayload` to reflect that the 4D core is used for evaluation but extras are sent if present, and reiterated the 0–10 scale contract.
- Updated a comment in `server/routes/ocr.js` to state that extra taste dimensions are accepted by the API but ignored for completeness/evaluation checks.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637f86dd28832a8867341421394ae1)