### PR TITLE
Ensure taste_vector is always serialized in profile responses

### DIFF
--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -137,6 +137,27 @@ const hasQuizAnswers = (quizAnswers) => {
   return Object.keys(quizAnswers).length > 0;
 };
 
+const resolveTasteVector = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (isPlainObject(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return isPlainObject(parsed) ? parsed : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+};
+
 /**
  * Validate and clamp a taste vector payload.
  *
@@ -261,6 +282,10 @@ const serializeTasteProfile = (taste) => {
     };
   }
 
+  const resolvedTasteVector =
+    resolveTasteVector(taste.taste_vector) ??
+    resolveTasteVector(taste.ai_raw_response?.taste_vector);
+
   // coffee_preferences je jediný zdroj pravdy pre chuťový profil.
   const coffeePreferences = {
     sweetness: Number(taste.sweetness),
@@ -277,7 +302,7 @@ const serializeTasteProfile = (taste) => {
     quiz_version: taste.quiz_version ?? null,
     quiz_answers: taste.quiz_answers ?? {},
     consistency_score: taste.consistency_score ?? null,
-    taste_vector: taste.taste_vector ?? null,
+    taste_vector: resolvedTasteVector,
     ai_recommendation: taste.ai_recommendation ?? null,
     manual_input: taste.manual_input ?? null,
     is_complete: taste.is_complete ?? false,


### PR DESCRIPTION
### Motivation
- FE expects `coffee_preferences.taste_vector` to be populated when a taste vector exists in the DB to avoid using a legacy top-level fallback. 
- Some stored vectors may be JSON strings or nested under `ai_raw_response`, so the serializer needs to normalize these forms. 
- This reduces warnings in `CoffeeTasteScanner` and keeps BE/FE contract consistent. 

### Description
- Add `resolveTasteVector` helper to parse/normalize a taste vector when it is a plain object or a JSON string. 
- Update `serializeTasteProfile` to set `coffee_preferences.taste_vector` from `resolveTasteVector(taste.taste_vector)` or `resolveTasteVector(taste.ai_raw_response?.taste_vector)`. 
- Keep legacy top-level profile mirror behavior unchanged while ensuring the nested `coffee_preferences.taste_vector` is populated when available. 
- All changes are contained to `server/routes/profile.js` and target serialization logic used by `buildProfileResponse`.

### Testing
- No automated tests were run for this change. 
- Change committed and ready for CI/QA verification that `GET /api/profile` now includes the resolved `coffee_preferences.taste_vector` when present in the DB.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639333bb10832a8e2e43a889a0b669)