### PR TITLE
Add `dimension_diffs` to evaluation response and show under verdict

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2271,6 +2271,41 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     const rounded = Math.round(Math.max(0, Math.min(100, normalized)));
     return `${rounded}% istota`;
   }, [evaluation]);
+  const dimensionDiffs = useMemo(() => {
+    const diffs = evaluation?.dimension_diffs ?? [];
+    const labelMap: Record<string, string> = {
+      acidity: 'Acidita',
+      sweetness: 'Sladkosť',
+      bitterness: 'Horkosť',
+      body: 'Telo',
+    };
+
+    return diffs
+      .map((diff, index) => {
+        if (!diff) {
+          return null;
+        }
+        const label = labelMap[diff.dimension] ?? diff.dimension;
+        const percent =
+          typeof diff.percent === 'number' ? `${Math.round(diff.percent)}%` : null;
+        const explanation = diff.explanation?.trim() ?? '';
+        if (!label || (!percent && !explanation)) {
+          return null;
+        }
+        return {
+          key: `${diff.dimension}-${index}`,
+          label,
+          percent,
+          explanation,
+        };
+      })
+      .filter(
+        (
+          entry
+        ): entry is { key: string; label: string; percent: string | null; explanation: string } =>
+          Boolean(entry),
+      );
+  }, [evaluation?.dimension_diffs]);
   const refreshControl =
     currentView === 'home'
       ? (
@@ -3314,6 +3349,24 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                             <Text style={styles.verdictConfidence}>{evaluationConfidenceLabel}</Text>
                           ) : null}
                           <Text style={styles.verdictDescription}>{verdictExplanation}</Text>
+                          {dimensionDiffs.length ? (
+                            <View style={styles.verdictDiffs}>
+                              <Text style={styles.verdictDiffsTitle}>Rozdiely v chutiach</Text>
+                              {dimensionDiffs.map(diff => (
+                                <View key={diff.key} style={styles.verdictDiffRow}>
+                                  <View style={styles.verdictDiffHeader}>
+                                    <Text style={styles.verdictDiffLabel}>{diff.label}</Text>
+                                    {diff.percent ? (
+                                      <Text style={styles.verdictDiffPercent}>{diff.percent}</Text>
+                                    ) : null}
+                                  </View>
+                                  {diff.explanation ? (
+                                    <Text style={styles.verdictDiffExplanation}>{diff.explanation}</Text>
+                                  ) : null}
+                                </View>
+                              ))}
+                            </View>
+                          ) : null}
                           {lowDataWarning ? (
                             <View style={styles.lowDataCard}>
                               <View style={styles.lowDataBadge}>

--- a/src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts
+++ b/src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts
@@ -635,6 +635,47 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       color: palette.textSecondary,
       lineHeight: 20,
     },
+    verdictDiffs: {
+      marginTop: 12,
+      paddingTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: palette.borderLight,
+      gap: 10,
+    },
+    verdictDiffsTitle: {
+      fontSize: 14,
+      fontWeight: '700',
+      color: palette.textPrimary,
+    },
+    verdictDiffRow: {
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: palette.borderLight,
+      backgroundColor: palette.surfaceElevated,
+    },
+    verdictDiffHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 4,
+    },
+    verdictDiffLabel: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: palette.textPrimary,
+    },
+    verdictDiffPercent: {
+      fontSize: 12,
+      fontWeight: '700',
+      color: palette.textSecondary,
+    },
+    verdictDiffExplanation: {
+      fontSize: 12,
+      color: palette.textSecondary,
+      lineHeight: 18,
+    },
     comparisonText: {
       fontSize: 13,
       color: palette.textSecondary,

--- a/src/services/ocrServices.ts
+++ b/src/services/ocrServices.ts
@@ -184,6 +184,62 @@ const normalizeEvaluationReasons = (value: unknown): CoffeeEvaluationReason[] =>
     .filter((entry): entry is CoffeeEvaluationReason => Boolean(entry));
 };
 
+const normalizePercentValue = (value: unknown): number | null => {
+  const raw =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value.replace(',', '.'))
+        : NaN;
+  if (!Number.isFinite(raw)) {
+    return null;
+  }
+  const scaled = raw <= 1 ? raw * 100 : raw;
+  const bounded = Math.max(0, Math.min(100, scaled));
+  return Number.isFinite(bounded) ? bounded : null;
+};
+
+const normalizeEvaluationDimensionDiffs = (value: unknown): CoffeeEvaluationDimensionDiff[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const record = entry as Record<string, unknown>;
+      const dimension =
+        typeof record.dimension === 'string'
+          ? record.dimension
+          : typeof record.key === 'string'
+            ? record.key
+            : '';
+      const explanation =
+        typeof record.explanation === 'string'
+          ? record.explanation
+          : typeof record.description === 'string'
+            ? record.description
+            : '';
+      const percent = normalizePercentValue(
+        record.percent ??
+          record.percentage ??
+          record.diff_percent ??
+          record.difference_percent
+      );
+      if (!dimension || (!explanation && percent == null)) {
+        return null;
+      }
+      return {
+        dimension,
+        percent,
+        explanation,
+      };
+    })
+    .filter((entry): entry is CoffeeEvaluationDimensionDiff => Boolean(entry));
+};
+
 const normalizeStringArray = (value: unknown): string[] => {
   if (!Array.isArray(value)) {
     return [];
@@ -743,6 +799,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
   const normalizedInsight =
     normalizeEvaluationInsight(record.insight) ??
     (fallbackInsightSections.length ? { headline: '', sections: fallbackInsightSections } : null);
+  const dimensionDiffs = normalizeEvaluationDimensionDiffs(record.dimension_diffs);
   if (normalizedStatus === 'profile_missing') {
     // Preserve profile-missing payloads so the UI can display the CTA and guidance text.
     return {
@@ -755,6 +812,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       what_might_bother_you: whatMightBotherYou,
       tips_to_make_it_better: tipsToMakeItBetter,
       recommended_brew_methods: recommendedBrewMethods,
+      dimension_diffs: dimensionDiffs,
       cta: {
         action:
           record.cta && typeof record.cta === 'object' && record.cta.action === 'complete_taste_profile'
@@ -786,6 +844,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
       what_might_bother_you: whatMightBotherYou,
       tips_to_make_it_better: tipsToMakeItBetter,
       recommended_brew_methods: recommendedBrewMethods,
+      dimension_diffs: dimensionDiffs,
       cta: { action: null, label: null },
       disclaimer: useNeutralCopy
         ? normalizeEvaluationText(record.disclaimer, NEUTRAL_EVALUATION_COPY.disclaimer)
@@ -813,6 +872,7 @@ const normalizeEvaluationResponse = (payload: unknown): CoffeeEvaluationResult =
     confidence: confidenceValue,
     summary,
     reasons,
+    dimension_diffs: dimensionDiffs,
     what_youll_like: whatYoullLike,
     what_might_bother_you: whatMightBotherYou,
     tips_to_make_it_better: tipsToMakeItBetter,
@@ -882,6 +942,12 @@ export interface CoffeeEvaluationReason {
   explanation: string;
 }
 
+export interface CoffeeEvaluationDimensionDiff {
+  dimension: string;
+  percent: number | null;
+  explanation: string;
+}
+
 export interface CoffeeEvaluationCta {
   action: 'complete_taste_profile' | null;
   label: string | null;
@@ -903,6 +969,7 @@ export interface CoffeeEvaluationResult {
   confidence: number | null;
   summary: string;
   reasons: CoffeeEvaluationReason[];
+  dimension_diffs: CoffeeEvaluationDimensionDiff[];
   what_youll_like: string[];
   what_might_bother_you: string[];
   tips_to_make_it_better: string[];
@@ -1404,6 +1471,7 @@ export const processOCR = async (
       confidence: null,
       summary: NEUTRAL_EVALUATION_COPY.summary,
       reasons: [],
+      dimension_diffs: [],
       what_youll_like: [],
       what_might_bother_you: [],
       tips_to_make_it_better: [],
@@ -1421,6 +1489,7 @@ export const processOCR = async (
       confidence: null,
       summary: 'Hodnotenie kávy je momentálne nedostupné.',
       reasons: [],
+      dimension_diffs: [],
       what_youll_like: [],
       what_might_bother_you: [],
       tips_to_make_it_better: [],
@@ -1450,6 +1519,7 @@ export const processOCR = async (
       confidence: null,
       summary: 'Z etikety nebolo možné prečítať text.',
       reasons: [],
+      dimension_diffs: [],
       what_youll_like: [],
       what_might_bother_you: [],
       tips_to_make_it_better: [],


### PR DESCRIPTION
### Motivation
- The evaluation API should expose per-dimension differences (e.g., acidity/sweetness/bitterness/body) with explanations and percentages for the FE to present under the verdict.
- Provide a robust normalization layer so the app can handle different incoming shapes and percent formats from the backend.
- Surface these diffs in the scanner UI beneath the verdict to improve clarity about how the coffee differs from the user profile.

### Description
- Added `normalizeEvaluationDimensionDiffs` and `normalizePercentValue` helpers and a `CoffeeEvaluationDimensionDiff` type in `src/services/ocrServices.ts` to parse and sanitize `dimension_diffs` from the evaluate response.
- Extended `normalizeEvaluationResponse` and fallback evaluation objects to include `dimension_diffs` so the field is always present on `CoffeeEvaluationResult`.
- Rendered the normalized diffs in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` via a `dimensionDiffs` `useMemo` and added a UI block under the verdict card to display label, percent and explanation.
- Added corresponding styles in `src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts` for the new diffs section.

### Testing
- No automated tests were run for this change.
- Manual visual verification of the new UI block was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ef219f58832a97bf5c5e04d68c69)