### PR TITLE
Normalize localized coffee labels in UI

### DIFF
--- a/src/screens/AllCoffeesScreen/AllCoffeesScreen.tsx
+++ b/src/screens/AllCoffeesScreen/AllCoffeesScreen.tsx
@@ -17,6 +17,7 @@ import BottomNav, {
 } from '../../components/navigation/BottomNav';
 import type { NavItem } from '../../components/navigation/BottomNav';
 import type { Coffee } from '../../types/Coffee';
+import { resolveLocalizedLabel } from '../../utils/localization';
 
 type CoffeeLibraryMode = 'all' | 'favorites';
 
@@ -102,8 +103,9 @@ const CoffeeLibraryScreen: React.FC<CoffeeLibraryInternalProps> = ({
   const brandOptions = useMemo(() => {
     const values = new Set<string>();
     coffees.forEach((coffee) => {
-      if (coffee.brand) {
-        values.add(coffee.brand);
+      const normalized = resolveLocalizedLabel(coffee.brand);
+      if (normalized) {
+        values.add(normalized);
       }
     });
     return Array.from(values).sort((a, b) => a.localeCompare(b));
@@ -112,8 +114,9 @@ const CoffeeLibraryScreen: React.FC<CoffeeLibraryInternalProps> = ({
   const processOptions = useMemo(() => {
     const values = new Set<string>();
     coffees.forEach((coffee) => {
-      if (coffee.process) {
-        values.add(coffee.process);
+      const normalized = resolveLocalizedLabel(coffee.process);
+      if (normalized) {
+        values.add(normalized);
       }
     });
     return Array.from(values).sort((a, b) => a.localeCompare(b));
@@ -122,8 +125,9 @@ const CoffeeLibraryScreen: React.FC<CoffeeLibraryInternalProps> = ({
   const varietyOptions = useMemo(() => {
     const values = new Set<string>();
     coffees.forEach((coffee) => {
-      if (coffee.variety) {
-        values.add(coffee.variety);
+      const normalized = resolveLocalizedLabel(coffee.variety);
+      if (normalized) {
+        values.add(normalized);
       }
     });
     return Array.from(values).sort((a, b) => a.localeCompare(b));
@@ -256,16 +260,22 @@ const CoffeeLibraryScreen: React.FC<CoffeeLibraryInternalProps> = ({
                 {coffee.isFavorite ? <Text style={styles.favoriteBadge}>❤️</Text> : null}
               </View>
               {coffee.brand ? (
-                <Text style={baseStyles.coffeeOrigin}>{coffee.brand}</Text>
+                <Text style={baseStyles.coffeeOrigin}>
+                  {resolveLocalizedLabel(coffee.brand)}
+                </Text>
               ) : null}
               {coffee.origin ? (
                 <Text style={baseStyles.coffeeOrigin}>{coffee.origin}</Text>
               ) : null}
               {coffee.process ? (
-                <Text style={baseStyles.coffeeOrigin}>Proces: {coffee.process}</Text>
+                <Text style={baseStyles.coffeeOrigin}>
+                  Proces: {resolveLocalizedLabel(coffee.process)}
+                </Text>
               ) : null}
               {coffee.variety ? (
-                <Text style={baseStyles.coffeeOrigin}>Odroda: {coffee.variety}</Text>
+                <Text style={baseStyles.coffeeOrigin}>
+                  Odroda: {resolveLocalizedLabel(coffee.variety)}
+                </Text>
               ) : null}
               {coffee.flavorNotes && coffee.flavorNotes.length > 0 ? (
                 <Text style={baseStyles.coffeeOrigin}>
@@ -459,21 +469,21 @@ const applyCoffeeFilter = (
 
     if (
       selectedBrand !== ALL_OPTION_VALUE &&
-      (coffee.brand ?? '').toLowerCase() !== selectedBrand.toLowerCase()
+      resolveLocalizedLabel(coffee.brand)?.toLowerCase() !== selectedBrand.toLowerCase()
     ) {
       return false;
     }
 
     if (
       selectedProcess !== ALL_OPTION_VALUE &&
-      (coffee.process ?? '').toLowerCase() !== selectedProcess.toLowerCase()
+      resolveLocalizedLabel(coffee.process)?.toLowerCase() !== selectedProcess.toLowerCase()
     ) {
       return false;
     }
 
     if (
       selectedVariety !== ALL_OPTION_VALUE &&
-      (coffee.variety ?? '').toLowerCase() !== selectedVariety.toLowerCase()
+      resolveLocalizedLabel(coffee.variety)?.toLowerCase() !== selectedVariety.toLowerCase()
     ) {
       return false;
     }

--- a/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
+++ b/src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { fetchCoffeeById } from '../../services/homePagesService';
 import type { Coffee } from '../../types/Coffee';
+import { resolveLocalizedLabel } from '../../utils/localization';
 
 /**
  * Screen displaying detailed information about a single scanned coffee.
@@ -73,12 +74,14 @@ const ScannedCoffeeDetailScreen: React.FC<{ coffeeId: string; onBack: () => void
         ← Späť
       </Text>
       <Text style={styles.title}>{coffee.name}</Text>
-      {coffee.brand ? <Text style={styles.subtitle}>{coffee.brand}</Text> : null}
+      {coffee.brand ? (
+        <Text style={styles.subtitle}>{resolveLocalizedLabel(coffee.brand)}</Text>
+      ) : null}
 
       <View style={styles.card}>
         <DetailRow label="Pôvod" value={coffee.origin} />
-        <DetailRow label="Proces" value={coffee.process} />
-        <DetailRow label="Odroda" value={coffee.variety} />
+        <DetailRow label="Proces" value={resolveLocalizedLabel(coffee.process)} />
+        <DetailRow label="Odroda" value={resolveLocalizedLabel(coffee.variety)} />
         <DetailRow label="Praženie" value={coffee.roastLevel} />
         <DetailRow
           label="Intenzita"

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -1,0 +1,54 @@
+const DEFAULT_LOCALE = 'sk-SK';
+
+const getDeviceLocale = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().locale || DEFAULT_LOCALE;
+  } catch (error) {
+    console.warn('Unable to resolve device locale, using default.', error);
+    return DEFAULT_LOCALE;
+  }
+};
+
+const normalizeLocale = (locale: string): string => locale.split(/[-_]/)[0]?.toLowerCase() ?? '';
+
+const uniqParts = (parts: string[]): string[] => {
+  const seen = new Set<string>();
+  return parts.filter((part) => {
+    const key = part.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+};
+
+export const resolveLocalizedLabel = (
+  value: string | null | undefined,
+  locale: string = getDeviceLocale(),
+): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const parts = uniqParts(
+    value
+      .split('/')
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
+
+  if (parts.length <= 1) {
+    return value.trim();
+  }
+
+  const language = normalizeLocale(locale);
+
+  if (language === 'en') {
+    return parts[1] ?? parts[0];
+  }
+
+  return parts[0];
+};
+
+export const getResolvedLocale = (): string => getDeviceLocale();


### PR DESCRIPTION
### Motivation
- Normalize slash-delimited labels like `Zrnková / Whole bean / ...` so the app shows a single, locale-appropriate variant (e.g. `Zrnková` for Slovak). 
- Deduplicate filter lists and avoid confusing duplicate entries in pickers caused by multi-language label payloads. 
- Ensure filtering and detail views compare and display the same localized label form for a consistent UX.

### Description
- Add `src/utils/localization.ts` with `resolveLocalizedLabel` and `getResolvedLocale` to parse, dedupe and select the correct slash-delimited part based on device locale. 
- Update `src/screens/AllCoffeesScreen/AllCoffeesScreen.tsx` to build `brand`, `process`, and `variety` picker options using `resolveLocalizedLabel`, display localized labels in coffee cards, and compare localized values in `applyCoffeeFilter`. 
- Update `src/screens/ScannedCoffeeDetailScreen/ScannedCoffeeDetailScreen.tsx` to display localized `brand`, `process`, and `variety` values in the detail view. 
- Use `Set`-based de-duplication and `localeCompare` sorting when assembling normalized picker options.

### Testing
- No automated tests were executed as part of this change. 
- Changes were limited to UI formatting and in-memory filtering helpers and should be covered by existing UI/integration tests where present. 
- Manual verification recommended on devices/emulators with different locales (e.g. `sk-SK` and `en-*`) to confirm label selection. 
- Type-checking and linting should be run in CI before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f2f4ebd8832a92eca8dfae5b37a3)