### PR TITLE
Consolidate CoffeeTasteScanner AI evaluation section

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -3190,119 +3190,173 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                         <Text style={styles.comparisonText}>{comparisonText}</Text>
                       </View>
 
-                      {isProfileMissing ? (
-                        // Profile is missing -> guide the user to the questionnaire instead of showing a score.
-                        <View style={styles.profileMissingCard}>
-                          <Text style={styles.profileMissingTitle}>Chýba chuťový profil</Text>
-                          <Text style={styles.profileMissingText}>
-                            {profileMissingText}
-                          </Text>
-                          <TouchableOpacity
-                            style={styles.profileMissingButton}
-                            onPress={handleQuestionnaireCTA}
-                            activeOpacity={0.85}
-                          >
-                            <Text style={styles.profileMissingButtonText}>{profileMissingCtaLabel}</Text>
-                          </TouchableOpacity>
+                      <View style={styles.compatibilityCardModern}>
+                        <View style={styles.sectionHeaderRow}>
+                          <Text style={styles.sectionTitle}>AI hodnotenie zhody</Text>
                         </View>
-                      ) : (
-                        <View style={styles.verdictCard}>
-                          <View style={styles.sectionHeaderRow}>
-                            <Text style={styles.sectionTitle}>Verdikt</Text>
-                          <View
-                              style={[
-                                styles.verdictBadge,
-                                evaluationVerdictTone === 'NO'
-                                  ? styles.verdictBadgeNo
-                                  : evaluationVerdictTone === 'RISKY'
-                                    ? styles.verdictBadgeRisky
-                                    : styles.verdictBadgeYes,
-                              ]}
+                        {isProfileMissing ? (
+                          <>
+                            <Text style={styles.profileMissingTitle}>Chýba chuťový profil</Text>
+                            <Text style={styles.profileMissingText}>
+                              {profileMissingText}
+                            </Text>
+                            <TouchableOpacity
+                              style={styles.profileMissingButton}
+                              onPress={handleQuestionnaireCTA}
+                              activeOpacity={0.85}
                             >
-                              <Text
+                              <Text style={styles.profileMissingButtonText}>
+                                {profileMissingCtaLabel}
+                              </Text>
+                            </TouchableOpacity>
+                          </>
+                        ) : (
+                          <>
+                            <View style={styles.sectionHeaderRow}>
+                              <Text style={styles.verdictDiffsTitle}>Verdikt</Text>
+                              <View
                                 style={[
-                                  styles.verdictBadgeText,
+                                  styles.verdictBadge,
                                   evaluationVerdictTone === 'NO'
-                                    ? styles.verdictBadgeTextNo
+                                    ? styles.verdictBadgeNo
                                     : evaluationVerdictTone === 'RISKY'
-                                      ? styles.verdictBadgeTextRisky
-                                      : styles.verdictBadgeTextYes,
+                                      ? styles.verdictBadgeRisky
+                                      : styles.verdictBadgeYes,
                                 ]}
                               >
-                                {verdictLabel}
-                              </Text>
+                                <Text
+                                  style={[
+                                    styles.verdictBadgeText,
+                                    evaluationVerdictTone === 'NO'
+                                      ? styles.verdictBadgeTextNo
+                                      : evaluationVerdictTone === 'RISKY'
+                                        ? styles.verdictBadgeTextRisky
+                                        : styles.verdictBadgeTextYes,
+                                  ]}
+                                >
+                                  {verdictLabel}
+                                </Text>
+                              </View>
                             </View>
-                          </View>
-                          {evaluationConfidenceLabel ? (
-                            <Text style={styles.verdictConfidence}>{evaluationConfidenceLabel}</Text>
-                          ) : null}
-                          <Text style={styles.verdictDescription}>{verdictExplanation}</Text>
-                          {dimensionDiffs.length ? (
-                            <View style={styles.verdictDiffs}>
-                              <Text style={styles.verdictDiffsTitle}>Rozdiely v chutiach</Text>
-                              {dimensionDiffs.map(diff => (
-                                <View key={diff.key} style={styles.verdictDiffRow}>
-                                  <View style={styles.verdictDiffHeader}>
-                                    <Text style={styles.verdictDiffLabel}>{diff.label}</Text>
-                                    {diff.percent ? (
-                                      <Text style={styles.verdictDiffPercent}>{diff.percent}</Text>
+                            {evaluationConfidenceLabel ? (
+                              <Text style={styles.verdictConfidence}>{evaluationConfidenceLabel}</Text>
+                            ) : null}
+                            <Text style={styles.verdictDescription}>{verdictExplanation}</Text>
+                            {dimensionDiffs.length ? (
+                              <View style={styles.verdictDiffs}>
+                                <Text style={styles.verdictDiffsTitle}>Rozdiely v chutiach</Text>
+                                {dimensionDiffs.map(diff => (
+                                  <View key={diff.key} style={styles.verdictDiffRow}>
+                                    <View style={styles.verdictDiffHeader}>
+                                      <Text style={styles.verdictDiffLabel}>{diff.label}</Text>
+                                      {diff.percent ? (
+                                        <Text style={styles.verdictDiffPercent}>{diff.percent}</Text>
+                                      ) : null}
+                                    </View>
+                                    {diff.explanation ? (
+                                      <Text style={styles.verdictDiffExplanation}>
+                                        {diff.explanation}
+                                      </Text>
                                     ) : null}
                                   </View>
-                                  {diff.explanation ? (
-                                    <Text style={styles.verdictDiffExplanation}>{diff.explanation}</Text>
-                                  ) : null}
-                                </View>
-                              ))}
-                            </View>
-                          ) : null}
-                          {lowDataWarning ? (
-                            <View style={styles.lowDataCard}>
-                              <View style={styles.lowDataBadge}>
-                                <Text style={styles.lowDataBadgeText}>Minimum údajov</Text>
+                                ))}
                               </View>
-                              <Text style={styles.lowDataText}>{lowDataWarning}</Text>
-                              <TouchableOpacity
-                                style={styles.lowDataButton}
-                                onPress={openCamera}
-                                activeOpacity={0.85}
-                              >
-                                <Text style={styles.lowDataButtonText}>Rescanovať etiketu</Text>
-                              </TouchableOpacity>
-                            </View>
-                          ) : null}
-                        </View>
-                      )}
+                            ) : null}
+                            {lowDataWarning ? (
+                              <View style={styles.lowDataCard}>
+                                <View style={styles.lowDataBadge}>
+                                  <Text style={styles.lowDataBadgeText}>Minimum údajov</Text>
+                                </View>
+                                <Text style={styles.lowDataText}>{lowDataWarning}</Text>
+                                <TouchableOpacity
+                                  style={styles.lowDataButton}
+                                  onPress={openCamera}
+                                  activeOpacity={0.85}
+                                >
+                                  <Text style={styles.lowDataButtonText}>Rescanovať etiketu</Text>
+                                </TouchableOpacity>
+                              </View>
+                            ) : null}
+                          </>
+                        )}
 
-                      {evaluationStatus === 'ok' ? (
-                        // AI evaluation sections are only shown when a complete profile exists.
-                        <View style={styles.compatibilityCardModern}>
-                          <View style={styles.sectionHeaderRow}>
-                            <Text style={styles.sectionTitle}>AI hodnotenie zhody</Text>
-                          </View>
-                          {evaluationIntroText ? (
-                            <Text style={styles.compatibilityIntro}>{evaluationIntroText}</Text>
-                          ) : null}
-                          {insightContent?.sections.length ? (
-                            <View style={styles.reasonBlocksWrapper}>
-                              {insightContent.sections.map((section, index) => (
-                                <View key={`${section.title}-${index}`} style={styles.reasonBlock}>
-                                  {section.title ? (
-                                    <Text style={styles.reasonTitle}>{section.title}</Text>
-                                  ) : null}
-                                  {section.bullets.map(bullet => (
-                                    <View key={bullet} style={styles.reasonRow}>
-                                      <View style={[styles.reasonBadge, insightBadgeStyle]}>
-                                        <Text style={styles.reasonBadgeText}>•</Text>
+                        {evaluationStatus === 'ok' ? (
+                          <View style={styles.aiSummarySection}>
+                            {evaluationIntroText ? (
+                              <Text style={styles.compatibilityIntro}>{evaluationIntroText}</Text>
+                            ) : null}
+                            {insightContent?.sections.length ? (
+                              <View style={styles.reasonBlocksWrapper}>
+                                {insightContent.sections.map((section, index) => (
+                                  <View key={`${section.title}-${index}`} style={styles.reasonBlock}>
+                                    {section.title ? (
+                                      <Text style={styles.reasonTitle}>{section.title}</Text>
+                                    ) : null}
+                                    {section.bullets.map(bullet => (
+                                      <View key={bullet} style={styles.reasonRow}>
+                                        <View style={[styles.reasonBadge, insightBadgeStyle]}>
+                                          <Text style={styles.reasonBadgeText}>•</Text>
+                                        </View>
+                                        <Text style={styles.reasonText}>{bullet}</Text>
                                       </View>
-                                      <Text style={styles.reasonText}>{bullet}</Text>
+                                    ))}
+                                  </View>
+                                ))}
+                              </View>
+                            ) : null}
+                          </View>
+                        ) : null}
+
+                        <View style={styles.aiSummarySection}>
+                          <Text style={styles.sectionSubtitle}>AI insight</Text>
+                          {insightStatusContent ? (
+                            <>
+                              {insightStatusContent.headline ? (
+                                <Text style={styles.verdictDescription}>
+                                  {insightStatusContent.headline}
+                                </Text>
+                              ) : null}
+                              <Text style={styles.verdictDescription}>{insightStatusContent.body}</Text>
+                              {insightStatusContent.ctaLabel ? (
+                                <TouchableOpacity
+                                  style={styles.profileMissingButton}
+                                  onPress={handleQuestionnaireCTA}
+                                  activeOpacity={0.85}
+                                >
+                                  <Text style={styles.profileMissingButtonText}>
+                                    {insightStatusContent.ctaLabel}
+                                  </Text>
+                                </TouchableOpacity>
+                              ) : null}
+                            </>
+                          ) : (
+                            <>
+                              {insightContent?.headline ? (
+                                <Text style={styles.verdictDescription}>{insightContent.headline}</Text>
+                              ) : null}
+                              {evaluationStatus !== 'ok' && insightContent?.sections.length ? (
+                                <View style={styles.reasonBlocksWrapper}>
+                                  {insightContent.sections.map((section, index) => (
+                                    <View key={`${section.title}-${index}`} style={styles.reasonBlock}>
+                                      {section.title ? (
+                                        <Text style={styles.reasonTitle}>{section.title}</Text>
+                                      ) : null}
+                                      {section.bullets.map(bullet => (
+                                        <View key={bullet} style={styles.reasonRow}>
+                                          <View style={[styles.reasonBadge, insightBadgeStyle]}>
+                                            <Text style={styles.reasonBadgeText}>•</Text>
+                                          </View>
+                                          <Text style={styles.reasonText}>{bullet}</Text>
+                                        </View>
+                                      ))}
                                     </View>
                                   ))}
                                 </View>
-                              ))}
-                            </View>
-                          ) : null}
+                              ) : null}
+                            </>
+                          )}
                         </View>
-                      ) : null}
+                      </View>
 
                       <View style={styles.ownershipCardModern}>
                         <View style={styles.sectionHeaderRow}>
@@ -3415,58 +3469,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                         </View>
                       </View>
 
-                      <LinearGradient colors={['#7FB069', '#00897B']} style={styles.insightCard}>
-                        <View style={styles.insightHeaderRow}>
-                          <View style={styles.insightIconWrapper}>
-                            <Text style={styles.insightIcon}>🤖</Text>
-                          </View>
-                          <Text style={styles.insightTitle}>AI insight</Text>
-                        </View>
-                        {insightStatusContent ? (
-                          <>
-                            {insightStatusContent.headline ? (
-                              <Text style={styles.insightText}>{insightStatusContent.headline}</Text>
-                            ) : null}
-                            <Text style={styles.insightText}>{insightStatusContent.body}</Text>
-                            {insightStatusContent.ctaLabel ? (
-                              <TouchableOpacity
-                                style={styles.profileMissingButton}
-                                onPress={handleQuestionnaireCTA}
-                                activeOpacity={0.85}
-                              >
-                                <Text style={styles.profileMissingButtonText}>
-                                  {insightStatusContent.ctaLabel}
-                                </Text>
-                              </TouchableOpacity>
-                            ) : null}
-                          </>
-                        ) : (
-                          <>
-                            {insightContent?.headline ? (
-                              <Text style={styles.insightText}>{insightContent.headline}</Text>
-                            ) : null}
-                            {insightContent?.sections.length ? (
-                              <View style={styles.reasonBlocksWrapper}>
-                                {insightContent.sections.map((section, index) => (
-                                  <View key={`${section.title}-${index}`} style={styles.reasonBlock}>
-                                    {section.title ? (
-                                      <Text style={styles.reasonTitle}>{section.title}</Text>
-                                    ) : null}
-                                    {section.bullets.map(bullet => (
-                                      <View key={bullet} style={styles.reasonRow}>
-                                        <View style={[styles.reasonBadge, insightBadgeStyle]}>
-                                          <Text style={styles.reasonBadgeText}>•</Text>
-                                        </View>
-                                        <Text style={styles.reasonText}>{bullet}</Text>
-                                      </View>
-                                    ))}
-                                  </View>
-                                ))}
-                              </View>
-                            ) : null}
-                          </>
-                        )}
-                      </LinearGradient>
 
                       <View style={styles.structuredCard}>
                         <View style={styles.sectionHeaderRow}>

--- a/src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts
+++ b/src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts
@@ -496,15 +496,6 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       color: palette.textSecondary,
       lineHeight: 18,
     },
-    profileMissingCard: {
-      backgroundColor: palette.surface,
-      borderRadius: 24,
-      padding: 20,
-      borderWidth: 1,
-      borderColor: 'rgba(255,154,118,0.35)',
-      marginBottom: 16,
-      ...baseShadow,
-    },
     profileMissingTitle: {
       fontSize: 18,
       fontWeight: '800',
@@ -528,15 +519,6 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       fontSize: 14,
       fontWeight: '700',
       color: palette.surface,
-    },
-    verdictCard: {
-      backgroundColor: palette.surface,
-      borderRadius: 24,
-      padding: 20,
-      borderWidth: 1,
-      borderColor: palette.borderLight,
-      marginBottom: 16,
-      ...baseShadow,
     },
     lowDataCard: {
       marginTop: 14,
@@ -686,6 +668,12 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       fontWeight: '600',
       color: palette.textTertiary,
       marginBottom: 6,
+    },
+    aiSummarySection: {
+      marginTop: 16,
+      paddingTop: 16,
+      borderTopWidth: 1,
+      borderTopColor: palette.borderLight,
     },
     sectionSubtitle: {
       fontSize: 12,
@@ -923,43 +911,6 @@ export const scannerStyles = (_isDarkMode: boolean = false) => {
       fontSize: 13,
       fontWeight: '600',
       color: palette.textSecondary,
-    },
-    insightCard: {
-      borderRadius: 24,
-      padding: 22,
-      marginBottom: 16,
-      overflow: 'hidden',
-      ...baseShadow,
-    },
-    insightHeaderRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      marginBottom: 12,
-      columnGap: 12,
-    },
-    insightIconWrapper: {
-      width: 36,
-      height: 36,
-      borderRadius: 12,
-      backgroundColor: 'rgba(255,255,255,0.18)',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    insightIcon: {
-      fontSize: 18,
-      color: '#FFFFFF',
-    },
-    insightTitle: {
-      fontSize: 13,
-      fontWeight: '800',
-      color: '#FFFFFF',
-      letterSpacing: 0.8,
-      textTransform: 'uppercase',
-    },
-    insightText: {
-      fontSize: 15,
-      color: '#FFFFFF',
-      lineHeight: 22,
     },
     structuredCard: {
       backgroundColor: palette.surface,


### PR DESCRIPTION
### Motivation
- Reduce duplicated UI by merging the separate verdict, compatibility and insight card sections into a single unified AI evaluation card.
- Keep all existing data and conditional behaviour while simplifying the layout and avoiding repeated rendering of the same insight content.

### Description
- Replaced separate `verdictCard`, `compatibilityCardModern` and `insightCard` blocks with one `compatibilityCardModern` wrapper that contains the profile-missing, verdict, compatibility summary and AI insight sections in a single card (`src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx`).
- Unified conditional rendering so insight sections are only rendered once and `evaluationStatus`/`isProfileMissing` logic is handled inside the single card.
- Added a shared divider section style `aiSummarySection` and removed now-unused card styles (`insightCard`, `verdictCard`, `profileMissingCard`) from `src/screens/CoffeeTasteScanner/styles/ProfessionalOCRScannerStyles.ts`.
- Adjusted badge/title placements and reused existing style tokens to preserve visual intent while consolidating markup.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c6183fec832abeb64e9d679924d4)