### PR TITLE
Extend calculateMatch to use structured metadata and pass structured data from OCR

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -72,17 +72,20 @@ const INSUFFICIENT_COFFEE_DATA_RESPONSE = {
 };
 
 const buildDeterministicFallbackResponse = ({ preferences, coffeeAttributes, correctedText }) => {
-  const safePreferences = preferences || {};
-  const matchScore = calculateMatch(correctedText || '', safePreferences);
-  const normalizedScore =
-    typeof matchScore === 'number' && Number.isFinite(matchScore) ? matchScore : 50;
-  const verdict = normalizedScore >= 75 ? 'suitable' : 'not_suitable';
-  const confidence = Number((normalizedScore / 100).toFixed(2));
-
   const structured =
     coffeeAttributes && typeof coffeeAttributes === 'object'
       ? coffeeAttributes.structured_metadata || {}
       : {};
+  const safePreferences = preferences || {};
+  const matchScore = calculateMatch(
+    correctedText || '',
+    safePreferences,
+    structured
+  );
+  const normalizedScore =
+    typeof matchScore === 'number' && Number.isFinite(matchScore) ? matchScore : 50;
+  const verdict = normalizedScore >= 75 ? 'suitable' : 'not_suitable';
+  const confidence = Number((normalizedScore / 100).toFixed(2));
   const origin = coffeeAttributes?.origin ?? structured?.origin;
   const roastLevel =
     coffeeAttributes?.roast_level ?? coffeeAttributes?.roastLevel ?? structured?.roast_level;
@@ -1290,8 +1293,18 @@ router.post('/api/ocr/save', async (req, res) => {
     const isProfileComplete = Boolean(
       preferences?.is_complete ?? preferences?.taste_profile_completed ?? false
     );
+    const structuredMatchMetadata = {
+      origin: normalizedOriginInput ?? structured.origin ?? derivedAttributes.origin,
+      roast_level:
+        normalizedRoastLevelInput ??
+        structured.roast_level ??
+        structured.roastLevel ??
+        derivedAttributes.roast_level,
+      processing: normalizedProcessingInput ?? structured.processing ?? derivedAttributes.processing,
+      varietals: normalizedVarietalsInput ?? structured.varietals ?? derivedAttributes.varietals,
+    };
     const matchPercentage = isProfileComplete
-      ? calculateMatch(corrected_text, preferences)
+      ? calculateMatch(corrected_text, preferences, structuredMatchMetadata)
       : null;
     const isRecommended = matchPercentage !== null ? matchPercentage > 75 : false;
     const coffeeName = extractCoffeeName(corrected_text || original_text);

--- a/server/utils/coffee.js
+++ b/server/utils/coffee.js
@@ -2,9 +2,10 @@
  * Vypočíta percentuálnu zhodu medzi opisom kávy a preferenciami používateľa.
  * @param {string} coffeeText - Textový opis kávy.
  * @param {object} preferences - Preferencie používateľa z databázy.
+ * @param {object} [structuredMetadata] - Štruktúrované metadáta kávy (origin, processing, roast_level, varietals).
  * @returns {number | null} Hodnota zhody v percentách alebo null pri neúplných preferenciách.
  */
-export const calculateMatch = (coffeeText, preferences) => {
+export const calculateMatch = (coffeeText, preferences, structuredMetadata = null) => {
   if (!preferences) return null;
 
   const hasCompletionFlag =
@@ -43,7 +44,75 @@ export const calculateMatch = (coffeeText, preferences) => {
 
   if (!passesCompletionCheck) return null;
 
-  const lower = (coffeeText || '').toLowerCase();
+  const normalizeStructuredValue = (value) =>
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  const normalizeStructuredList = (value) => {
+    if (Array.isArray(value)) {
+      return value
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter(Boolean);
+    }
+    if (typeof value === 'string') {
+      return value
+        .split(/[,;\n]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+    return [];
+  };
+
+  const structured = structuredMetadata && typeof structuredMetadata === 'object'
+    ? structuredMetadata
+    : null;
+  const structuredOrigin = normalizeStructuredValue(structured?.origin);
+  const structuredProcessing = normalizeStructuredValue(structured?.processing);
+  const structuredRoastLevel = normalizeStructuredValue(
+    structured?.roast_level ?? structured?.roastLevel
+  );
+  const structuredVarietals = normalizeStructuredList(structured?.varietals);
+
+  const derivedSignals = [];
+  const roastLower = structuredRoastLevel?.toLowerCase() ?? '';
+  if (roastLower) {
+    if (/(light|blonde|svetl|light roast|omni)/.test(roastLower)) {
+      derivedSignals.push('light', 'mild', 'bright');
+    }
+    if (/(medium|stred|omni)/.test(roastLower)) {
+      derivedSignals.push('medium', 'balanced');
+    }
+    if (/(dark|espresso|tmav)/.test(roastLower)) {
+      derivedSignals.push('dark', 'bold', 'strong', 'intense');
+    }
+  }
+
+  const processingLower = structuredProcessing?.toLowerCase() ?? '';
+  if (processingLower) {
+    if (/(natural|dry)/.test(processingLower)) {
+      derivedSignals.push('sweet', 'berry', 'fruit');
+    }
+    if (/(honey|pulped)/.test(processingLower)) {
+      derivedSignals.push('sweet', 'caramel');
+    }
+    if (/(washed|wet)/.test(processingLower)) {
+      derivedSignals.push('bright', 'citrus', 'clean');
+    }
+    if (/(anaerobic|ferment)/.test(processingLower)) {
+      derivedSignals.push('intense', 'fruit');
+    }
+  }
+
+  const structuredText = [
+    coffeeText,
+    structuredOrigin,
+    structuredProcessing,
+    structuredRoastLevel,
+    ...structuredVarietals,
+    ...derivedSignals,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const lower = structuredText.toLowerCase();
 
   const weights = {
     strength: 25,


### PR DESCRIPTION
### Motivation
- Improve match scoring by incorporating explicit structured coffee metadata (origin, processing, roast_level, varietals) in addition to OCR text. 
- Allow OCR evaluation paths (deterministic fallback and saved scans) to provide structured signals when available. 
- Derive simple taste/strength signals from roast and processing to boost matching accuracy. 
- Keep behavior compatible when structured metadata is absent by falling back to text-only matching.

### Description
- Updated `calculateMatch` signature to `calculateMatch(coffeeText, preferences, structuredMetadata)` and added normalization helpers for structured fields. 
- Folded structured fields and derived signals (from `roast_level` and `processing`) into a combined `structuredText` that is used alongside OCR text for keyword matching. 
- Updated `server/routes/ocr.js` to pass `structured` metadata into the deterministic fallback call to `calculateMatch` and to build a `structuredMatchMetadata` object for the main `/api/ocr/save` flow. 
- Changes touch `server/utils/coffee.js` and `server/routes/ocr.js` and preserve previous behavior when no structured data is present.

### Testing
- No automated tests were run as part of this change. 
- Manual verification was not recorded in automated test logs. 
- No test failures reported (no tests executed). 
- Run-time behavior should remain unchanged for text-only inputs and use structured signals when provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f48a1a1c832a8fd2d671bc3ce9b7)