### PR TITLE
Handle object AI responses and normalize taste-profile content

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -425,7 +425,15 @@ router.post('/api/profile/taste-profile', async (req, res) => {
       }
     );
 
-    const content = aiResponse.data?.choices?.[0]?.message?.content?.trim() ?? '';
+    const rawContent = aiResponse.data?.choices?.[0]?.message?.content;
+    let content = '';
+    if (typeof rawContent === 'string') {
+      content = rawContent.trim();
+    } else if (rawContent && typeof rawContent === 'object') {
+      content = JSON.stringify(rawContent);
+    } else if (rawContent !== undefined && rawContent !== null) {
+      content = String(rawContent);
+    }
     return res.json({ content });
   } catch (err) {
     console.error('❌ Chyba AI profilu:', err);

--- a/src/components/personalization/tasteAiUtils.ts
+++ b/src/components/personalization/tasteAiUtils.ts
@@ -138,7 +138,7 @@ export const buildFallbackAIResponse = (fallbackVector: TasteVector): TasteAIRes
 });
 
 export const parseTasteAIResponse = (
-  aiResponse: string | undefined,
+  aiResponse: unknown,
   fallbackVector: TasteVector,
 ): { response: TasteAIResponse; warnings: string[] } => {
   const warnings: string[] = [];
@@ -150,7 +150,12 @@ export const parseTasteAIResponse = (
   }
 
   try {
-    const parsed = JSON.parse(aiResponse);
+    const parsed =
+      typeof aiResponse === 'string' ? JSON.parse(aiResponse) : aiResponse;
+    if (!parsed || typeof parsed !== 'object') {
+      warnings.push('AI response JSON parse failed');
+      return { response: fallback, warnings };
+    }
     const recommendation =
       typeof parsed?.ai_recommendation === 'string' && parsed.ai_recommendation.trim()
         ? parsed.ai_recommendation.trim()
@@ -267,7 +272,7 @@ export const callOpenAIJsonSchema = async (
   systemPrompt: string,
   userPrompt: string,
   temperature = 0.2,
-): Promise<string | undefined> => {
+): Promise<string | Record<string, unknown> | undefined> => {
   const token = await auth().currentUser?.getIdToken();
   const response = await fetch(`${API_URL}/profile/taste-profile`, {
     method: 'POST',
@@ -284,8 +289,17 @@ export const callOpenAIJsonSchema = async (
 
   const data = await response.json().catch(() => ({}));
   console.log('📥 [BE] prefs response:', data);
+  const content = data?.content;
+  const contentType = Array.isArray(content) ? 'array' : typeof content;
+  console.log('📥 [BE] prefs content type:', contentType);
   if (!response.ok) {
     throw new Error(data?.error || 'AI request failed');
   }
-  return data?.content?.trim();
+  if (typeof content === 'string') {
+    return content.trim();
+  }
+  if (content && typeof content === 'object') {
+    return content as Record<string, unknown>;
+  }
+  return undefined;
 };


### PR DESCRIPTION
### Motivation
- Make the frontend robust against AI responses that may already be parsed objects instead of JSON strings.
- Improve diagnostics by logging the backend `content` type returned from the taste-profile endpoint.
- Stabilize the API contract so the backend always returns `content` as a JSON string to avoid ambiguity on the client.

### Description
- Change `parseTasteAIResponse` to accept `aiResponse: unknown` and only `JSON.parse` when `aiResponse` is a string, otherwise use the object directly and emit a warning if the value is not an object.  
- Update `callOpenAIJsonSchema` to return `Promise<string | Record<string, unknown> | undefined>` and log the `content` type with `console.log`, returning either a trimmed string or the object.  
- Modify the server `POST /api/profile/taste-profile` handler to coerce `aiResponse.data.choices[0].message.content` into a string by trimming strings or `JSON.stringify`ing objects before returning `{ content }`.  
- Add small validation/warning paths so malformed or non-object `content` falls back safely to existing defaults.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963818d18dc832aad73b70a718222ff)