### PR TITLE
Guard taste vector normalization for scanner insights

### DIFF
--- a/src/utils/scanPreferenceComparison.ts
+++ b/src/utils/scanPreferenceComparison.ts
@@ -120,7 +120,10 @@ const resolveTasteVector = (
   if (nestedVector && typeof nestedVector === 'object') {
     return nestedVector as TasteVector;
   }
-  return tasteVector ?? null;
+  if (tasteVector && typeof tasteVector === 'object') {
+    return tasteVector;
+  }
+  return null;
 };
 
 const scoreToLevel = (value: number): TasteLevel => {
@@ -327,13 +330,14 @@ export const buildScanPreferenceComparison = (
 ): ScanPreferenceComparisonResult => {
   const evaluation = input.evaluation ?? null;
   const tasteVector = resolveTasteVector(input.coffeePreferences, input.tasteVector);
-  const normalizedTasteVector = tasteVector
-    ? Object.fromEntries(
-        Object.entries(tasteVector)
-          .map(([key, value]) => [key, normalizeVectorValue(value)])
-          .filter(([, value]) => value != null),
-      )
-    : null;
+  const normalizedTasteVector =
+    tasteVector && typeof tasteVector === 'object'
+      ? Object.fromEntries(
+          Object.entries(tasteVector)
+            .map(([key, value]) => [key, normalizeVectorValue(value)])
+            .filter(([, value]) => value != null),
+        )
+      : null;
 
   const reasonLevelMap = buildReasonLevelMap(evaluation);
   fillFromVerdictExplanation(evaluation, reasonLevelMap);


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when non-object or undefined taste vectors are passed into the scanner preference comparison routines by ensuring only object-shaped taste vectors are used.

### Description
- Make `resolveTasteVector` return the `tasteVector` only when it is an object and prefer `coffeePreferences.taste_vector` when present to avoid passing non-object values downstream.
- Add a defensive guard before calling `Object.entries` in `buildScanPreferenceComparison` so normalization runs only on object taste vectors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694a2bf038832a8c718706995f05b7)