### PR TITLE
Fix verdict reason spread crash in CoffeeTasteScanner

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2210,6 +2210,40 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
     }
     return `${normalized}% istota`;
   }, [evaluation?.confidence]);
+  // AI recommendation sentences coming from the scan response; reused for the insight section.
+  const recommendationSentences = useMemo(() => {
+    if (!scanResult?.recommendation) {
+      return [];
+    }
+    return scanResult.recommendation
+      .split(/[\.\n]/)
+      .map(sentence => sentence.trim())
+      .filter(Boolean);
+  }, [scanResult]);
+
+  const reasonSentences = recommendationSentences.slice(1);
+
+  const positiveReasons = useMemo(() => {
+    if (!reasonSentences.length && recommendationSentences.length) {
+      return recommendationSentences;
+    }
+
+    return reasonSentences.filter(sentence => {
+      const lower = sentence.toLowerCase();
+      return POSITIVE_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
+    });
+  }, [reasonSentences, recommendationSentences]);
+
+  const cautionReasons = useMemo(() => {
+    if (!reasonSentences.length) {
+      return [];
+    }
+    return reasonSentences.filter(sentence => {
+      const lower = sentence.toLowerCase();
+      const isPositive = POSITIVE_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
+      return !isPositive && CAUTION_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
+    });
+  }, [reasonSentences]);
   const verdictReasonBuckets = useMemo(() => {
     const verdictLines = [
       ...extractVerdictExplanationLines(evaluation?.verdict_explanation),
@@ -2371,41 +2405,6 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
   const matchLabel = aiMatchLabel
     ? aiMatchLabel
     : compatibility?.label ?? (evaluationStatus !== 'ok' ? neutralVerdictCopy : undefined);
-
-  // AI recommendation sentences coming from the scan response; reused for the insight section.
-  const recommendationSentences = useMemo(() => {
-    if (!scanResult?.recommendation) {
-      return [];
-    }
-    return scanResult.recommendation
-      .split(/[\.\n]/)
-      .map(sentence => sentence.trim())
-      .filter(Boolean);
-  }, [scanResult]);
-
-  const reasonSentences = recommendationSentences.slice(1);
-
-  const positiveReasons = useMemo(() => {
-    if (!reasonSentences.length && recommendationSentences.length) {
-      return recommendationSentences;
-    }
-
-    return reasonSentences.filter(sentence => {
-      const lower = sentence.toLowerCase();
-      return POSITIVE_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
-    });
-  }, [reasonSentences, recommendationSentences]);
-
-  const cautionReasons = useMemo(() => {
-    if (!reasonSentences.length) {
-      return [];
-    }
-    return reasonSentences.filter(sentence => {
-      const lower = sentence.toLowerCase();
-      const isPositive = POSITIVE_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
-      return !isPositive && CAUTION_REASON_KEYWORDS.some(keyword => lower.includes(keyword));
-    });
-  }, [reasonSentences]);
 
   const structuredTasteVector = useMemo(() => {
     return extractTasteVectorFromPayload(scanResult?.evaluation?.raw);


### PR DESCRIPTION
### Motivation
- Guard against a runtime crash caused by spreading `undefined` when aggregating verdict reasons by ensuring AI recommendation-derived reason arrays are computed before they are used.

### Description
- Move parsing of `scanResult.recommendation` into `recommendationSentences` and derive `reasonSentences`, `positiveReasons`, and `cautionReasons` earlier in the file so they are defined before `verdictReasonBuckets` is built.
- Remove the later duplicate block to avoid re-defining the same memos and potential ordering issues.
- Keep `useMemo` dependency arrays aligned with the moved computations to preserve memoization semantics.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694ced4d88832abbb5a28cec47907e)