### PR TITLE
Always include `updated_at` and `last_recalculated_at` in OCR taste profile payloads

### DIFF
--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -493,19 +493,10 @@ const mapTasteProfilePayload = (
   }
 
   const { updatedAt, lastRecalculatedAt } = resolvedTimestamps;
-  const hasServerOrigin =
-    options?.tasteProfileSource !== undefined
-      ? options.tasteProfileSource !== 'client'
-      : isServerTasteProfile(profile);
-  const timestampPayload = hasServerOrigin
-    ? {
-        updated_at: updatedAt,
-        last_recalculated_at: lastRecalculatedAt,
-      }
-    : {
-        ...(updatedAt ? { updated_at: updatedAt } : {}),
-        ...(lastRecalculatedAt ? { last_recalculated_at: lastRecalculatedAt } : {}),
-      };
+  const timestampPayload = {
+    updated_at: updatedAt ?? null,
+    last_recalculated_at: lastRecalculatedAt ?? null,
+  };
   return {
     taste_vector: ocrTasteVector,
     sweetness: ocrTasteVector.sweetness,


### PR DESCRIPTION
### Motivation

- Ensure backend does not consider client-side taste profiles stale by always sending timestamps when evaluating OCR (`POST /api/ocr/evaluate`).
- Previously the mapping omitted timestamps for `taste_profile_source: "client"`, which could mark up-to-date client profiles as outdated.
- Preserve timestamp fields through the snake_case normalization pipeline so `updated_at` and `last_recalculated_at` reach the server intact.

### Description

- Updated `mapTasteProfilePayload` in `src/services/ocrServices.ts` to always include `updated_at` and `last_recalculated_at` (using `null` fallbacks) in the payload.
- Removed conditional `hasServerOrigin` branching that previously suppressed timestamps for client-origin profiles.
- The `preferences` branch already sets timestamp fields with null fallbacks and remains unchanged, and the payloads are still normalized with `normalizeKeysToSnakeCase` before sending.

### Testing

- No automated tests were run as part of this change.
- Changes were limited to payload mapping logic and rely on existing normalization behavior to preserve snake_case keys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639233f7e4832a88e776a66aa3ef39)