### PR TITLE
Handle OCR evaluations retried without taste profile

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -90,6 +90,7 @@ interface ScanResult {
   evaluation?: CoffeeEvaluationResult | null;
   tasteProfileSent?: boolean;
   tasteProfileRejectedAsStale?: boolean;
+  evaluationWithoutProfile?: boolean;
 }
 
 type ScanResultLike = ScanResult & { rawStructuredResponse?: unknown };
@@ -237,7 +238,20 @@ const buildComparisonText = (
   profilePreferences: Record<string, unknown> | null | undefined,
   coffeePreferences: Record<string, unknown> | null | undefined,
   isProfileStale: boolean,
+  evaluationWithoutProfile: boolean,
 ): string => {
+  if (evaluationWithoutProfile) {
+    const hasAiText = typeof aiRecommendation === 'string' && aiRecommendation.trim().length > 0;
+    return [
+      'Profil bol pri hodnotení vynechaný, preto sa porovnanie s profilom nezobrazuje.',
+      hasAiText
+        ? `Posledné AI zhrnutie profilu:\n${aiRecommendation.trim()}`
+        : null,
+      'Zo skenu zatiaľ nemáme dostatok údajov na porovnanie.',
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+  }
   const { summary: preferenceSummary, sourceLabel } = buildPreferenceSummary({
     profilePreferences: isProfileStale ? null : profilePreferences,
     preferenceSnapshot,
@@ -2220,6 +2234,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       profile?.preferences ?? null,
       profileCoffeePreferences,
       isProfileStale,
+      Boolean(scanResult?.evaluationWithoutProfile),
     ),
     [
       evaluation,
@@ -2227,6 +2242,7 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       profile?.preferences,
       profileCoffeePreferences,
       isProfileStale,
+      scanResult?.evaluationWithoutProfile,
     ],
   );
   // Suppress compatibility scoring whenever the AI evaluation is not ready.

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -863,6 +863,7 @@ interface OCRResult {
   evaluation?: CoffeeEvaluationResult | null;
   tasteProfileSent?: boolean;
   tasteProfileRejectedAsStale?: boolean;
+  evaluationWithoutProfile?: boolean;
 }
 
 /**
@@ -1434,6 +1435,7 @@ export const processOCR = async (
     );
     let tasteProfileSent = false;
     let tasteProfileRejectedAsStale = false;
+    let evaluationWithoutProfile = false;
     const emptyTextEvaluation: CoffeeEvaluationResult = {
       status: 'insufficient_coffee_data',
       verdict: null,
@@ -1521,6 +1523,7 @@ export const processOCR = async (
                   'Stale taste profile detected. Retrying evaluation without taste profile.',
                 );
                 tasteProfileRejectedAsStale = true;
+                evaluationWithoutProfile = true;
                 const retryPayload = { ...basePayload };
                 const retryResult = await loggedFetchWithStatusRetry(
                   `${API_URL}/ocr/evaluate`,
@@ -1661,6 +1664,7 @@ export const processOCR = async (
       evaluation,
       tasteProfileSent,
       tasteProfileRejectedAsStale,
+      evaluationWithoutProfile,
     };
   } catch (error) {
     console.error('OCR processing error:', error);


### PR DESCRIPTION
### Motivation
- Ensure the frontend knows when the OCR evaluation was retried without the user taste profile after a stale-profile `409` response so the UI can avoid showing misleading profile comparison copy. 
- Prevent displaying the label "Aktuálny profil (dotazník)" when the evaluation was performed without a profile and instead show a neutral explanation. 

### Description
- Added an `evaluationWithoutProfile` flag to the OCR result types (`OCRResult` / `ScanResult`) and wired it into the `processOCR` flow in `src/services/ocrServices.ts`. 
- Set `evaluationWithoutProfile = true` when the evaluation receives a `409` stale-profile response and the code retries without the taste profile. 
- Plumbed the new flag into `CoffeeTasteScanner` (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`) and extended `buildComparisonText` to short-circuit and render a neutral message when `evaluationWithoutProfile` is true. 
- Updated the `useMemo` call to pass `scanResult?.evaluationWithoutProfile` so the comparison text reflects the new state. 

### Testing
- No automated tests were executed for these changes. 
- Changes were limited to adding a flag and using it in UI text selection, with a commit made after local edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d956dbe0832a86225855d8f6f01a)