### PR TITLE
Handle stale taste profiles in scan summaries

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -89,6 +89,7 @@ interface ScanResult {
   structuredRaw?: unknown;
   evaluation?: CoffeeEvaluationResult | null;
   tasteProfileSent?: boolean;
+  tasteProfileRejectedAsStale?: boolean;
 }
 
 type ScanResultLike = ScanResult & { rawStructuredResponse?: unknown };
@@ -235,15 +236,19 @@ const buildComparisonText = (
   aiRecommendation: string | null | undefined,
   profilePreferences: Record<string, unknown> | null | undefined,
   coffeePreferences: Record<string, unknown> | null | undefined,
+  isProfileStale: boolean,
 ): string => {
   const { summary: preferenceSummary, sourceLabel } = buildPreferenceSummary({
-    profilePreferences,
+    profilePreferences: isProfileStale ? null : profilePreferences,
     preferenceSnapshot,
     coffeePreferences,
+    isProfileStale,
   });
   const formSection = preferenceSummary
     ? `Aktuálny profil (${sourceLabel}):\n${preferenceSummary}`
-    : 'Aktuálny profil (dotazník): zatiaľ nemáme uložené hodnoty.';
+    : isProfileStale
+      ? 'Profil je zastaraný.'
+      : 'Aktuálny profil (dotazník): zatiaľ nemáme uložené hodnoty.';
 
   const hasAiText = typeof aiRecommendation === 'string' && aiRecommendation.trim().length > 0;
   const aiSection = hasAiText
@@ -2192,6 +2197,21 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   const profileCoffeePreferences =
     (profile as unknown as { coffee_preferences?: Record<string, unknown> | null })
       ?.coffee_preferences ?? null;
+  const profileTimestamps = useMemo(() => {
+    if (!profile || typeof profile !== 'object') {
+      return { updatedAt: null, lastRecalculatedAt: null };
+    }
+    const record = profile as Partial<UserTasteProfile>;
+    const updatedAt = typeof record.updatedAt === 'string' ? record.updatedAt : null;
+    const lastRecalculatedAt =
+      typeof record.lastRecalculatedAt === 'string' ? record.lastRecalculatedAt : null;
+    return { updatedAt, lastRecalculatedAt };
+  }, [profile]);
+  const hasProfileTimestamps = Boolean(
+    profileTimestamps.updatedAt || profileTimestamps.lastRecalculatedAt,
+  );
+  const isProfileStale =
+    Boolean(scanResult?.tasteProfileRejectedAsStale) || (Boolean(profile) && !hasProfileTimestamps);
   const comparisonText = useMemo(
     () => buildComparisonText(
       evaluation,
@@ -2199,8 +2219,15 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       preferenceSnapshot?.ai_recommendation ?? null,
       profile?.preferences ?? null,
       profileCoffeePreferences,
+      isProfileStale,
     ),
-    [evaluation, preferenceSnapshot, profile?.preferences, profileCoffeePreferences],
+    [
+      evaluation,
+      preferenceSnapshot,
+      profile?.preferences,
+      profileCoffeePreferences,
+      isProfileStale,
+    ],
   );
   // Suppress compatibility scoring whenever the AI evaluation is not ready.
   const shouldSuppressCompatibility = evaluationStatus !== 'ok';

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -862,6 +862,7 @@ interface OCRResult {
   rawStructuredResponse?: unknown;
   evaluation?: CoffeeEvaluationResult | null;
   tasteProfileSent?: boolean;
+  tasteProfileRejectedAsStale?: boolean;
 }
 
 /**
@@ -1432,6 +1433,7 @@ export const processOCR = async (
       estimatedAttributes,
     );
     let tasteProfileSent = false;
+    let tasteProfileRejectedAsStale = false;
     const emptyTextEvaluation: CoffeeEvaluationResult = {
       status: 'insufficient_coffee_data',
       verdict: null,
@@ -1518,6 +1520,7 @@ export const processOCR = async (
                 console.warn(
                   'Stale taste profile detected. Retrying evaluation without taste profile.',
                 );
+                tasteProfileRejectedAsStale = true;
                 const retryPayload = { ...basePayload };
                 const retryResult = await loggedFetchWithStatusRetry(
                   `${API_URL}/ocr/evaluate`,
@@ -1657,6 +1660,7 @@ export const processOCR = async (
       rawStructuredResponse,
       evaluation,
       tasteProfileSent,
+      tasteProfileRejectedAsStale,
     };
   } catch (error) {
     console.error('OCR processing error:', error);

--- a/src/utils/__tests__/preferenceSummary.test.ts
+++ b/src/utils/__tests__/preferenceSummary.test.ts
@@ -18,4 +18,28 @@ describe('buildPreferenceSummary', () => {
     expect(result.sourceLabel).toBe('uložené preferencie');
     expect(result.summary).toBe('Kyslosť 4/10, Sladkosť 7/10, Horkosť 9/10, Telo 10/10');
   });
+
+  it('prefers stored preferences when profile is stale', () => {
+    const result = buildPreferenceSummary({
+      profilePreferences: {
+        acidity: 1,
+        sweetness: 2,
+        bitterness: 3,
+        body: 4,
+      },
+      preferenceSnapshot: {
+        taste_vector: {
+          acidity: 0.6,
+          sweetness: 0.4,
+          bitterness: 0.2,
+          body: 0.8,
+        },
+      },
+      coffeePreferences: null,
+      isProfileStale: true,
+    });
+
+    expect(result.sourceLabel).toBe('uložené preferencie');
+    expect(result.summary).toBe('Kyslosť 6/10, Sladkosť 4/10, Horkosť 2/10, Telo 8/10');
+  });
 });

--- a/src/utils/preferenceSummary.ts
+++ b/src/utils/preferenceSummary.ts
@@ -10,6 +10,7 @@ type PreferenceSummaryInput = {
   profilePreferences?: TasteVector | null;
   preferenceSnapshot?: PreferenceSnapshot | null;
   coffeePreferences?: TasteVector | null;
+  isProfileStale?: boolean;
 };
 
 type PreferenceSummaryResult = {
@@ -54,10 +55,13 @@ export const buildPreferenceSummary = ({
   profilePreferences,
   preferenceSnapshot,
   coffeePreferences,
+  isProfileStale = false,
 }: PreferenceSummaryInput): PreferenceSummaryResult => {
-  const primaryEntries = buildEntries(profilePreferences ?? null);
+  const primaryEntries = buildEntries(isProfileStale ? null : (profilePreferences ?? null));
   let entries = primaryEntries;
-  let sourceLabel: PreferenceSummaryResult['sourceLabel'] = 'dotazník';
+  let sourceLabel: PreferenceSummaryResult['sourceLabel'] = isProfileStale
+    ? 'uložené preferencie'
+    : 'dotazník';
 
   if (entries.length === 0) {
     const fallbackVector =


### PR DESCRIPTION
### Motivation
- Ensure scan comparison text and preference summaries do not incorrectly use a questionnaire profile when the server rejects a submitted taste profile as stale (HTTP 409) or when profile timestamps are missing.
- Prefer stored `preferenceSnapshot` when the active profile is stale or lacks `updatedAt`/`lastRecalculatedAt` to avoid misleading source labels and guidance.
- Surface a clear user-facing notice when a profile is considered stale instead of showing questionnaire content.

### Description
- Track stale taste profile rejections by adding `tasteProfileRejectedAsStale` to the OCR evaluation flow and returning it on `processOCR` results (`src/services/ocrServices.ts`).
- Propagate the stale flag into the scanner UI by adding `tasteProfileRejectedAsStale` to `ScanResult`, computing `isProfileStale` when timestamps are absent, and passing it to `buildComparisonText` (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`).
- Update `buildComparisonText` to prefer `preferenceSnapshot` when `isProfileStale` and to display the message `Profil je zastaraný.` when appropriate (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`).
- Change `buildPreferenceSummary` to accept `isProfileStale` and avoid labeling the source as `dotazník` when the profile is stale, preferring stored preferences; and add a unit test for this behavior (`src/utils/preferenceSummary.ts`, `src/utils/__tests__/preferenceSummary.test.ts`).

### Testing
- Added a unit test `prefers stored preferences when profile is stale` in `src/utils/__tests__/preferenceSummary.test.ts` to verify fallback to `preferenceSnapshot` and source labeling.
- No automated test suite or CI run was executed as part of this change (tests were added but not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d7e646a4832aaecf79e5b99ef321)