### PR TITLE
Remove matchPercentage/isRecommended from cached OCR payloads and brew context metadata

### DIFF
--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -102,6 +102,11 @@ const getIsoWeekday = (date: Date): number => {
   return weekday === 0 ? 7 : weekday;
 };
 
+const sanitizeMetadata = (metadata: Record<string, unknown>): Record<string, unknown> => {
+  const { matchPercentage, isRecommended, match_percentage, is_recommended, ...rest } = metadata;
+  return rest;
+};
+
 const buildBrewContext = (metadata?: Record<string, unknown>): BrewContext => {
   const now = new Date();
   const context: BrewContext = {
@@ -110,7 +115,10 @@ const buildBrewContext = (metadata?: Record<string, unknown>): BrewContext => {
   };
 
   if (metadata && Object.keys(metadata).length > 0) {
-    context.metadata = { ...metadata };
+    const sanitizedMetadata = sanitizeMetadata(metadata);
+    if (Object.keys(sanitizedMetadata).length > 0) {
+      context.metadata = { ...sanitizedMetadata };
+    }
   }
 
   return context;

--- a/src/screens/CoffeeTasteScanner/utils.ts
+++ b/src/screens/CoffeeTasteScanner/utils.ts
@@ -19,6 +19,11 @@ export const getIsoWeekday = (date: Date): number => {
   return weekday === 0 ? 7 : weekday;
 };
 
+const sanitizeMetadata = (metadata: Record<string, unknown>): Record<string, unknown> => {
+  const { matchPercentage, isRecommended, match_percentage, is_recommended, ...rest } = metadata;
+  return rest;
+};
+
 export const buildBrewContext = (metadata?: Record<string, unknown>): BrewContext => {
   const now = new Date();
   const context: BrewContext = {
@@ -27,7 +32,10 @@ export const buildBrewContext = (metadata?: Record<string, unknown>): BrewContex
   };
 
   if (metadata && Object.keys(metadata).length > 0) {
-    context.metadata = { ...metadata };
+    const sanitizedMetadata = sanitizeMetadata(metadata);
+    if (sanitizedMetadata && Object.keys(sanitizedMetadata).length > 0) {
+      context.metadata = { ...sanitizedMetadata };
+    }
   }
 
   return context;

--- a/src/services/offlineCache.ts
+++ b/src/services/offlineCache.ts
@@ -2,6 +2,19 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const LAST_KEY = 'ocr:last';
 
+const sanitizeRecommendationFields = (payload: any): any => {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+
+  if (Array.isArray(payload)) {
+    return payload.map((item) => sanitizeRecommendationFields(item));
+  }
+
+  const { matchPercentage, isRecommended, match_percentage, is_recommended, ...rest } = payload;
+  return rest;
+};
+
 /**
  * Persists an OCR parsing result in local encrypted storage and tracks the last
  * saved identifier for easy retrieval.
@@ -15,7 +28,8 @@ const LAST_KEY = 'ocr:last';
  */
 export const saveOCRResult = async (id: string, payload: any) => {
   try {
-    await AsyncStorage.setItem(`ocr:${id}`, JSON.stringify(payload));
+    const sanitizedPayload = sanitizeRecommendationFields(payload);
+    await AsyncStorage.setItem(`ocr:${id}`, JSON.stringify(sanitizedPayload));
     await AsyncStorage.setItem(LAST_KEY, id);
   } catch (error) {
     console.error('Error saving OCR result:', error);
@@ -39,7 +53,7 @@ export const loadOCRResult = async (id?: string) => {
       if (!key) return null;
     }
     const data = await AsyncStorage.getItem(`ocr:${key}`);
-    return data ? JSON.parse(data) : null;
+    return data ? sanitizeRecommendationFields(JSON.parse(data)) : null;
   } catch (error) {
     console.error('Error loading OCR result:', error);
     return null;


### PR DESCRIPTION
### Motivation
- Prevent persisting transient AI recommendation signals (`matchPercentage` / `isRecommended`) in local cache and diary context to avoid leaking or depending on volatile recommendation fields.
- Ensure diary `context.metadata` and offline OCR cache do not include match/recommendation flags that are not needed for personalization logic.

### Description
- Strip recommendation fields when saving/loading OCR results by adding `sanitizeRecommendationFields` to `src/services/offlineCache.ts` so `matchPercentage`, `isRecommended` and snake_case variants are removed.
- Sanitize metadata passed into `buildBrewContext` in `src/screens/CoffeeTasteScanner/utils.ts` and `src/screens/CoffeeReceipeScanner/index.tsx` via a new `sanitizeMetadata` helper so those keys are not copied into `context.metadata`.
- Ensure `loadOCRResult` also returns a sanitized object so existing cached entries won’t reintroduce the removed fields.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b7e3d1e60832a9358d942275096b2)