### PR TITLE
Normalize scan and recipe fields in home statistics parsing

### DIFF
--- a/src/services/homeStatisticsService.ts
+++ b/src/services/homeStatisticsService.ts
@@ -179,12 +179,25 @@ export const fetchHomeStatistics = async (): Promise<HomeStatistics> => {
 
     const payload = await response.json();
 
+    const scanCountSource =
+      payload?.scanCount ??
+      payload?.scan_count ??
+      payload?.scans ??
+      payload?.totalScans ??
+      payload?.total_scans;
+
+    const recipeGenerationSource =
+      payload?.recipeGenerationCount ??
+      payload?.recipe_generation_count ??
+      payload?.recipeGenerations ??
+      payload?.recipe_generations;
+
     return {
       monthlyBrewCount: Math.round(coerceNumber(payload?.monthlyBrewCount, 0)),
       topRecipe: sanitizeTopRecipe(payload?.topRecipe),
       topTastingNotes: sanitizeTopTastingNotes(payload?.topTastingNotes),
-      scanCount: Math.round(coerceNumber(payload?.scanCount, 0)),
-      recipeGenerationCount: Math.round(coerceNumber(payload?.recipeGenerationCount, 0)),
+      scanCount: Math.round(coerceNumber(scanCountSource, 0)),
+      recipeGenerationCount: Math.round(coerceNumber(recipeGenerationSource, 0)),
     };
   } catch (error) {
     console.warn('homeStatisticsService: nepodarilo sa načítať štatistiky', error);


### PR DESCRIPTION
### Motivation
- The home dashboard sometimes showed `scanCount` as zero because the backend returns different field names (camelCase, snake_case, or alternate keys). 
- The parsing logic previously only read `payload.scanCount` which missed other common payload shapes. 
- Accepting multiple key variants reduces deserialization errors when the API contract varies. 

### Description
- Updated `src/services/homeStatisticsService.ts` to derive `scanCountSource` from multiple candidate keys (`scanCount`, `scan_count`, `scans`, `totalScans`, `total_scans`).
- Added `recipeGenerationSource` that accepts alternate keys (`recipeGenerationCount`, `recipe_generation_count`, `recipeGenerations`, `recipe_generations`).
- The returned `scanCount` and `recipeGenerationCount` now use `coerceNumber` on these normalized sources to preserve existing sanitization. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fded8f10832a8228cc3eefb85b86)