### PR TITLE
Warn when disabled evaluation helpers are called

### DIFF
--- a/src/services/ocr/evaluation.ts
+++ b/src/services/ocr/evaluation.ts
@@ -4,16 +4,26 @@ import type {
   VerdictExplanation,
 } from './types';
 
-// Evaluation logic intentionally disabled for now.
+// Evaluation logic disabled temporarily.
 // Placeholder exports keep callers stable without running comparisons.
+
+const warnEvaluationDisabled = (caller: string): void => {
+  console.warn(`[OCR] ${caller} disabled temporarily.`);
+};
 
 export const resolveVerdictExplanationText = (
   _value: VerdictExplanation | null | undefined,
-): string => '';
+): string => {
+  warnEvaluationDisabled('resolveVerdictExplanationText');
+  return '';
+};
 
 export const resolveInsightSummary = (
   _insight: CoffeeEvaluationInsight | null | undefined,
-): string => '';
+): string => {
+  warnEvaluationDisabled('resolveInsightSummary');
+  return '';
+};
 
 export const NEUTRAL_EVALUATION_COPY = {
   summary: '',
@@ -21,20 +31,23 @@ export const NEUTRAL_EVALUATION_COPY = {
   disclaimer: '',
 };
 
-export const normalizeEvaluationResponse = (_payload: unknown): CoffeeEvaluationResult => ({
-  status: 'unknown',
-  verdict: null,
-  confidence: null,
-  summary: '',
-  reasons: [],
-  dimension_diffs: [],
-  what_youll_like: [],
-  what_might_bother_you: [],
-  tips_to_make_it_better: [],
-  recommended_brew_methods: [],
-  cta: { action: null, label: null },
-  disclaimer: '',
-  verdict_explanation: '',
-  insight: null,
-  raw: null,
-});
+export const normalizeEvaluationResponse = (_payload: unknown): CoffeeEvaluationResult => {
+  warnEvaluationDisabled('normalizeEvaluationResponse');
+  return {
+    status: 'unknown',
+    verdict: null,
+    confidence: null,
+    summary: '',
+    reasons: [],
+    dimension_diffs: [],
+    what_youll_like: [],
+    what_might_bother_you: [],
+    tips_to_make_it_better: [],
+    recommended_brew_methods: [],
+    cta: { action: null, label: null },
+    disclaimer: '',
+    verdict_explanation: '',
+    insight: null,
+    raw: null,
+  };
+};

--- a/src/utils/scanPreferenceComparison.ts
+++ b/src/utils/scanPreferenceComparison.ts
@@ -31,7 +31,10 @@ export type ScanPreferenceComparisonResult = {
   reasons: string[];
 };
 
-// Placeholder implementation to disable comparisons while keeping exports stable.
+// Placeholder implementation disabled temporarily to keep exports stable.
+const warnScanComparisonDisabled = (caller: string): void => {
+  console.warn(`[ScanPreferenceComparison] ${caller} disabled temporarily.`);
+};
 const parseNumericValue = (value: unknown): number | null => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -46,6 +49,7 @@ const parseNumericValue = (value: unknown): number | null => {
 };
 
 export const normalizeVectorValue = (value: unknown): number | null => {
+  warnScanComparisonDisabled('normalizeVectorValue');
   const parsed = parseNumericValue(value);
   if (parsed == null) {
     return null;
@@ -57,7 +61,10 @@ export const normalizeVectorValue = (value: unknown): number | null => {
 
 export const buildScanPreferenceComparison = (
   _input: ScanPreferenceComparisonInput,
-): ScanPreferenceComparisonResult => ({
-  dimensions: [],
-  reasons: [],
-});
+): ScanPreferenceComparisonResult => {
+  warnScanComparisonDisabled('buildScanPreferenceComparison');
+  return {
+    dimensions: [],
+    reasons: [],
+  };
+};


### PR DESCRIPTION
### Motivation

- Temporarily surface a clear runtime warning when disabled OCR evaluation or scan-comparison helpers are invoked so callers and developers notice the feature is intentionally turned off.  
- Keep placeholder return values stable to avoid breaking call-sites while the real logic remains disabled.

### Description

- Add `warnEvaluationDisabled` and call it from `resolveVerdictExplanationText`, `resolveInsightSummary`, and `normalizeEvaluationResponse` in `src/services/ocr/evaluation.ts`, and update the surrounding comment to note the temporary disablement.  
- Add `warnScanComparisonDisabled` and call it from `normalizeVectorValue` and `buildScanPreferenceComparison` in `src/utils/scanPreferenceComparison.ts`, and update the placeholder comment to indicate temporary disablement.  
- Keep existing placeholder return values and shapes so APIs remain stable (no changes to return types or call-site contracts).  
- Warnings are emitted via `console.warn` and include the helper name for easier debugging.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b7c869bbc832a9ed3be8fe774abb8)