### PR TITLE
Simplify OCR processing result payload

### DIFF
--- a/src/services/ocr/processOCR.ts
+++ b/src/services/ocr/processOCR.ts
@@ -1,20 +1,16 @@
-import { API_HOST, API_URL } from '../api';
+import { API_HOST } from '../api';
 import { normalizeKeysToSnakeCase } from '../../utils/normalize';
-import { getAuthToken } from './auth';
 import { fixTextWithAI } from './aiServices';
-import { estimateCoffeeAttributesFromText, mergeStructuredMetadata, normalizeStructuredMetadataPayload } from './metadata';
 import { ensureOnline, loggedFetch } from './network';
 import { isCoffeeRelatedText } from './textDetection';
-import type { OCRResult, StructuredCoffeeMetadata } from './types';
-import { safeParseJSON } from './utils';
+import type { OCRResult } from './types';
 
 /**
- * Processes OCR using backend services with offline fallbacks, AI enrichment, label detection,
- * and structured metadata parsing.
+ * Processes OCR using backend services with offline fallbacks, AI enrichment, and label detection.
  *
  * @param {string} base64image - Base64 encoded image captured from the coffee label.
  * @param {{ imagePath?: string }} [options] - Optional hints including a pre-saved image path to reuse for offline flow.
- * @returns {Promise<OCRResult|null>} Consolidated OCR result including recommendations and metadata, or `null` when offline fallback fails.
+ * @returns {Promise<OCRResult|null>} Consolidated OCR result, or `null` when offline fallback fails.
  * @throws {Error} Propagates unexpected errors other than offline scenarios which are handled via fallback logic.
  */
 export const processOCR = async (
@@ -57,16 +53,6 @@ export const processOCR = async (
     const detectionLabels: string[] | undefined = Array.isArray(ocrData.labels)
       ? ocrData.labels.filter((label: unknown): label is string => typeof label === 'string')
       : undefined;
-    const detectionConfidence =
-      typeof ocrData.coffeeConfidence === 'number' ? ocrData.coffeeConfidence : undefined;
-    const initialStructuredMetadata = safeParseJSON<Record<string, unknown>>(
-      ocrData.structured_metadata ?? ocrData.structuredMetadata
-    );
-    const initialNormalizedStructuredMetadata =
-      normalizeStructuredMetadataPayload(initialStructuredMetadata);
-    const initialStructuredConfidence = safeParseJSON<Record<string, unknown>>(
-      ocrData.structured_confidence ?? ocrData.structuredConfidence
-    );
 
     // 2. Oprav text pomocou AI
     const correctedText = await fixTextWithAI(originalText);
@@ -90,119 +76,11 @@ export const processOCR = async (
       nonCoffeeReason = `Rozpoznané: ${detectionLabels.slice(0, 3).join(', ')}`;
     }
 
-    let scanId = '';
-    let structuredMetadata: StructuredCoffeeMetadata | null = null;
-    let structuredConfidence: Record<string, unknown> | null = null;
-    let structuredUncertainty: Record<string, unknown> | null = null;
-    let rawStructuredResponse: unknown = null;
-
-    let token: string | null = null;
-    const hasCoffeeTextSignals =
-      hasReadableText &&
-      (isCoffeeRelatedText(trimmedCorrectedText) || isCoffeeRelatedText(originalText));
-    const minTextOnlyLength = 40;
-    const hasTextOnlyCoffeeSignal =
-      !detectionLabels?.length &&
-      !initialStructuredMetadata &&
-      trimmedCorrectedText.length >= minTextOnlyLength &&
-      isCoffeeRelatedText(trimmedCorrectedText);
-    const shouldPersistScan =
-      hasCoffeeTextSignals ||
-      hasTextOnlyCoffeeSignal ||
-      (isCoffee &&
-        (Boolean(detectionLabels?.length) || Boolean(initialStructuredMetadata)));
-    const shouldEvaluate = isCoffee !== false && hasReadableText;
-    if (shouldEvaluate || shouldPersistScan) {
-      await ensureOnline();
-      token = await getAuthToken();
-      if (!token) {
-        throw new Error('Nie si prihlásený');
-      }
-    }
-    if (shouldPersistScan) {
-      const savePayload: Record<string, unknown> = {
-        original_text: originalText,
-        corrected_text: trimmedCorrectedText,
-      };
-      if (initialStructuredMetadata) {
-        savePayload.structured_metadata = initialStructuredMetadata;
-      }
-      if (initialStructuredConfidence) {
-        savePayload.structured_confidence = initialStructuredConfidence;
-      }
-
-      const saveResponse = await loggedFetch(`${API_URL}/ocr/save`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        // Expect snake_case keys for OCR payloads (manual QA: verify request body format).
-        body: JSON.stringify(normalizeKeysToSnakeCase(savePayload)),
-      });
-
-      if (saveResponse.ok) {
-        const saveData = await saveResponse.json();
-        console.log('📥 [BE] Save OCR response:', saveData);
-        scanId = saveData.id || '';
-
-        const metadataRaw =
-          saveData.structured_metadata ??
-          saveData.structuredMetadata ??
-          initialStructuredMetadata;
-        const metadataParsed = safeParseJSON<Record<string, any>>(metadataRaw);
-        structuredMetadata = normalizeStructuredMetadataPayload(metadataParsed);
-        if (structuredMetadata) {
-          rawStructuredResponse = metadataParsed;
-        }
-
-        structuredConfidence = safeParseJSON<Record<string, unknown>>(
-          saveData.structured_confidence ??
-            saveData.structuredConfidence ??
-            initialStructuredConfidence
-        );
-        structuredUncertainty = safeParseJSON<Record<string, unknown>>(
-          saveData.structured_uncertainty
-        );
-        if (rawStructuredResponse == null) {
-          rawStructuredResponse = metadataRaw ?? null;
-        }
-      }
-    }
-    if (!structuredMetadata && initialNormalizedStructuredMetadata) {
-      structuredMetadata = initialNormalizedStructuredMetadata;
-      if (rawStructuredResponse == null) {
-        rawStructuredResponse = initialStructuredMetadata;
-      }
-    }
-    if (!structuredConfidence && initialStructuredConfidence) {
-      structuredConfidence = initialStructuredConfidence;
-    }
-    // 4. Získaj odhadované atribúty z textu etikety
-    const estimatedAttributes = estimateCoffeeAttributesFromText(trimmedCorrectedText);
-    const mergedStructuredMetadata = mergeStructuredMetadata(
-      structuredMetadata,
-      estimatedAttributes,
-    );
-    structuredMetadata = mergedStructuredMetadata;
-    const recommendation = hasReadableText
-      ? `AI opis: ${trimmedCorrectedText}`
-      : 'Z etikety sa nepodarilo získať čitateľný text.';
-
     return {
       original: originalText,
       corrected: trimmedCorrectedText,
-      recommendation,
-      scanId,
-      source: 'online',
       isCoffee,
-      detectionLabels,
-      detectionConfidence,
       nonCoffeeReason,
-      structuredMetadata,
-      structuredConfidence,
-      structuredUncertainty,
-      rawStructuredResponse,
     };
   } catch (error) {
     console.error('OCR processing error:', error);

--- a/src/services/ocr/types.ts
+++ b/src/services/ocr/types.ts
@@ -89,37 +89,8 @@ export interface CoffeeEvaluationResult {
 export interface OCRResult {
   original: string;
   corrected: string;
-  recommendation: string;
-  matchPercentage?: number | null;
-  isRecommended?: boolean;
-  scanId?: string;
-  brewingMethods?: string[];
-  source?: 'offline' | 'online';
   isCoffee?: boolean;
   nonCoffeeReason?: string;
-  /**
-   * Labels returned by Vision label detection (e.g., "coffee", "espresso").
-   * Optional when the backend does not return label annotations.
-   */
-  detectionLabels?: string[];
-  /**
-   * Confidence score derived from label detection for coffee-related labels.
-   * Optional and may be undefined when label detection is unavailable.
-   */
-  detectionConfidence?: number;
-  /**
-   * Structured metadata extracted from OCR text when available (e.g., origin, roast, notes).
-   */
-  structuredMetadata?: StructuredCoffeeMetadata | null;
-  /**
-   * Confidence flags for structured metadata extraction when provided by the backend.
-   */
-  structuredConfidence?: Record<string, unknown> | null;
-  structuredUncertainty?: Record<string, unknown> | null;
-  rawStructuredResponse?: unknown;
-  evaluation?: CoffeeEvaluationResult | null;
-  tasteProfileSent?: boolean;
-  tasteProfileRejectedAsStale?: boolean;
 }
 
 export interface OCRHistory {


### PR DESCRIPTION
### Motivation
- Reduce the OCR result surface and stop persisting scans to the backend, keeping only the minimal fields required for the UX (original/corrected text and optional coffee guard info).
- Remove structured metadata, evaluation and other result fields that are no longer used by the client and avoid calling `/ocr/save`.

### Description
- Updated `src/services/ocr/processOCR.ts` to stop calling the save endpoint and removed all persistence, structured metadata parsing/merging, and evaluation logic, returning only `original`, `corrected`, `isCoffee` and `nonCoffeeReason`.
- Removed unused imports from `processOCR` (`API_URL`, `getAuthToken`, metadata helpers and JSON-safe parsing utilities) and simplified the function JSDoc and flow.
- Slimmed the `OCRResult` type in `src/services/ocr/types.ts` to only include `original`, `corrected`, `isCoffee?` and `nonCoffeeReason?`, removing recommendation, matchPercentage, scanId, brewingMethods, detection/structured fields, evaluation, and other result properties.
- Ensured the returned object from `processOCR` matches the new `OCRResult` shape.

### Testing
- No automated tests were run as part of this change.
- Manual verification is recommended (TypeScript type check / app build) before merging to ensure no callers expect removed fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b81c01dcc832abede8f5b48719d1f)