### PR TITLE
Adjust scan comparison copy for partial coffee profiles

### DIFF
--- a/src/utils/scanPreferenceComparison.ts
+++ b/src/utils/scanPreferenceComparison.ts
@@ -267,10 +267,35 @@ const fillFromVerdictExplanation = (
   }
 };
 
+const hasCoffeeProfileSignals = (evaluation: CoffeeEvaluationResult | null | undefined): boolean => {
+  if (!evaluation || typeof evaluation.verdict_explanation !== 'object') {
+    return false;
+  }
+  const coffeeSummary = evaluation.verdict_explanation.coffee_profile_summary;
+  if (typeof coffeeSummary !== 'string' || !coffeeSummary.trim()) {
+    return false;
+  }
+  const lower = coffeeSummary.toLowerCase();
+  return [
+    'pôvod',
+    'povod',
+    'pražen',
+    'prazen',
+    'spracovan',
+    'odrod',
+    'varietal',
+    'tóny',
+    'tony',
+    'chuť',
+    'chut',
+  ].some((keyword) => lower.includes(keyword));
+};
+
 const buildDimensionLine = (
   config: DimensionConfig,
   preferenceLevel: TasteLevel | null,
   coffeeLevel: TasteLevel | null,
+  hasCoffeeSignals: boolean,
 ): string | null => {
   if (!preferenceLevel && !coffeeLevel) {
     return null;
@@ -287,7 +312,9 @@ const buildDimensionLine = (
     return `Profil preferuje ${preferenceAdj} ${config.noun}, káva má ${coffeeAdj} → ${MATCH_LABELS[match]}.`;
   }
   if (preferenceAdj) {
-    return `Profil preferuje ${preferenceAdj} ${config.noun}, no profil kávy je nejasný.`;
+    return hasCoffeeSignals
+      ? `Profil preferuje ${preferenceAdj} ${config.noun}, no profil kávy je dostupný čiastočne.`
+      : `Profil preferuje ${preferenceAdj} ${config.noun}, no profil kávy je nejasný.`;
   }
   if (coffeeAdj) {
     return `Káva má ${coffeeAdj} ${config.noun}, no preferencia nie je známa.`;
@@ -310,6 +337,7 @@ export const buildScanPreferenceComparison = (
 
   const reasonLevelMap = buildReasonLevelMap(evaluation);
   fillFromVerdictExplanation(evaluation, reasonLevelMap);
+  const hasCoffeeSignals = hasCoffeeProfileSignals(evaluation);
 
   const dimensions = DIMENSIONS.map(config => {
     const rawPreferenceValue = normalizedTasteVector?.[config.key] ?? null;
@@ -317,7 +345,7 @@ export const buildScanPreferenceComparison = (
       ? scoreToLevel(rawPreferenceValue)
       : reasonLevelMap[config.key].preferenceLevel;
     const coffeeLevel = reasonLevelMap[config.key].coffeeLevel;
-    const line = buildDimensionLine(config, preferenceLevel, coffeeLevel);
+    const line = buildDimensionLine(config, preferenceLevel, coffeeLevel, hasCoffeeSignals);
     const match = preferenceLevel && coffeeLevel
       ? preferenceLevel === coffeeLevel
         ? 'match'


### PR DESCRIPTION
### Motivation
- Avoid showing the label "nejasné" for coffee profile dimensions when the evaluation already contains partial coffee attributes. 
- When we have origin/roast/processing/varietal or similar signals, convey that the profile is partially available instead of fully unclear. 
- Keep user-facing comparison lines more informative and consistent with backend evaluation summaries. 

### Description
- Added `hasCoffeeProfileSignals` helper in `src/utils/scanPreferenceComparison.ts` to detect partial coffee attributes in `verdict_explanation.coffee_profile_summary`. 
- Extended `buildDimensionLine` to accept a `hasCoffeeSignals` flag and branch the copy accordingly. 
- When only preference side is present but there are coffee signals, replace the line `"...profil kávy je nejasný."` with `"...profil kávy je dostupný čiastočne."`. 
- Updated mapping call site to compute and pass `hasCoffeeSignals` into `buildDimensionLine` for each dimension. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e5ba2e3c832ab1285f873c2bfdf8)