### PR TITLE
Shorten coffee scan comparison summary

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -236,27 +236,46 @@ const buildComparisonText = (
   coffeePreferences: Record<string, unknown> | null | undefined,
   isProfileStale: boolean,
 ): string => {
+  const truncateText = (value: string, maxLength: number): string => {
+    const trimmed = value.trim();
+    if (trimmed.length <= maxLength) {
+      return trimmed;
+    }
+    return `${trimmed.slice(0, maxLength).trimEnd()}…`;
+  };
+
+  const firstSentence = (value: string, maxLength = 160): string => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const match = trimmed.match(/[^.!?\n]+[.!?]?/);
+    const sentence = match ? match[0] : trimmed;
+    return truncateText(sentence, maxLength);
+  };
+
   const { summary: preferenceSummary, sourceLabel } = buildPreferenceSummary({
     profilePreferences: isProfileStale ? null : profilePreferences,
     preferenceSnapshot,
     coffeePreferences,
     isProfileStale,
   });
-  const formSection = preferenceSummary
-    ? `Aktuálny profil (${sourceLabel}):\n${preferenceSummary}`
+  const profileSentence = preferenceSummary
+    ? `Profil (${sourceLabel}): ${preferenceSummary}.`
     : isProfileStale
       ? 'Profil je zastaraný.'
-      : 'Aktuálny profil (dotazník): zatiaľ nemáme uložené hodnoty.';
+      : 'Profil ešte nemá uložené hodnoty.';
 
   const hasAiText = typeof aiRecommendation === 'string' && aiRecommendation.trim().length > 0;
-  const aiSection = hasAiText
-    ? `Posledné AI zhrnutie profilu:\n${aiRecommendation.trim()}`
-    : null;
+  const aiSummary = hasAiText ? firstSentence(aiRecommendation) : '';
 
   if (!evaluation) {
-    return [formSection, aiSection, 'Zo skenu zatiaľ nemáme dostatok údajov na porovnanie.']
-      .filter(Boolean)
-      .join('\n\n');
+    const sentences = [
+      profileSentence,
+      aiSummary ? `AI profil: ${aiSummary}.` : null,
+      'Zo skenu zatiaľ nemáme dostatok údajov na porovnanie.',
+    ].filter(Boolean);
+    return sentences.join(' ');
   }
 
   const comparison = buildScanPreferenceComparison({
@@ -297,25 +316,23 @@ const buildComparisonText = (
     insightHeadline && insightHeadline !== verdictExplanationText ? `• ${insightHeadline}` : null,
   ].filter((line): line is string => Boolean(line));
 
-  const scanSection = scanLines.length
-    ? `Zo skenu vyplýva:\n${scanLines.join('\n')}`
-    : 'Zo skenu zatiaľ nemáme dostatok údajov na porovnanie.';
+  const scanSummary = firstSentence(
+    verdictExplanationText || comparisonSummary || 'Zo skenu zatiaľ nemáme dostatok údajov.',
+  );
+  const sentences = [profileSentence, `Zo skenu: ${scanSummary}.`];
 
-  const dimensionSection = dimensionLines.length
-    ? `Porovnanie po dimenziách:\n${dimensionLines.map(line => `• ${line}`).join('\n')}`
-    : null;
+  const bulletCandidates = [
+    aiSummary ? `AI profil: ${aiSummary}` : null,
+    ...scanLines,
+    ...dimensionLines,
+    ...comparison.reasons,
+  ].filter((line): line is string => Boolean(line));
+  const bullets = bulletCandidates
+    .map(line => line.replace(/^•\s*/, ''))
+    .filter((line, index, array) => array.indexOf(line) === index)
+    .slice(0, 3);
 
-  const reasonSection = comparison.reasons.length
-    ? `Argumenty od AI:\n${comparison.reasons.map(reason => `• ${reason}`).join('\n')}`
-    : null;
-
-  const comparisonSection = comparisonSummary
-    ? `Rozdiely/zhoda:\n${comparisonSummary}`
-    : null;
-
-  return [formSection, aiSection, scanSection, dimensionSection, reasonSection, comparisonSection]
-    .filter(Boolean)
-    .join('\n\n');
+  return bullets.length ? `${sentences.join(' ')}\n${bullets.map(line => `• ${line}`).join('\n')}` : sentences.join(' ');
 };
 
 const WELCOME_GRADIENT = ['#FF9966', '#A86B8C'];


### PR DESCRIPTION
### Motivation
- Reduce verbosity of the coffee taste comparison text in the scanner UI by providing a concise summary (1–2 sentences) and a short list of key bullets to improve readability on small screens.
- Ensure long AI or verdict texts are truncated to avoid overflowing the comparison card and make the default summary suitable for a compact view.

### Description
- Add `truncateText` and `firstSentence` helpers to extract and trim the first sentence and to cap text length.
- Replace the multi-paragraph profile/AI sections with a single `profileSentence` and a shortened `aiSummary` for compact display.
- When evaluation exists, produce a one-line scan summary (`Zo skenu: ...`) plus up to three deduplicated bullets drawn from AI summary, scan insight lines, per-dimension lines, and AI reasons, and limit bullets to 3.
- Remove the previous multi-section output and consolidate into a shorter sentence-first format that falls back to a short message when no evaluation is available.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c57ad978832a851ea295bc70cbbe)