### PR TITLE
Remove verdict details from scan views

### DIFF
--- a/src/screens/ScanDetailScreen/index.tsx
+++ b/src/screens/ScanDetailScreen/index.tsx
@@ -11,25 +11,6 @@ interface ScanDetailScreenProps {
 const ScanDetailScreen: React.FC<ScanDetailScreenProps> = ({ scan }) => {
   const { colors } = useTheme();
 
-  const flavorNotes = Array.isArray(scan.flavor_notes)
-    ? scan.flavor_notes.filter((note): note is string => typeof note === 'string')
-    : typeof scan.flavor_notes === 'string'
-      ? [scan.flavor_notes]
-      : [];
-
-  const detailRows: { label: string; value?: string | number | null }[] = [
-    { label: 'Pražiareň / Značka', value: scan.brand },
-    { label: 'Pôvod', value: scan.origin },
-    { label: 'Praženie', value: scan.roast_level },
-    {
-      label: 'Zhoda s profilom',
-      value: typeof scan.match_percentage === 'number' ? `${scan.match_percentage}%` : 'Profil chýba',
-    },
-    { label: 'Hodnotenie', value: typeof scan.rating === 'number' ? `${scan.rating}/5` : null },
-    { label: 'Odporúčanie AI', value: scan.is_recommended === false ? 'Skôr NIE' : scan.is_recommended ? 'Skôr ÁNO' : null },
-    { label: 'Obľúbená', value: scan.is_favorite ? 'Áno' : null },
-  ];
-
   return (
     <ScrollView style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.header}>
@@ -42,25 +23,7 @@ const ScanDetailScreen: React.FC<ScanDetailScreenProps> = ({ scan }) => {
       </View>
 
       <View style={[styles.card, { backgroundColor: colors.cardBackground }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Detaily skenu</Text>
-        {detailRows
-          .filter((row) => row.value)
-          .map((row) => (
-            <View key={row.label} style={styles.row}>
-              <Text style={[styles.label, { color: colors.textSecondary }]}>{row.label}</Text>
-              <Text style={[styles.value, { color: colors.text }]}>{row.value}</Text>
-            </View>
-          ))}
-        {flavorNotes.length ? (
-          <View style={styles.row}>
-            <Text style={[styles.label, { color: colors.textSecondary }]}>Chuťové poznámky</Text>
-            <Text style={[styles.value, { color: colors.text }]}>{flavorNotes.join(', ')}</Text>
-          </View>
-        ) : null}
-      </View>
-
-      <View style={[styles.card, { backgroundColor: colors.cardBackground }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Rozpoznaný text</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Opis</Text>
         <Text style={[styles.body, { color: colors.text }]}>{scan.corrected_text || scan.original_text}</Text>
       </View>
     </ScrollView>
@@ -92,17 +55,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '700',
     marginBottom: 12,
-  },
-  row: {
-    marginBottom: 10,
-  },
-  label: {
-    fontSize: 13,
-    marginBottom: 4,
-  },
-  value: {
-    fontSize: 15,
-    fontWeight: '600',
   },
   body: {
     fontSize: 14,

--- a/src/screens/ScanHistoryScreen/index.tsx
+++ b/src/screens/ScanHistoryScreen/index.tsx
@@ -64,31 +64,9 @@ const ScanHistoryScreen: React.FC<ScanHistoryScreenProps> = ({ onSelectScan }) =
         <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
           {item.coffee_name || 'Neznáma káva'}
         </Text>
-        {item.brand ? (
-          <Text style={[styles.meta, { color: colors.text }]} numberOfLines={1}>
-            {item.brand}
-          </Text>
-        ) : null}
-        {item.origin ? (
-          <Text style={[styles.meta, { color: colors.text }]} numberOfLines={1}>
-            {item.origin}
-          </Text>
-        ) : null}
         <Text style={[styles.date, { color: colors.textSecondary  }]}>
           {new Date(item.created_at).toLocaleString('sk-SK')}
         </Text>
-        <View style={styles.metaRow}>
-          {typeof item.rating === 'number' ? (
-            <Text style={[styles.chip, { backgroundColor: colors.cardBackground , color: colors.text }]}>
-              ⭐ {item.rating}
-            </Text>
-          ) : null}
-          {item.is_recommended !== undefined || typeof item.match_percentage === 'number' ? (
-            <Text style={[styles.chip, { backgroundColor: colors.cardBackground , color: colors.text }]}>
-              🎯 {item.is_recommended === false ? 'Mimo preferencií' : 'Sedí k profilu'}
-            </Text>
-          ) : null}
-        </View>
       </View>
     </TouchableOpacity>
   );
@@ -185,17 +163,6 @@ const styles = StyleSheet.create({
   date: {
     fontSize: 13,
     marginBottom: 8,
-  },
-  metaRow: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  chip: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 8,
-    overflow: 'hidden',
-    fontSize: 12,
   },
   loaderContainer: {
     flex: 1,


### PR DESCRIPTION
### Motivation
- Simplify scan-related screens to remove subjective/AI verdict information and only display neutral metadata like name, timestamp and description.

### Description
- Update `src/screens/ScanHistoryScreen/index.tsx` to remove brand/origin lines and rating/match/AI recommendation chips, and delete corresponding styles for the chips.
- Update `src/screens/ScanDetailScreen/index.tsx` to remove the detailed info rows and flavor notes, keep only the title, timestamp and description, and rename the description section header to `Opis`.
- Changes affect the `ScanHistoryScreen` and `ScanDetailScreen` UI components only and remove about 82 lines of verdict-related rendering and styles.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b7d28e720832abd89d8e2f9d74cf0)