### PR TITLE
Add AI-based structured metadata extraction to OCR and prefer AI fields in processing

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -784,6 +784,119 @@ const normalizeTasteProfileForEvaluation = (profile) => {
   return tasteVector ? { ...profile, ...tasteVector } : profile;
 };
 
+const parseStructuredResponseJson = (content) => {
+  if (!content || typeof content !== 'string') {
+    return null;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    const match = trimmed.match(/\{[\s\S]*\}/);
+    if (!match) {
+      return null;
+    }
+    try {
+      return JSON.parse(match[0]);
+    } catch (innerError) {
+      return null;
+    }
+  }
+};
+
+const extractStructuredMetadataFromText = async (text) => {
+  if (!text || typeof text !== 'string' || text.trim().length === 0) {
+    return { structured_metadata: null, structured_confidence: null };
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return { structured_metadata: null, structured_confidence: null };
+  }
+
+  const prompt = `Z OCR textu extrahuj štruktúrované údaje o káve.
+Vráť JSON s dvomi kľúčmi: structured_metadata a structured_confidence.
+structured_metadata musí obsahovať presne tieto kľúče:
+name, roast_level, processing, origin, varietals, flavor_notes, roaster, roast_date, coffee_type, weight, brew_methods.
+Použi null, ak hodnota nie je z textu jasná. Odrody (varietals), flavor_notes a brew_methods vráť ako pole stringov.
+structured_confidence má rovnaké kľúče a obsahuje číslo 0 až 1 alebo null podľa istoty.
+Nepridávaj ďalší text, iba čistý JSON.
+
+OCR text:
+${text}`;
+
+  try {
+    console.log('📤 [OpenAI] Structured metadata prompt meta:', {
+      model: 'gpt-4o',
+      chars: prompt.length,
+    });
+    const response = await axios.post(
+      'https://api.openai.com/v1/chat/completions',
+      {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'Si expert na kávu. Extrahuješ štruktúrované údaje z OCR textu etikiet kávy.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        temperature: 0.2,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    console.log('📥 [OpenAI] Structured metadata response meta:', {
+      id: response.data?.id,
+      model: response.data?.model,
+      usage: response.data?.usage,
+    });
+
+    const content = response.data?.choices?.[0]?.message?.content || '';
+    const parsed = parseStructuredResponseJson(content);
+    if (!parsed || typeof parsed !== 'object') {
+      return { structured_metadata: null, structured_confidence: null };
+    }
+
+    const structuredMetadata =
+      parsed.structured_metadata ||
+      parsed.structuredMetadata ||
+      parsed.metadata ||
+      parsed.data ||
+      null;
+    const structuredConfidence =
+      parsed.structured_confidence ||
+      parsed.structuredConfidence ||
+      parsed.confidence ||
+      null;
+
+    const resolvedMetadata =
+      structuredMetadata && typeof structuredMetadata === 'object'
+        ? structuredMetadata
+        : parsed;
+    const resolvedConfidence =
+      structuredConfidence && typeof structuredConfidence === 'object'
+        ? structuredConfidence
+        : null;
+
+    return {
+      structured_metadata: resolvedMetadata,
+      structured_confidence: resolvedConfidence,
+    };
+  } catch (error) {
+    console.error('Structured metadata AI error:', error?.message ?? error);
+    return { structured_metadata: null, structured_confidence: null };
+  }
+};
+
 // ========== OCR ENDPOINTS ==========
 
 /**
@@ -857,7 +970,16 @@ router.post('/ocr', async (req, res) => {
       textLength: text.length,
       labelCount: labels.length,
     });
-    res.json({ text, labels, coffeeConfidence, isCoffee });
+    const { structured_metadata, structured_confidence } =
+      await extractStructuredMetadataFromText(text);
+    res.json({
+      text,
+      labels,
+      coffeeConfidence,
+      isCoffee,
+      structured_metadata,
+      structured_confidence,
+    });
   } catch (error) {
     console.error('OCR server error:', error?.message ?? error);
     res.status(500).json({ error: 'OCR failed', detail: error?.message ?? error });

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -253,6 +253,91 @@ const estimateCoffeeAttributesFromText = (
   };
 };
 
+const normalizeStructuredMetadataPayload = (
+  payload: Record<string, any> | null,
+): StructuredCoffeeMetadata | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const normalizeString = (value: unknown): string | null => {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  const normalizeStringArray = (value: unknown): string[] | null => {
+    if (Array.isArray(value)) {
+      const cleaned = value
+        .map(item => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean);
+      return cleaned.length ? cleaned : null;
+    }
+    if (typeof value === 'string') {
+      const parts = value
+        .split(/[,;\n]/)
+        .map(part => part.trim())
+        .filter(Boolean);
+      return parts.length ? parts : null;
+    }
+    return null;
+  };
+
+  const confidenceSource =
+    payload.confidenceFlags ?? payload.confidence_flags ?? payload.flags ?? null;
+
+  let confidenceFlags: StructuredCoffeeMetadata['confidenceFlags'] = null;
+  if (confidenceSource && typeof confidenceSource === 'object') {
+    confidenceFlags = {
+      roaster:
+        typeof confidenceSource.roaster === 'boolean'
+          ? confidenceSource.roaster
+          : null,
+      origin:
+        typeof confidenceSource.origin === 'boolean'
+          ? confidenceSource.origin
+          : null,
+      roastLevel:
+        typeof confidenceSource.roastLevel === 'boolean'
+          ? confidenceSource.roastLevel
+          : typeof confidenceSource.roast_level === 'boolean'
+          ? confidenceSource.roast_level
+          : null,
+      processing:
+        typeof confidenceSource.processing === 'boolean'
+          ? confidenceSource.processing
+          : null,
+      flavorNotes:
+        typeof confidenceSource.flavorNotes === 'boolean'
+          ? confidenceSource.flavorNotes
+          : typeof confidenceSource.flavor_notes === 'boolean'
+          ? confidenceSource.flavor_notes
+          : null,
+      roastDate:
+        typeof confidenceSource.roastDate === 'boolean'
+          ? confidenceSource.roastDate
+          : typeof confidenceSource.roast_date === 'boolean'
+          ? confidenceSource.roast_date
+          : null,
+      varietals:
+        typeof confidenceSource.varietals === 'boolean'
+          ? confidenceSource.varietals
+          : null,
+    };
+  }
+
+  return {
+    roaster: normalizeString(payload.roaster ?? payload.roaster_name) ?? null,
+    origin: normalizeString(payload.origin),
+    roastLevel: normalizeString(payload.roastLevel ?? payload.roast_level) ?? null,
+    processing: normalizeString(payload.processing),
+    flavorNotes: normalizeStringArray(payload.flavorNotes ?? payload.flavor_notes),
+    roastDate: normalizeString(payload.roastDate ?? payload.roast_date) ?? null,
+    varietals: normalizeStringArray(payload.varietals),
+    confidenceFlags,
+  };
+};
+
 const mergeStructuredMetadata = (
   base: StructuredCoffeeMetadata | null,
   fallback: Pick<
@@ -1192,6 +1277,8 @@ export const processOCR = async (
     const initialStructuredMetadata = safeParseJSON<Record<string, unknown>>(
       ocrData.structured_metadata ?? ocrData.structuredMetadata
     );
+    const initialNormalizedStructuredMetadata =
+      normalizeStructuredMetadataPayload(initialStructuredMetadata);
     const initialStructuredConfidence = safeParseJSON<Record<string, unknown>>(
       ocrData.structured_confidence ?? ocrData.structuredConfidence
     );
@@ -1284,96 +1371,8 @@ export const processOCR = async (
           saveData.structuredMetadata ??
           initialStructuredMetadata;
         const metadataParsed = safeParseJSON<Record<string, any>>(metadataRaw);
-        if (metadataParsed && typeof metadataParsed === 'object') {
-          const normalizeString = (value: unknown): string | null => {
-            if (typeof value !== 'string') return null;
-            const trimmed = value.trim();
-            return trimmed.length > 0 ? trimmed : null;
-          };
-
-          const normalizeStringArray = (value: unknown): string[] | null => {
-            if (Array.isArray(value)) {
-              const cleaned = value
-                .map(item => (typeof item === 'string' ? item.trim() : ''))
-                .filter(Boolean);
-              return cleaned.length ? cleaned : null;
-            }
-            if (typeof value === 'string') {
-              const parts = value
-                .split(/[,;\n]/)
-                .map(part => part.trim())
-                .filter(Boolean);
-              return parts.length ? parts : null;
-            }
-            return null;
-          };
-
-          const confidenceSource =
-            metadataParsed.confidenceFlags ??
-            metadataParsed.confidence_flags ??
-            metadataParsed.flags ??
-            null;
-
-          let confidenceFlags: StructuredCoffeeMetadata['confidenceFlags'] = null;
-          if (confidenceSource && typeof confidenceSource === 'object') {
-            confidenceFlags = {
-              roaster:
-                typeof confidenceSource.roaster === 'boolean'
-                  ? confidenceSource.roaster
-                  : null,
-              origin:
-                typeof confidenceSource.origin === 'boolean'
-                  ? confidenceSource.origin
-                  : null,
-              roastLevel:
-                typeof confidenceSource.roastLevel === 'boolean'
-                  ? confidenceSource.roastLevel
-                  : typeof confidenceSource.roast_level === 'boolean'
-                  ? confidenceSource.roast_level
-                  : null,
-              processing:
-                typeof confidenceSource.processing === 'boolean'
-                  ? confidenceSource.processing
-                  : null,
-              flavorNotes:
-                typeof confidenceSource.flavorNotes === 'boolean'
-                  ? confidenceSource.flavorNotes
-                  : typeof confidenceSource.flavor_notes === 'boolean'
-                  ? confidenceSource.flavor_notes
-                  : null,
-              roastDate:
-                typeof confidenceSource.roastDate === 'boolean'
-                  ? confidenceSource.roastDate
-                  : typeof confidenceSource.roast_date === 'boolean'
-                  ? confidenceSource.roast_date
-                  : null,
-              varietals:
-                typeof confidenceSource.varietals === 'boolean'
-                  ? confidenceSource.varietals
-                  : null,
-            };
-          }
-
-          structuredMetadata = {
-            roaster:
-              normalizeString(metadataParsed.roaster ?? metadataParsed.roaster_name) ??
-              null,
-            origin: normalizeString(metadataParsed.origin),
-            roastLevel:
-              normalizeString(metadataParsed.roastLevel ?? metadataParsed.roast_level) ??
-              null,
-            processing: normalizeString(metadataParsed.processing),
-            flavorNotes:
-              normalizeStringArray(
-                metadataParsed.flavorNotes ?? metadataParsed.flavor_notes
-              ),
-            roastDate:
-              normalizeString(metadataParsed.roastDate ?? metadataParsed.roast_date) ??
-              null,
-            varietals: normalizeStringArray(metadataParsed.varietals),
-            confidenceFlags,
-          };
-
+        structuredMetadata = normalizeStructuredMetadataPayload(metadataParsed);
+        if (structuredMetadata) {
           rawStructuredResponse = metadataParsed;
         }
 
@@ -1389,6 +1388,15 @@ export const processOCR = async (
           rawStructuredResponse = metadataRaw ?? null;
         }
       }
+    }
+    if (!structuredMetadata && initialNormalizedStructuredMetadata) {
+      structuredMetadata = initialNormalizedStructuredMetadata;
+      if (rawStructuredResponse == null) {
+        rawStructuredResponse = initialStructuredMetadata;
+      }
+    }
+    if (!structuredConfidence && initialStructuredConfidence) {
+      structuredConfidence = initialStructuredConfidence;
     }
     const fallbackEvaluation: CoffeeEvaluationResult = {
       status: 'unknown',
@@ -1428,10 +1436,12 @@ export const processOCR = async (
 
     // 4. Získaj AI hodnotenie a návrhy metód súčasne
     const estimatedAttributes = estimateCoffeeAttributesFromText(trimmedCorrectedText);
-    const evaluationStructuredMetadata = mergeStructuredMetadata(
+    const mergedStructuredMetadata = mergeStructuredMetadata(
       structuredMetadata,
       estimatedAttributes,
     );
+    structuredMetadata = mergedStructuredMetadata;
+    const evaluationStructuredMetadata = mergedStructuredMetadata;
     let tasteProfileSent = false;
     let tasteProfileRejectedAsStale = false;
     const emptyTextEvaluation: CoffeeEvaluationResult = {


### PR DESCRIPTION
### Motivation

- Extract richer, structured coffee metadata from raw OCR text using an AI step so downstream evaluation can rely on explicit fields like `name`, `roast_level`, `processing`, `origin`, `varietals`, `flavor_notes`, `roaster`, `roast_date`, `coffee_type`, `weight`, and `brew_methods`.
- Surface AI-derived `structured_metadata` and `structured_confidence` from the backend OCR endpoint so the frontend can prefer AI results over brittle heuristics.
- Normalize and validate AI/BE structured payloads centrally to avoid inconsistent formats across sources.
- Use the existing local heuristic only as a fallback when AI/BE metadata is missing or incomplete.

### Description

- Added `parseStructuredResponseJson` and `extractStructuredMetadataFromText` to `server/routes/ocr.js` which call the OpenAI chat API and return `structured_metadata` and `structured_confidence` alongside the OCR `text`, `labels`, `coffeeConfidence`, and `isCoffee` in the `/ocr` response.
- Added `normalizeStructuredMetadataPayload` to `src/services/ocrServices.ts` to normalize AI/BE structured metadata (strings, arrays, and `confidenceFlags`) into the `StructuredCoffeeMetadata` shape.
- Updated OCR processing in `src/services/ocrServices.ts` to prefer normalized AI/BE structured metadata (`initialNormalizedStructuredMetadata`) and fall back to the local `estimateCoffeeAttributesFromText` heuristic; merged results are assigned to `structuredMetadata` and sent to the evaluation endpoint.
- Replaced inline ad-hoc normalization logic with the centralized `normalizeStructuredMetadataPayload` and ensured `structured_confidence` is preserved when provided by BE/AI.

### Testing

- No automated tests were run as part of this change.
- Manual runtime logging was added around the OpenAI calls to aid debugging in integration tests.
- Existing evaluation and save flows were preserved and adapted to use normalized structured payloads without altering endpoint contracts.
- Integration with the evaluation endpoint remains unchanged aside from sending the merged `structured_metadata` payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963db89fa4c832a96e57fb4d9b1b0fd)