### PR TITLE
Warn on unknown quiz_version; add FE/BE sync notes for quiz keys

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -21,6 +21,7 @@ const TASTE_VECTOR_KEYS = [
   'intensity',
   'experimentalism',
 ];
+// Keep in sync with FE question IDs (CoffeePreferenceForm.tsx).
 const QUIZ_ANSWER_KEYS_BY_VERSION = {
   'taste-2024-10': [
     'dealbreaker',
@@ -197,7 +198,10 @@ const validateQuizAnswers = (value, quizVersion) => {
     : null;
 
   if (quizVersion && !expectedKeys) {
-    throw new Error(`Invalid quiz_version "${quizVersion}" for quiz_answers.`);
+    console.warn(
+      `[profile] Unknown quiz_version "${quizVersion}" for quiz_answers; ` +
+        'falling back to soft validation.'
+    );
   }
 
   const expectedKeySet = expectedKeys ? new Set(expectedKeys) : null;

--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -545,6 +545,7 @@ ${TASTE_AI_SCHEMA_PROMPT}`;
     );
 
     const preferences = {
+      // Ak sa zmenia question IDs, treba zosúladiť QUIZ_ANSWER_KEYS_BY_VERSION na BE.
       quiz_version: 'taste-2024-10',
       quiz_answers: answers,
       // OCR evaluácia použije iba známe dimenzie, extra hodnoty ostanú zachované.


### PR DESCRIPTION
### Motivation
- Reduce breakage when question IDs change by making backend validation more tolerant to unknown quiz versions.
- Make it explicit that frontend question IDs must be kept in sync with backend expected keys to avoid runtime errors.
- Allow saving user preferences even if the backend does not recognize the `quiz_version` yet by applying soft validation.

### Description
- Replace a hard error with a `console.warn` in `validateQuizAnswers` so unknown `quiz_version` values fall back to soft validation instead of blocking saves.
- Keep a top-of-file comment next to `QUIZ_ANSWER_KEYS_BY_VERSION` reminding maintainers to sync it with the FE `CoffeePreferenceForm.tsx` question IDs.
- Add a comment in `src/components/personalization/CoffeePreferenceForm.tsx` next to the `quiz_version: 'taste-2024-10'` payload to document the required BE/FE synchronization.
- Behavior: when `quiz_version` is unknown the key whitelist is skipped and only per-answer type validation (string) is enforced, while unknown per-version keys still reject when a known version is used.

### Testing
- No automated tests were added or executed for this change.
- Basic file-level lint/type checks were not run as part of this rollout.
- Manual runtime behavior was not verified by automated suites in this PR.
- Developers should run the app and existing integration tests to validate the new soft-validation behavior before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696389241748832aa3df7c7a7398cbe1)