### PR TITLE
Increase acidity mapping for 'high' and boost acidity for fruit-heavy notes

### DIFF
--- a/src/utils/tasteProfile.ts
+++ b/src/utils/tasteProfile.ts
@@ -327,7 +327,7 @@ function mapAcidity(preferences: CoffeePreferenceSnapshot): number | null {
         return 5.5;
       case 'high':
       case 'vysoká':
-        return 7.8;
+        return 8.5;
       default:
         break;
     }
@@ -479,9 +479,13 @@ function applyFruitFlavorAdjustments(base: TasteRadarScores, notes: string[]): v
   const normalizedNotes = Array.from(new Set(notes.map(note => note.toLowerCase())));
   const hasCitrusBerry = normalizedNotes.some(note => citrusBerryKeywords.some(keyword => note.includes(keyword)));
   const hasFruitSweetness = normalizedNotes.some(note => fruitSweetnessKeywords.some(keyword => note.includes(keyword)));
+  const hasFruitHeavy = normalizedNotes.some(note => note.includes('fruit-heavy') || note.includes('fruit heavy'));
 
   if (hasCitrusBerry) {
     base.acidity = clamp(base.acidity + 0.4);
+  }
+  if (hasFruitHeavy) {
+    base.acidity = clamp(Math.max(base.acidity, 6.6));
   }
   if (hasFruitSweetness) {
     base.sweetness = clamp(base.sweetness + 0.3);


### PR DESCRIPTION
### Motivation
- Increase the mapped acidity for explicit "high"/"vysoká" user preference to better reflect a higher acidity perception.  
- Ensure flavor notes that indicate a "fruit-heavy" profile raise the acidity baseline so fruit-forward coffees register appropriately.  
- Improve alignment between textual flavor cues and the numeric acidity score used by the taste radar.  

### Description
- In `src/utils/tasteProfile.ts` updated `mapAcidity` so `case 'high'/'vysoká'` now returns `8.5` instead of `7.8`.  
- Added detection for `"fruit-heavy"` and `"fruit heavy"` in `applyFruitFlavorAdjustments` to set `base.acidity` to at least `6.6` using `clamp(Math.max(base.acidity, 6.6))`.  
- Kept existing citrus/berry and fruit-sweetness adjustments (`+0.4` to acidity and `+0.3` to sweetness) intact.  

### Testing
- No automated tests were run as part of this change.  
- No CI or unit test output was generated or reported for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f649e4ec832ab67e654ea7e5ca83)