### PR TITLE
Use structured taste data for scan attributes

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -740,6 +740,50 @@ const normalizeTasteVectorTo10 = (
   };
 };
 
+const extractTasteVectorFromPayload = (payload: unknown): TasteProfileVector | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const nestedTasteVector = (input: unknown): Record<string, number> | null => {
+    if (!input || typeof input !== 'object') {
+      return null;
+    }
+    return input as Record<string, number>;
+  };
+
+  const directCandidate =
+    nestedTasteVector(record.taste_vector) ??
+    nestedTasteVector(record.tasteVector) ??
+    nestedTasteVector(record.taste_profile) ??
+    nestedTasteVector(record.tasteProfile) ??
+    nestedTasteVector(
+      typeof record.taste_profile === 'object'
+        ? (record.taste_profile as Record<string, unknown>).taste_vector
+        : null,
+    ) ??
+    nestedTasteVector(
+      typeof record.tasteProfile === 'object'
+        ? (record.tasteProfile as Record<string, unknown>).taste_vector ??
+          (record.tasteProfile as Record<string, unknown>).tasteVector
+        : null,
+    ) ??
+    nestedTasteVector(
+      typeof record.coffee_attributes === 'object'
+        ? (record.coffee_attributes as Record<string, unknown>).taste_vector
+        : null,
+    ) ??
+    nestedTasteVector(
+      typeof record.coffeeAttributes === 'object'
+        ? (record.coffeeAttributes as Record<string, unknown>).taste_vector ??
+          (record.coffeeAttributes as Record<string, unknown>).tasteVector
+        : null,
+    );
+
+  return directCandidate ? normalizeTasteVectorTo10(directCandidate) : null;
+};
+
 const hasCompleteTasteVector = (vector?: TasteProfileVector | null): boolean => {
   if (!vector) {
     return false;
@@ -785,6 +829,98 @@ const normalizeRoastLevel = (value?: string | null): RoastCategory => {
     return 'dark';
   }
   return 'unknown';
+};
+
+const buildTasteVectorFromStructuredMetadata = (
+  metadata?: StructuredCoffeeMetadata | null,
+): TasteProfileVector | null => {
+  if (!metadata) {
+    return null;
+  }
+
+  const roastCategory = normalizeRoastLevel(metadata.roastLevel);
+  const processing = metadata.processing?.toLowerCase() ?? '';
+  const flavorNotes = metadata.flavorNotes?.map(note => note.toLowerCase()) ?? [];
+  const hasStructuredSignals =
+    roastCategory !== 'unknown' || Boolean(processing) || flavorNotes.length > 0;
+
+  if (!hasStructuredSignals) {
+    return null;
+  }
+
+  const vector = {
+    sweetness: 5,
+    acidity: 5,
+    bitterness: 5,
+    body: 5,
+  };
+
+  switch (roastCategory) {
+    case 'light':
+      vector.acidity += 2;
+      vector.sweetness += 0.5;
+      vector.bitterness -= 1;
+      vector.body -= 0.5;
+      break;
+    case 'medium':
+      vector.acidity += 0.5;
+      vector.body += 0.5;
+      break;
+    case 'dark':
+      vector.bitterness += 2;
+      vector.body += 1;
+      vector.acidity -= 1.5;
+      vector.sweetness -= 0.5;
+      break;
+    default:
+      break;
+  }
+
+  if (processing) {
+    if (processing.includes('natural') || processing.includes('honey')) {
+      vector.sweetness += 1;
+      vector.body += 0.5;
+      vector.acidity -= 0.3;
+    } else if (processing.includes('washed')) {
+      vector.acidity += 1;
+      vector.body -= 0.3;
+    } else if (processing.includes('anaerobic')) {
+      vector.sweetness += 0.5;
+      vector.acidity += 0.5;
+    }
+  }
+
+  const noteMatches = (keywords: string[]) =>
+    flavorNotes.some(note => keywords.some(keyword => note.includes(keyword)));
+
+  if (noteMatches(['citr', 'citrus', 'lemon', 'lime', 'bergamot'])) {
+    vector.acidity += 1.2;
+    vector.sweetness += 0.3;
+  }
+  if (noteMatches(['berry', 'ovoc', 'fruit', 'cherry', 'jahod', 'malin'])) {
+    vector.acidity += 0.8;
+    vector.sweetness += 0.5;
+  }
+  if (noteMatches(['čokol', 'cocoa', 'kakao', 'karamel', 'toffee', 'nut', 'orie', 'mandl'])) {
+    vector.sweetness += 0.7;
+    vector.body += 0.6;
+    vector.bitterness += 0.4;
+  }
+  if (noteMatches(['spice', 'koreni', 'smok', 'dym'])) {
+    vector.bitterness += 0.8;
+    vector.body += 0.4;
+  }
+  if (noteMatches(['tea', 'čaj', 'flower', 'kvet'])) {
+    vector.acidity += 0.6;
+    vector.body -= 0.3;
+  }
+
+  return {
+    sweetness: clampTasteValue(vector.sweetness),
+    acidity: clampTasteValue(vector.acidity),
+    bitterness: clampTasteValue(vector.bitterness),
+    body: clampTasteValue(vector.body),
+  };
 };
 
 const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
@@ -2500,7 +2636,46 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     return combined.toLowerCase();
   }, [recognizedText, scanResult]);
 
+  const structuredTasteVector = useMemo(() => {
+    const aiVector =
+      extractTasteVectorFromPayload(scanResult?.structuredRaw) ??
+      extractTasteVectorFromPayload(scanResult?.evaluation?.raw);
+    if (aiVector) {
+      return aiVector;
+    }
+    return buildTasteVectorFromStructuredMetadata(structuredMetadata);
+  }, [scanResult?.evaluation?.raw, scanResult?.structuredRaw, structuredMetadata]);
+
   const tasteAttributes = useMemo(() => {
+    if (structuredTasteVector) {
+      return [
+        {
+          key: 'acidity',
+          label: 'Kyslosť',
+          value: clampTasteValue(structuredTasteVector.acidity),
+          style: styles.tasteFillAcidity,
+        },
+        {
+          key: 'sweetness',
+          label: 'Sladkosť',
+          value: clampTasteValue(structuredTasteVector.sweetness),
+          style: styles.tasteFillSweetness,
+        },
+        {
+          key: 'bitterness',
+          label: 'Horkosť',
+          value: clampTasteValue(structuredTasteVector.bitterness),
+          style: styles.tasteFillBitterness,
+        },
+        {
+          key: 'body',
+          label: 'Telo',
+          value: clampTasteValue(structuredTasteVector.body),
+          style: styles.tasteFillBody,
+        },
+      ];
+    }
+
     const computeScore = (
       base: number,
       positiveKeywords: string[],
@@ -2546,7 +2721,14 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
         style: styles.tasteFillBody,
       },
     ];
-  }, [combinedLowerText, styles.tasteFillAcidity, styles.tasteFillSweetness, styles.tasteFillBitterness, styles.tasteFillBody]);
+  }, [
+    combinedLowerText,
+    structuredTasteVector,
+    styles.tasteFillAcidity,
+    styles.tasteFillSweetness,
+    styles.tasteFillBitterness,
+    styles.tasteFillBody,
+  ]);
 
   const flavorTags = useMemo(() => {
     const structuredNotes = structuredFields.flavorNotes.value;


### PR DESCRIPTION
### Motivation
- Provide more accurate taste attribute values by using structured metadata and AI-provided taste vectors when available rather than relying only on text heuristics.
- Reduce flaky or misleading estimates derived from label text parsing when the backend/AI returns explicit taste information.

### Description
- Added `extractTasteVectorFromPayload` to pull normalized taste vectors from various shapes of AI/structured payloads (e.g. `taste_vector`, `tasteProfile`, `coffee_attributes`).
- Added `buildTasteVectorFromStructuredMetadata` to infer a 4D taste vector (`sweetness`, `acidity`, `bitterness`, `body`) from `StructuredCoffeeMetadata` (roast, processing, flavor notes) as a best-effort fallback.
- Introduced `structuredTasteVector` (from `scanResult.structuredRaw`, `scanResult.evaluation.raw`, or structured metadata) and updated `tasteAttributes` to prioritize this vector and fall back to existing text-based heuristics only when structured/AI data is absent.
- Changes implemented in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` and reuse existing helper `normalizeTasteVectorTo10` and `clampTasteValue` for normalization.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c70fa344832ab5ff2432cc4cc86c)