### PR TITLE
Make flavor tags non-interactive

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -3637,20 +3637,11 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                           ))}
                         </View>
                         <View style={styles.flavorTagsRow}>
-                          {flavorTags.map(tag => {
-                            const isPlaceholder = tag === 'N/A';
-                            return (
-                              <TouchableOpacity
-                                key={tag}
-                                style={styles.flavorTag}
-                                onPress={() => handleFlavorPress(tag)}
-                                activeOpacity={0.85}
-                                disabled={isPlaceholder}
-                              >
-                                <Text style={styles.flavorTagText}>{tag}</Text>
-                              </TouchableOpacity>
-                            );
-                          })}
+                          {flavorTags.map(tag => (
+                            <View key={tag} style={styles.flavorTag}>
+                              <Text style={styles.flavorTagText}>{tag}</Text>
+                            </View>
+                          ))}
                         </View>
                       </View>
 


### PR DESCRIPTION
### Motivation
- Make the flavor tag chips non-interactive to avoid accidental taps and simplify the taste profile UI by replacing pressable tags with static display elements.

### Description
- In `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` replaced the `TouchableOpacity` used to render `flavorTags` with plain `View` + `Text` chips, removing the `onPress` handler and disabled logic while preserving existing styles.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c951c2ac832a940ad154d12ebb20)