### PR TITLE
Add flavor profile block to AI verdict section

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -2294,6 +2294,34 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
       ? sections.join('\n')
       : 'Zatiaľ nemáme dôvody prečo je káva vhodná alebo nie.';
   }, [verdictReasonBuckets]);
+  const flavorNotesSummary = useMemo(() => {
+    const notes = structuredFields.flavorNotes.value;
+    if (!notes || notes.length === 0) {
+      return null;
+    }
+    const cleaned = notes.map(note => note.trim()).filter(Boolean);
+    return cleaned.length ? cleaned.join(', ') : null;
+  }, [structuredFields.flavorNotes.value]);
+  const tasteAttributesSummary = useMemo(() => {
+    if (!tasteAttributes || tasteAttributes.length === 0) {
+      return null;
+    }
+    return tasteAttributes
+      .map(attribute => `${attribute.label.toLowerCase()} ${Math.round(attribute.value)}/10`)
+      .join(', ');
+  }, [tasteAttributes]);
+  const tasteProfileSummary = useMemo(() => {
+    if (flavorNotesSummary && tasteAttributesSummary) {
+      return `Tóny: ${flavorNotesSummary}\nProfil: ${tasteAttributesSummary}`;
+    }
+    if (flavorNotesSummary) {
+      return `Tóny: ${flavorNotesSummary}`;
+    }
+    if (tasteAttributesSummary) {
+      return `Profil: ${tasteAttributesSummary}`;
+    }
+    return 'Chuťové tóny zatiaľ neboli rozpoznané.';
+  }, [flavorNotesSummary, tasteAttributesSummary]);
   const refreshControl =
     currentView === 'home'
       ? (
@@ -3034,6 +3062,10 @@ const CoffeeTasteScanner: React.FC<ProfessionalOCRScannerProps> = ({
                               <Text style={styles.verdictConfidence}>{evaluationConfidenceLabel}</Text>
                             ) : null}
                             <Text style={styles.verdictDescription}>{verdictReasonText}</Text>
+                            <View style={styles.aiSummarySection}>
+                              <Text style={styles.sectionSubtitle}>Chuťové tóny / profil kávy</Text>
+                              <Text style={styles.verdictDescription}>{tasteProfileSummary}</Text>
+                            </View>
                             {lowDataWarning ? (
                               <View style={styles.lowDataCard}>
                                 <View style={styles.lowDataBadge}>


### PR DESCRIPTION
### Motivation
- Surface parsed flavor information alongside the AI verdict so users can see detected tasting notes and attribute scores directly in the verdict area, including when the verdict is `not_suitable`.

### Description
- Read `structuredFields.flavorNotes` and prepare a readable comma-separated summary (`flavorNotesSummary`).
- Render a concise taste attributes summary from the existing `tasteAttributes` (`tasteAttributesSummary`) and combine both into `tasteProfileSummary` with a fallback message when none are available.
- Insert a new UI block titled `Chuťové tóny / profil kávy` directly beneath the verdict description so it remains visible for all verdicts.
- Changes made in `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` (added memoized summaries and the new view block).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696952310bac832ab72d68feb945e98f)