### PR TITLE
Prepend `comparison_summary` to scan comparison output and de-duplicate lines

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -308,6 +308,31 @@ const buildComparisonText = (
     return 'Zatiaľ nemáme dôvody prečo by káva sedela alebo nie.';
   }
 
+  const verdictExplanation = evaluation?.verdict_explanation;
+  const comparisonSummary =
+    verdictExplanation && typeof verdictExplanation === 'object'
+      && typeof verdictExplanation.comparison_summary === 'string'
+      ? verdictExplanation.comparison_summary.trim()
+      : '';
+  const comparisonSummaryLines = comparisonSummary
+    ? extractSentenceBlocks(comparisonSummary)
+    : [];
+  const normalizedSummaryLines = comparisonSummaryLines.map(line =>
+    normalizeReasonLine(line).toLowerCase(),
+  );
+  const shouldOmitDuplicateLine = (line: string): boolean => {
+    if (!normalizedSummaryLines.length) {
+      return false;
+    }
+    const normalizedLine = normalizeReasonLine(line).toLowerCase();
+    if (!normalizedLine) {
+      return false;
+    }
+    return normalizedSummaryLines.some(summaryLine =>
+      summaryLine.includes(normalizedLine) || normalizedLine.includes(summaryLine),
+    );
+  };
+
   const comparison = buildScanPreferenceComparison({
     evaluation,
     coffeePreferences: preferenceSnapshot ?? coffeePreferences ?? null,
@@ -328,10 +353,17 @@ const buildComparisonText = (
     neutral: neutralInsights,
   } = splitReasonLines(comparison.reasons);
 
+  const filteredMatchLines = matchLines.filter(line => !shouldOmitDuplicateLine(line));
+  const filteredMismatchLines = mismatchLines.filter(line => !shouldOmitDuplicateLine(line));
+  const filteredPositiveInsights = positiveInsights.filter(line => !shouldOmitDuplicateLine(line));
+  const filteredCautionInsights = cautionInsights.filter(line => !shouldOmitDuplicateLine(line));
+  const filteredNeutralInsights = neutralInsights.filter(line => !shouldOmitDuplicateLine(line));
+
   const sections = [
-    formatReasonBlock('Prečo sedí', [...matchLines, ...positiveInsights]),
-    formatReasonBlock('Prečo nesedí', [...mismatchLines, ...cautionInsights]),
-    formatReasonBlock('Ďalšie zistenia', neutralInsights),
+    formatReasonBlock('Prehľad porovnania', comparisonSummaryLines),
+    formatReasonBlock('Prečo sedí', [...filteredMatchLines, ...filteredPositiveInsights]),
+    formatReasonBlock('Prečo nesedí', [...filteredMismatchLines, ...filteredCautionInsights]),
+    formatReasonBlock('Ďalšie zistenia', filteredNeutralInsights),
   ].filter((section): section is string => Boolean(section));
 
   return sections.length


### PR DESCRIPTION
### Motivation
- Ensure the AI `verdict_explanation.comparison_summary` is shown prominently before the detailed match/mismatch lines in the scan comparison text. 
- Avoid repeating the same sentences twice when the `comparison_summary` already contains the same information as the generated match/mismatch or insight lines.

### Description
- Updated `buildComparisonText` to read `evaluation?.verdict_explanation.comparison_summary` and extract sentence blocks using `extractSentenceBlocks` to create a new `Prehľad porovnania` block. 
- Introduced normalization and a `shouldOmitDuplicateLine` helper (using `normalizeReasonLine`) to filter out match/mismatch/insight lines that duplicate the summary content. 
- Prepended the `Prehľad porovnania` section to the existing sections and switched match/mismatch/insight lists to their filtered variants so the summary is primary and detailed lines remain supplemental.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696de897a8832ab9c6c8ec6951712c)