### PR TITLE
Add question context to AI prompt answers

### DIFF
--- a/src/components/personalization/CoffeePreferenceForm.tsx
+++ b/src/components/personalization/CoffeePreferenceForm.tsx
@@ -352,6 +352,28 @@ const CoffeePreferenceForm = ({
       .filter(Boolean);
   };
 
+  const formatQuestionContext = (question: Question) =>
+    question.title.replace(/^(?:\d+\uFE0F?\u20E3|🔟)\s*/u, '').trim();
+
+  const buildAnswerPromptMap = (
+    orderedQuestions: string[],
+    quizAnswers: Record<string, string>,
+    fallbackLabel = 'neodpovedané',
+  ) => {
+    const answerPromptMap: Record<string, string> = {};
+    orderedQuestions.forEach((id, idx) => {
+      const question = allQuestions.find(q => q.id === id);
+      const selectedValue = quizAnswers[id];
+      const answerLabel = question?.options.find(opt => opt.value === selectedValue)?.label ?? fallbackLabel;
+      if (!question) {
+        answerPromptMap[`Q${idx + 1}`] = `Q${idx + 1}: ${answerLabel}`;
+        return;
+      }
+      const context = formatQuestionContext(question);
+      answerPromptMap[`Q${idx + 1}`] = `Q${idx + 1} (${context}): ${answerLabel}`;
+    });
+    return answerPromptMap;
+  };
 
   /**
    * Zavolá OpenAI a vygeneruje odporúčanie podľa nového chuťového vektora.
@@ -383,17 +405,10 @@ const CoffeePreferenceForm = ({
         'control',
       ];
 
-      const answerMap: Record<string, string> = {};
-      orderedQuestions.forEach((id, idx) => {
-        answerMap[`Q${idx + 1}`] = getAnswerLabel(id, quizAnswers);
-      });
-
-      const previousAnswerMap: Record<string, string> = {};
-      orderedQuestions.forEach((id, idx) => {
-        previousAnswerMap[`Q${idx + 1}`] = priorProfile?.quiz_answers
-          ? getAnswerLabel(id, priorProfile.quiz_answers)
-          : 'neznáme';
-      });
+      const answerMap = buildAnswerPromptMap(orderedQuestions, quizAnswers);
+      const previousAnswerMap = priorProfile?.quiz_answers
+        ? buildAnswerPromptMap(orderedQuestions, priorProfile.quiz_answers)
+        : buildAnswerPromptMap(orderedQuestions, {}, 'neznáme');
 
       const answerDeltas = buildAnswerDeltaSummary(
         orderedQuestions,


### PR DESCRIPTION
### Motivation
- Prevent the AI from misinterpreting short option labels as positive preferences by adding semantic context to each quiz answer in the prompt.
- Make current and previous answers self-descriptive so the model can use question intent when generating the taste profile.

### Description
- Added `formatQuestionContext` to strip numeric emoji prefixes and extract the human-readable question context from `title`.
- Introduced `buildAnswerPromptMap(orderedQuestions, quizAnswers, fallbackLabel)` which produces entries like `Q1 (čo ti vadí najviac): B) silná horkosť` and uses a configurable fallback label.
- Replaced the previous `answerMap`/`previousAnswerMap` construction in `generateAIRecommendation` to use `buildAnswerPromptMap` and default missing previous answers to `neznáme`.

### Testing
- No automated tests were run for this change.
- Code was compiled and the file was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d0ebd6e4832a9f16dc7632c0c6b0)