### PR TITLE
Remove rating UI blocks from scanner screens

### DIFF
--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -158,7 +158,6 @@ const resolveTastePreferenceFromProfile = (
 const WELCOME_GRADIENT = ['#FF9966', '#A86B8C'];
 const COFFEE_GRADIENT = ['#8B6544', '#6B4423'];
 const WARM_GRADIENT = ['#FFA000', '#FF6B6B'];
-const RATING_GRADIENT = ['#FFFFFF', '#F5E6D3'];
 const TIP_GRADIENT = ['#9C27B0', '#FF6B6B'];
 
 const brewingMethodHints: Record<string, string> = {
@@ -787,12 +786,6 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
 
     return commaSegments;
   }, [scanResult]);
-  const ratingDisplay = useMemo(() => {
-    if (userRating > 0) {
-      return userRating.toFixed(1);
-    }
-    return '—';
-  }, [userRating]);
   const refreshControl =
     currentView === 'home'
       ? <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
@@ -1015,45 +1008,6 @@ const CoffeeReceipeScanner: React.FC<BrewScannerProps> = ({
                             textAlignVertical="top"
                           />
                         </View>
-                      </View>
-
-                      <View style={styles.scanRatingWrapper}>
-                        <LinearGradient colors={RATING_GRADIENT} style={styles.scanRatingCard}>
-                          <View style={styles.scanRatingHeader}>
-                            <Text style={styles.scanRatingTitle}>Ohodnoť kávu</Text>
-                            <Text style={styles.scanRatingValue}>{ratingDisplay}</Text>
-                          </View>
-                          <View style={styles.scanStarsRow}>
-                            {[1, 2, 3, 4, 5].map((star) => (
-                              <TouchableOpacity
-                                key={star}
-                                style={styles.scanStarButton}
-                                onPress={() => handleRating(star)}
-                                activeOpacity={0.85}
-                              >
-                                <Text
-                                  style={[
-                                    styles.scanStarIcon,
-                                    star <= userRating && styles.scanStarIconActive,
-                                  ]}
-                                >
-                                  ⭐
-                                </Text>
-                              </TouchableOpacity>
-                            ))}
-                          </View>
-                          <TouchableOpacity
-                            style={[styles.scanFavoriteButton, isFavorite && styles.scanFavoriteButtonActive]}
-                            onPress={handleFavoriteToggle}
-                            activeOpacity={0.85}
-                          >
-                            <Text
-                              style={[styles.scanFavoriteText, isFavorite && styles.scanFavoriteTextActive]}
-                            >
-                              {isFavorite ? '❤️ Uložené' : '♡ Obľúbené'}
-                            </Text>
-                          </TouchableOpacity>
-                        </LinearGradient>
                       </View>
 
                       <View style={styles.scanMethodSection}>

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2955,12 +2955,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     );
   }, [evaluation, evaluationStatus]);
 
-  const ratingDisplay =
-    userRating > 0
-      ? `${userRating}/5`
-      : isHistoryReadOnly
-        ? 'Bez hodnotenia'
-        : 'Ohodnoť';
   const editorHint = isHistoryReadOnly
     ? 'História je len na čítanie'
     : 'Uprav, ak niečo nesedí';
@@ -3751,52 +3745,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                         />
                       </View>
 
-                      <View style={styles.ratingCardModern}>
-                        <View style={styles.ratingHeaderRow}>
-                          <View>
-                            <Text style={styles.sectionTitle}>Tvoje hodnotenie</Text>
-                            <Text style={styles.sectionSubtitle}>Ako veľmi ti sedí?</Text>
-                          </View>
-                          <Text style={styles.ratingDisplay}>{ratingDisplay}</Text>
-                        </View>
-                        <View style={styles.ratingStarsRow}>
-                          {[1, 2, 3, 4, 5].map(star => (
-                            <TouchableOpacity
-                              key={star}
-                              style={[
-                                styles.ratingStarButton,
-                                isHistoryReadOnly && { opacity: 0.5 },
-                              ]}
-                              onPress={() => handleRating(star)}
-                              disabled={isHistoryReadOnly}
-                            >
-                              <Text
-                                style={[
-                                  styles.ratingStarIcon,
-                                  star <= userRating && styles.ratingStarIconActive,
-                                ]}
-                              >
-                                ⭐
-                              </Text>
-                            </TouchableOpacity>
-                          ))}
-                        </View>
-                        <TouchableOpacity
-                          style={[
-                            styles.favoriteToggle,
-                            isFavorite && styles.favoriteToggleActive,
-                            isHistoryReadOnly && { opacity: 0.5 },
-                          ]}
-                          onPress={handleFavoriteToggle}
-                          disabled={isHistoryReadOnly}
-                        >
-                          <Text
-                            style={[styles.favoriteToggleText, isFavorite && styles.favoriteToggleTextActive]}
-                          >
-                            {isFavorite ? '❤️ Uložené medzi obľúbené' : '♡ Pridať medzi obľúbené'}
-                          </Text>
-                        </TouchableOpacity>
-                      </View>
                     </View>
 
                     <View style={styles.bottomSpacer} />


### PR DESCRIPTION
### Motivation
- Remove the on-screen rating widgets from scanner screens while leaving underlying rating state/handlers available for use elsewhere.

### Description
- Removed the modern rating card JSX block from `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` so the editor/structured fields flow continues without the rating UI.
- Removed the `scanRatingWrapper` / `scanRatingCard` JSX block (the “Ohodnoť kávu” card) from `src/screens/CoffeeReceipeScanner/index.tsx` so the method/tip sections render directly after the scan text card.
- Dropped the now-unused UI-only pieces such as the `RATING_GRADIENT` constant and component-level `ratingDisplay` computations that were only used for the removed cards.
- Kept rating-related state and handlers (e.g. `userRating`, `handleRating`, `handleFavoriteToggle`) intact so the logic can still be used elsewhere.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c8b47c38832a9ef0a9887d3b7230)