### PR TITLE
Add fallback warning note for unknown quiz versions

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -22,6 +22,8 @@ const TASTE_VECTOR_KEYS = [
   'experimentalism',
 ];
 // Keep in sync with FE question IDs (CoffeePreferenceForm.tsx).
+// NOTE: Unknown quiz_version falls back to soft validation to avoid hard errors,
+// so keep FE/BE updates synchronized when adding new questions.
 const QUIZ_ANSWER_KEYS_BY_VERSION = {
   'taste-2024-10': [
     'dealbreaker',
@@ -200,7 +202,7 @@ const validateQuizAnswers = (value, quizVersion) => {
   if (quizVersion && !expectedKeys) {
     console.warn(
       `[profile] Unknown quiz_version "${quizVersion}" for quiz_answers; ` +
-        'falling back to soft validation.'
+        'falling back to soft validation. Ensure FE/BE question sync.'
     );
   }
 


### PR DESCRIPTION
### Motivation

- Ensure the backend behavior for unknown `quiz_version` is documented and visible to future maintainers. 
- Avoid hard errors when the front-end sends answers for a quiz version the backend does not yet recognize. 
- Encourage synchronized updates between FE question IDs and BE validation rules. 

### Description

- Added a developer note above `QUIZ_ANSWER_KEYS_BY_VERSION` in `server/routes/profile.js` explaining the soft-validation fallback for unknown quiz versions. 
- Expanded the `console.warn` message in `validateQuizAnswers` to remind to `Ensure FE/BE question sync.`
- Kept existing behavior: unknown versions still fall back to soft validation (no hard error), and known-version key checks remain enforced. 
- Affected file: `server/routes/profile.js`.

### Testing

- No automated tests were run for this change. 
- No test failures were observed because tests were not executed. 
- Manual verification is limited to static code inspection of the updated warning/comment. 
- Recommend adding or updating unit tests around `validateQuizAnswers` when introducing new quiz versions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696392b7822c832a8cdbc8d462118b7b)