### PR TITLE
Treat boolean confidence conservatively and add low-confidence warning

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -521,6 +521,8 @@ const resolveConfidenceEntry = (
   key: StructuredFieldKey,
   fallbackFlag?: boolean | null,
 ): { confidence: number | null; warning: string | null } => {
+  const booleanConfidenceEstimate = 0.8;
+  const lowConfidenceThreshold = 0.85;
   const aliases = STRUCTURED_CONFIDENCE_KEYS[key] ?? [key];
   let confidence: number | null = null;
   let warning: string | null = null;
@@ -531,7 +533,7 @@ const resolveConfidenceEntry = (
       return;
     }
     if (typeof entry === 'boolean') {
-      confidence = entry ? 1 : 0;
+      confidence = entry ? booleanConfidenceEstimate : null;
       return;
     }
     if (typeof entry === 'string') {
@@ -572,7 +574,14 @@ const resolveConfidenceEntry = (
   }
 
   if (confidence == null && typeof fallbackFlag === 'boolean') {
-    confidence = fallbackFlag ? 1 : 0;
+    confidence = fallbackFlag ? booleanConfidenceEstimate : null;
+  }
+
+  if (confidence != null) {
+    const normalized = confidence > 1 ? confidence / 100 : confidence;
+    if (normalized < lowConfidenceThreshold && warning == null) {
+      warning = 'AI si nie je isté';
+    }
   }
 
   return { confidence, warning };


### PR DESCRIPTION
### Motivation
- Avoid treating boolean `confidenceFlags` as 100% certain and surface an explicit low-confidence notice for AI-filled structured fields so users are aware when the model is unsure.

### Description
- Update `resolveConfidenceEntry` in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` to treat boolean confidences as a conservative estimate (`0.8`) instead of `1`, apply the same estimate for fallback flags, and set a warning text `"AI si nie je isté"` when normalized confidence is below `0.85`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c82bdba0832abf85277e0d4dbf42)