### PR TITLE
Render `comparison_summary` first in CoffeeTasteScanner

### DIFF
--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -267,6 +267,14 @@ const formatReasonBlock = (title: string, lines: string[]): string | null => {
   return `${title}\n${cleaned.map(line => `• ${line}`).join('\n')}`;
 };
 
+const formatSummaryBlock = (title: string, lines: string[]): string | null => {
+  const cleaned = uniqueLines(lines.map(normalizeReasonLine).filter(Boolean));
+  if (!cleaned.length) {
+    return null;
+  }
+  return `${title}\n${cleaned.join('\n')}`;
+};
+
 const extractVerdictExplanationLines = (
   payload: CoffeeEvaluationResult['verdict_explanation'] | null | undefined,
 ): string[] => {
@@ -360,10 +368,16 @@ const buildComparisonText = (
   const filteredNeutralInsights = neutralInsights.filter(line => !shouldOmitDuplicateLine(line));
 
   const sections = [
-    formatReasonBlock('Prehľad porovnania', comparisonSummaryLines),
-    formatReasonBlock('Prečo sedí', [...filteredMatchLines, ...filteredPositiveInsights]),
-    formatReasonBlock('Prečo nesedí', [...filteredMismatchLines, ...filteredCautionInsights]),
-    formatReasonBlock('Ďalšie zistenia', filteredNeutralInsights),
+    formatSummaryBlock('Zhrnutie porovnania', comparisonSummaryLines),
+    formatReasonBlock(
+      'Doplnkové dôvody prečo sedí',
+      [...filteredMatchLines, ...filteredPositiveInsights],
+    ),
+    formatReasonBlock(
+      'Doplnkové dôvody prečo nesedí',
+      [...filteredMismatchLines, ...filteredCautionInsights],
+    ),
+    formatReasonBlock('Doplnkové zistenia', filteredNeutralInsights),
   ].filter((section): section is string => Boolean(section));
 
   return sections.length


### PR DESCRIPTION
### Motivation
- Surface `evaluation.verdict_explanation.comparison_summary` as the primary block so the main comparison message is shown first and not buried among bullet details.
- De-emphasize match/mismatch insight lines so they appear as supplemental information and do not overshadow the summary.

### Description
- Add `formatSummaryBlock` to render summary lines without bullets while reusing normalization and uniqueness logic.
- Render `comparison_summary` lines first using `formatSummaryBlock('Zhrnutie porovnania', comparisonSummaryLines)` when `evaluation?.verdict_explanation?.comparison_summary` exists and is a string.
- Move match/mismatch/insight lists after the summary and change their headings to `Doplnkové dôvody prečo sedí`, `Doplnkové dôvody prečo nesedí`, and `Doplnkové zistenia` so they are clearly supplemental.
- Preserve existing de-duplication via `shouldOmitDuplicateLine` and do not change the extraction logic for verdict explanation fields.

### Testing
- No automated tests were run for this change.
- No CI test results are included in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696970e33394832a8fcc2d8a46895e05)