### PR TITLE
Remove success alerts after scan completion

### DIFF
--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -493,14 +493,6 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
 
         // Načítaj aktualizovanú históriu
         await loadHistory();
-
-        // Zobraz výsledok
-        Alert.alert(
-          '✅ Skenovanie dokončené',
-          result.recommendation ||
-            'Skontroluj výsledok nižšie.',
-          [{ text: 'OK', style: 'default' }],
-        );
       }
     } catch (error) {
       console.error('Error processing image:', error);

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -1227,19 +1227,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     }
 
     await loadHistory();
-
-    const alertReason = (normalizedResult.recommendation || '')
-      .split(/[\.\n]/)
-      .map(sentence => sentence.trim())
-      .filter(Boolean)[0];
-
-    Alert.alert(
-      '✅ Skenovanie dokončené',
-      normalizedResult.isRecommended
-        ? alertReason || 'Podľa tvojho profilu by ti mohla chutiť.'
-        : alertReason || 'Vyzerá to, že nesedí na tvoje preferencie.',
-      [{ text: 'OK', style: 'default' }],
-    );
   };
 
   const handleConfirmNonCoffee = async () => {


### PR DESCRIPTION
### Motivation
- Reduce modal interruptions after successful scans by removing the success `Alert.alert` dialogs while keeping automatic saving and view transitions intact.
- Keep existing error and confirmation alerts in place so failure paths still surface to the user.

### Description
- Removed the success alert shown after a recipe scan in `src/screens/CoffeeReceipeScanner/index.tsx` while preserving the `setScanResult`, `setCurrentView('scan')`, and `await loadHistory()` logic.
- Removed the success alert shown after a taste scan in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` while preserving recent-scan saving, identity/signal handling, feedback modal behavior, and `await loadHistory()`.
- No other behavioral changes were made; error alerts remain unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c3403690832a9a6a5a88df503457)