### PR TITLE
Update OCR evaluation to include intensity/experimentalism

### DIFF
--- a/server/routes/__tests__/ocr-evaluation.test.js
+++ b/server/routes/__tests__/ocr-evaluation.test.js
@@ -1,4 +1,8 @@
-import { isValidEvaluationResponse, resolveCorrectedText } from '../ocr.js';
+import {
+  formatTasteProfileSummary,
+  isValidEvaluationResponse,
+  resolveCorrectedText,
+} from '../ocr.js';
 
 describe('isValidEvaluationResponse', () => {
   it('accepts a valid evaluation response', () => {
@@ -82,5 +86,23 @@ describe('resolveCorrectedText', () => {
     });
 
     expect(resolved).toBe('Valid fallback text.');
+  });
+});
+
+describe('formatTasteProfileSummary', () => {
+  it('includes intensity and experimentalism for a 6D taste vector', () => {
+    const summary = formatTasteProfileSummary({
+      taste_vector: {
+        sweetness: 6,
+        acidity: 5,
+        bitterness: 4,
+        body: 7,
+        intensity: 8,
+        experimentalism: 3,
+      },
+    });
+
+    expect(summary).toContain('intenzita 8/10');
+    expect(summary).toContain('experimentalnosť 3/10');
   });
 });

--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -113,19 +113,37 @@ const buildDeterministicFallbackResponse = ({ preferences, coffeeAttributes, cor
 
   const formatPreference = (value) =>
     value === null || value === undefined || value === '' ? 'neznáme' : value;
+  const extraPreferenceBits = [];
+  if (safePreferences.intensity !== undefined && safePreferences.intensity !== null) {
+    extraPreferenceBits.push(`intenzita ${formatPreference(safePreferences.intensity)}`);
+  }
+  if (
+    safePreferences.experimentalism !== undefined &&
+    safePreferences.experimentalism !== null
+  ) {
+    extraPreferenceBits.push(
+      `experimentalnosť ${formatPreference(safePreferences.experimentalism)}`
+    );
+  }
+  const extraPreferenceSummary =
+    extraPreferenceBits.length > 0 ? `, ${extraPreferenceBits.join(', ')}` : '';
   const userPreferencesSummary = `Tvoje preferencie: sladkosť ${formatPreference(
     safePreferences.sweetness
   )}, acidita ${formatPreference(safePreferences.acidity)}, horkosť ${formatPreference(
     safePreferences.bitterness
-  )}, telo ${formatPreference(safePreferences.body)}.`;
+  )}, telo ${formatPreference(safePreferences.body)}${extraPreferenceSummary}.`;
+  const extraComparisonSummary =
+    extraPreferenceBits.length > 0
+      ? ` Zohľadnili sme aj ${extraPreferenceBits.join(' a ')}.`
+      : '';
   const comparisonSummary =
     verdict === 'suitable'
       ? `Porovnanie s tvojím profilom: textová zhoda vychádza na ${Math.round(
           normalizedScore
-        )} %, preto kávu hodnotíme ako vhodnú.`
+        )} %, preto kávu hodnotíme ako vhodnú.${extraComparisonSummary}`
       : `Porovnanie s tvojím profilom: textová zhoda vychádza na ${Math.round(
           normalizedScore
-        )} %, preto kávu hodnotíme ako menej vhodnú.`;
+        )} %, preto kávu hodnotíme ako menej vhodnú.${extraComparisonSummary}`;
 
   return {
     status: 'ok',
@@ -303,16 +321,26 @@ const formatTasteProfileSummary = (profile) => {
   if (!vector || typeof vector !== 'object') {
     return null;
   }
-  const { sweetness, acidity, bitterness, body } = vector;
-  const values = [sweetness, acidity, bitterness, body];
+  const { sweetness, acidity, bitterness, body, intensity, experimentalism } = vector;
+  const values = [sweetness, acidity, bitterness, body, intensity, experimentalism];
   if (!values.some((value) => typeof value === 'number' && Number.isFinite(value))) {
     return null;
   }
   const formatValue = (value) =>
     typeof value === 'number' && Number.isFinite(value) ? `${value}/10` : 'neznáme';
-  return `sladkosť ${formatValue(sweetness)}, acidita ${formatValue(
-    acidity
-  )}, horkosť ${formatValue(bitterness)}, telo ${formatValue(body)}`;
+  const summaryBits = [
+    `sladkosť ${formatValue(sweetness)}`,
+    `acidita ${formatValue(acidity)}`,
+    `horkosť ${formatValue(bitterness)}`,
+    `telo ${formatValue(body)}`,
+  ];
+  if (intensity !== undefined && intensity !== null) {
+    summaryBits.push(`intenzita ${formatValue(intensity)}`);
+  }
+  if (experimentalism !== undefined && experimentalism !== null) {
+    summaryBits.push(`experimentalnosť ${formatValue(experimentalism)}`);
+  }
+  return summaryBits.join(', ');
 };
 
 const formatCoffeeAttributesSummary = (attributes) => {
@@ -1534,6 +1562,7 @@ PRAVIDLÁ:
   - user_preferences_summary začína "Tvoje preferencie:" a stručne zhrnie chuťový profil.
   - coffee_profile_summary začína "Profil kávy:" a stručne zhrnie profil kávy.
   - comparison_summary začína "Porovnanie s tvojím profilom:" a jasne porovná oba profily.
+- Ak sú v chuťovom profile dostupné intensity alebo experimentalism, explicitne ich zahrň do user_preferences_summary a comparison_summary.
 - Insight musí byť konzistentný s verdictom (bez protichodných tvrdení).
 - Použi jediný kontrakt: insight objekt s poliami zo schémy (žiadne top-level zoznamy).
 
@@ -1543,6 +1572,8 @@ user_taste_profile: {
   "acidity": ${preferences.acidity},
   "bitterness": ${preferences.bitterness},
   "body": ${preferences.body},
+  "intensity": ${preferences.intensity ?? null},
+  "experimentalism": ${preferences.experimentalism ?? null},
   "flavor_notes": ${JSON.stringify(preferences.flavor_notes ?? [])},
   "milk_preferences": ${JSON.stringify(preferences.milk_preferences || {})},
   "caffeine_sensitivity": ${JSON.stringify(preferences.caffeine_sensitivity ?? null)},
@@ -1889,5 +1920,5 @@ router.post('/api/ocr/purchase', async (req, res) => {
   }
 });
 
-export { isValidEvaluationResponse, resolveCorrectedText };
+export { isValidEvaluationResponse, resolveCorrectedText, formatTasteProfileSummary };
 export default router;


### PR DESCRIPTION
### Motivation
- Support optional `intensity` and `experimentalism` taste dimensions so AI comparison and heuristic fallbacks use them when present.
- Make `verdict_explanation`/`comparison_summary` explicitly reflect these extra dimensions when available.
- Ensure taste profile formatting supports 6D vectors for downstream prompts and deterministic fallbacks.
- Add unit coverage to prevent regressions for 6D taste vectors.

### Description
- Update `buildDeterministicFallbackResponse` to append `intensity` and `experimentalism` into the `user_preferences_summary` and to mention them in the `comparison_summary` when present.
- Extend `formatTasteProfileSummary` to read `intensity` and `experimentalism` from the resolved taste vector and include them in the returned summary string.
- Add guidance and include `intensity`/`experimentalism` in the AI `userPrompt` payload so the model can incorporate those dimensions into evaluations, and export `formatTasteProfileSummary` from `server/routes/ocr.js`.
- Add a unit test `server/routes/__tests__/ocr-evaluation.test.js` that asserts a 6D taste vector summary contains `intenzita` and `experimentalnosť` entries.

### Testing
- Added a unit test for `formatTasteProfileSummary` that verifies a 6D taste vector includes `intenzita 8/10` and `experimentalnosť 3/10`.
- No automated test suite (unit or CI) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696394291b1c832a9f1ed638bf53a88e)