### PR TITLE
Adjust acidity and sweetness from fruit flavor notes

### DIFF
--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -33,6 +33,8 @@ const DEFAULT_PROFILE_CONFIDENCE_THRESHOLD = 0.4;
 
 const fruitKeywords = ['fruit', 'fruity', 'berry', 'berries', 'citrus', 'orange', 'lemon', 'lime', 'apple', 'pear', 'peach', 'stone', 'wine'];
 const warmAromaKeywords = ['chocolate', 'cocoa', 'nut', 'nutty', 'caramel', 'spice', 'spicy', 'vanilla', 'floral', 'flower'];
+const citrusBerryKeywords = ['citrus', 'orange', 'lemon', 'lime', 'grapefruit', 'berry', 'berries', 'raspberry', 'strawberry', 'blueberry'];
+const fruitSweetnessKeywords = ['fruit', 'fruity', 'apple', 'pear', 'peach', 'stone', 'mango', 'pineapple', 'melon', 'plum', 'cherry'];
 
 /**
  * Restricts a numeric value to the provided minimum and maximum range for radar charts.
@@ -469,6 +471,23 @@ function mergeFruitiness(existing: number, incoming: number | null, notes: strin
   return clamp(existing);
 }
 
+function applyFruitFlavorAdjustments(base: TasteRadarScores, notes: string[]): void {
+  if (!notes.length) {
+    return;
+  }
+
+  const normalizedNotes = Array.from(new Set(notes.map(note => note.toLowerCase())));
+  const hasCitrusBerry = normalizedNotes.some(note => citrusBerryKeywords.some(keyword => note.includes(keyword)));
+  const hasFruitSweetness = normalizedNotes.some(note => fruitSweetnessKeywords.some(keyword => note.includes(keyword)));
+
+  if (hasCitrusBerry) {
+    base.acidity = clamp(base.acidity + 0.4);
+  }
+  if (hasFruitSweetness) {
+    base.sweetness = clamp(base.sweetness + 0.3);
+  }
+}
+
 /**
  * Builds composite taste radar scores by blending stored profile data with recent preference inputs.
  *
@@ -544,6 +563,7 @@ export function buildTasteRadarScores({ profile, preferences }: TasteRadarSource
     const { aroma, fruitiness } = evaluateFlavorNotes(preferences.flavorNotes);
     base.aroma = aroma === null ? blend(base.aroma, clamp(DEFAULT_SCORE + preferences.flavorNotes.length * 0.6)) : blend(base.aroma, aroma, 1.5);
     base.fruitiness = mergeFruitiness(base.fruitiness, fruitiness, preferences.flavorNotes);
+    applyFruitFlavorAdjustments(base, preferences.flavorNotes);
 
     if (preferences.preferredDrinks.includes('espresso') || preferences.preferredDrinks.includes('ristretto')) {
       base.body = blend(base.body, clamp(base.body + 1.2));


### PR DESCRIPTION
### Motivation

- Map fruit-related flavor notes to small adjustments in the taste radar so flavor text affects acidity and sweetness.
- Detect citrus/berry signals to increase perceived acidity and detect general fruit signals to increase perceived sweetness.
- Use normalized flavor note lists (the output of `parseStringArray`) to derive these adjustments.

### Description

- Added keyword lists `citrusBerryKeywords` and `fruitSweetnessKeywords` to detect citrus/berry and general fruit signals.
- Implemented `applyFruitFlavorAdjustments(base, notes)` which applies a gentle +0.4 to `base.acidity` for citrus/berry and +0.3 to `base.sweetness` for fruit.
- Call `applyFruitFlavorAdjustments` after existing flavor-note scoring inside `buildTasteRadarScores` so parsed `flavorNotes` influence radar outputs.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f59072b0832a8a3870bb170e60a4)