### PR TITLE
Remove scan history/navigation and hide scan result UIs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,6 @@ import AuthScreen from './src/components/auth/AuthVisual';
 import HomeScreen from './src/screens/HomeScreen';
 import CoffeeTasteScanner from './src/screens/CoffeeTasteScanner';
 import CoffeeReceipeScanner from './src/screens/CoffeeReceipeScanner';
-import RecipeHistoryDetailScreen from './src/screens/CoffeeReceipeScanner/RecipeHistoryDetailScreen';
 import { DiscoverCoffeesScreen, } from './src/screens/AllCoffeesScreen';
 import UserProfile from './src/screens/UserProfile';
 import EditUserProfile from './src/components/profile/EditUserProfile';
@@ -19,8 +18,6 @@ import RecipeStepsScreen from './src/screens/RecipeStepsScreen/RecipeStepsScreen
 import PersonalizationDashboard from './src/components/personalization/PersonalizationDashboard';
 import BrewHistoryScreen from './src/screens/BrewHistory';
 import BrewHistoryDetailScreen from './src/screens/BrewHistory/DetailScreen';
-import ScanHistoryScreen from './src/screens/ScanHistoryScreen';
-import ScanDetailScreen from './src/screens/ScanDetailScreen';
 import BrewLogForm from './src/components/brew/BrewLogForm';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import { scale } from './src/theme/responsive';
@@ -33,9 +30,8 @@ import SavedTipsScreen from './src/screens/SavedTipsScreen';
 import ScannedCoffeeDetailScreen from './src/screens/ScannedCoffeeDetailScreen';
 import TipsScreen from './src/screens/TipsScreen';
 
-import type { RecipeHistory } from './src/services/recipeServices';
 import { fetchRecipeHistory, fetchRecipes } from './src/services/recipeServices';
-import { fetchCoffees, fetchScanHistory } from './src/services/homePagesService';
+import { fetchCoffees } from './src/services/homePagesService';
 import { fetchRecentScans } from './src/services/coffeeServices';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import { PreferenceLearningEngine } from './src/services/PreferenceLearningEngine';
@@ -59,7 +55,6 @@ import { SUPABASE_ANON_KEY, SUPABASE_URL } from './src/config/env';
 import { API_URL } from './src/services/api';
 import type { BrewLog } from './src/types/BrewLog';
 import type { BrewDevice, Recipe } from './src/types/Recipe';
-import type { OCRHistory } from './src/services/ocrServices';
 import { hydrateUserSignals } from './src/services/userSignals';
 
 type ScreenName =
@@ -73,7 +68,6 @@ type ScreenName =
   | 'discover'
   | 'recipes'
   | 'recipe-steps'
-  | 'recipe-history-detail'
   | 'favorites'
   | 'inventory'
   | 'taste-quiz'
@@ -83,8 +77,6 @@ type ScreenName =
   | 'brew-log'
   | 'community-recipes'
   | 'saved-tips'
-  | 'scan-history'
-  | 'scan-detail'
   | 'coffee-detail';
 
 type AuthNotice = {
@@ -677,8 +669,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
   const [checkingTasteQuiz, setCheckingTasteQuiz] = useState(true);
 
   const [selectedBrewLog, setSelectedBrewLog] = useState<BrewLog | null>(null);
-  const [selectedRecipeHistory, setSelectedRecipeHistory] = useState<RecipeHistory | null>(null);
-  const [selectedScan, setSelectedScan] = useState<OCRHistory | null>(null);
   const [selectedCoffeeId, setSelectedCoffeeId] = useState<string | null>(null);
   const [authNotice] = useState<AuthNotice | null>(null);
   const { isDark, colors } = useTheme();
@@ -857,7 +847,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
           fetchRecipes(),
           fetchCoffees(),
           fetchRecipeHistory(50),
-          fetchScanHistory(20),
           fetchRecentScans(20),
         ]);
       } catch (error) {
@@ -1263,15 +1252,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     setCurrentScreen('scanner');
   };
 
-  const handleScanHistoryPress = () => {
-    setCurrentScreen('scan-history');
-  };
-
-  const handleScanDetailPress = (scan: OCRHistory) => {
-    setSelectedScan(scan);
-    setCurrentScreen('scan-detail');
-  };
-
   // Open dedicated scanner for preparing a drink (same as scan for now)
   const handleBrewPress = () => {
     setCurrentScreen('brew');
@@ -1356,32 +1336,12 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
     setCurrentScreen('brew-history');
   };
 
-  const handleRecipeHistoryEntryPress = (entry: RecipeHistory) => {
-    setSelectedRecipeHistory(entry);
-    setCurrentScreen('recipe-history-detail');
-  };
-
-  const handleRecipeHistoryDetailBack = () => {
-    setSelectedRecipeHistory(null);
-    setCurrentScreen('brew');
-  };
-
   const handleCommunityRecipesPress = () => {
     setCurrentScreen('community-recipes');
   };
 
   const handleSavedTipsPress = () => {
     setCurrentScreen('saved-tips');
-  };
-
-  const handleScanHistoryBack = () => {
-    setSelectedScan(null);
-    setCurrentScreen('scanner');
-  };
-
-  const handleScanDetailBack = () => {
-    setSelectedScan(null);
-    setCurrentScreen('scan-history');
   };
 
   // Navigate to coffee detail when a card is tapped in "Moje kávy".
@@ -1398,8 +1358,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
 
   const handleBackPress = () => {
     setSelectedBrewLog(null);
-    setSelectedRecipeHistory(null);
-    setSelectedScan(null);
     setSelectedCoffeeId(null);
     setCurrentScreen('home');
   };
@@ -1492,69 +1450,8 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
           </TouchableOpacity>
         </View>
         <CoffeeTasteScanner
-          onHistoryPress={handleScanHistoryPress}
           onQuestionnairePress={handleScannerPreferencesPress}
         />
-        <BottomNav
-          active="home"
-          onHomePress={handleBackPress}
-          onDiscoverPress={handleDiscoverPress}
-          onRecipesPress={handleRecipesPress}
-          onFavoritesPress={handleFavoritesPress}
-          onProfilePress={handleProfilePress}
-        />
-      </ResponsiveWrapper>
-    );
-  }
-
-  if (currentScreen === 'scan-history') {
-    return (
-      <ResponsiveWrapper
-        backgroundColor={colors.background}
-        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
-        statusBarBackground={colors.background}
-      >
-        <View style={styles.header}>
-          <TouchableOpacity
-            style={[styles.backButton, { backgroundColor: colors.primary }]}
-            onPress={handleScanHistoryBack}
-          >
-            <Text style={styles.backButtonText}>← Späť</Text>
-          </TouchableOpacity>
-        </View>
-        <ScanHistoryScreen onBack={handleScanHistoryBack} onSelectScan={handleScanDetailPress} />
-        <BottomNav
-          active="home"
-          onHomePress={handleBackPress}
-          onDiscoverPress={handleDiscoverPress}
-          onRecipesPress={handleRecipesPress}
-          onFavoritesPress={handleFavoritesPress}
-          onProfilePress={handleProfilePress}
-        />
-      </ResponsiveWrapper>
-    );
-  }
-
-  if (currentScreen === 'scan-detail') {
-    if (!selectedScan) {
-      return null;
-    }
-
-    return (
-      <ResponsiveWrapper
-        backgroundColor={colors.background}
-        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
-        statusBarBackground={colors.background}
-      >
-        <View style={styles.header}>
-          <TouchableOpacity
-            style={[styles.backButton, { backgroundColor: colors.primary }]}
-            onPress={handleScanDetailBack}
-          >
-            <Text style={styles.backButtonText}>← Späť</Text>
-          </TouchableOpacity>
-        </View>
-        <ScanDetailScreen scan={selectedScan} onBack={handleScanDetailBack} />
         <BottomNav
           active="home"
           onHomePress={handleBackPress}
@@ -1619,7 +1516,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
             setRecipeStepsReturnTo('brew');
             setCurrentScreen('recipe-steps');
           }}
-          onRecipeHistoryPress={handleRecipeHistoryEntryPress}
           onSeeAllRecipes={handleSeeAllRecipes}
         />
         <BottomNav
@@ -1657,37 +1553,6 @@ const AppContent = ({ personalization, setPersonalization }: AppContentProps): R
         />
         <BottomNav
           active={recipeStepsReturnTo === 'recipes' ? 'recipes' : 'home'}
-          onHomePress={handleBackPress}
-          onDiscoverPress={handleDiscoverPress}
-          onRecipesPress={handleRecipesPress}
-          onFavoritesPress={handleFavoritesPress}
-          onProfilePress={handleProfilePress}
-        />
-      </ResponsiveWrapper>
-    );
-  }
-
-  if (currentScreen === 'recipe-history-detail') {
-    if (!selectedRecipeHistory) {
-      return null;
-    }
-
-    return (
-      <ResponsiveWrapper
-        backgroundColor={colors.background}
-        statusBarStyle={isDark ? 'light-content' : 'dark-content'}
-        statusBarBackground={colors.background}
-      >
-        <View style={styles.header}>
-          <TouchableOpacity
-            style={[styles.backButton, { backgroundColor: colors.primary }]}
-            onPress={handleRecipeHistoryDetailBack}>
-            <Text style={styles.backButtonText}>← Späť</Text>
-          </TouchableOpacity>
-        </View>
-        <RecipeHistoryDetailScreen entry={selectedRecipeHistory} />
-        <BottomNav
-          active="home"
           onHomePress={handleBackPress}
           onDiscoverPress={handleDiscoverPress}
           onRecipesPress={handleRecipesPress}

--- a/src/screens/CoffeeReceipeScanner/RecipeHistoryDetailScreen.tsx
+++ b/src/screens/CoffeeReceipeScanner/RecipeHistoryDetailScreen.tsx
@@ -1,28 +1,7 @@
 import React, { useMemo } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
-import type { RecipeHistory } from '../../services/recipeServices';
 import { useTheme } from '../../theme/ThemeProvider';
 import type { Colors } from '../../theme/colors';
-
-type RecipeHistoryDetailScreenProps = {
-  entry: RecipeHistory;
-};
-
-const formatDate = (iso: string): string => {
-  try {
-    const date = new Date(iso);
-    if (Number.isNaN(date.getTime())) {
-      return iso;
-    }
-    return date.toLocaleDateString('sk-SK', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-  } catch (error) {
-    return iso;
-  }
-};
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -53,11 +32,6 @@ const createStyles = (colors: Colors) =>
       fontSize: 14,
       color: colors.textSecondary,
     },
-    heroDevice: {
-      fontSize: 14,
-      color: colors.textSecondary,
-      marginTop: 8,
-    },
     section: {
       backgroundColor: colors.cardBackground,
       borderRadius: 16,
@@ -80,41 +54,36 @@ const createStyles = (colors: Colors) =>
       lineHeight: 20,
       color: colors.textSecondary,
     },
-    recipeLine: {
+    messageText: {
       fontSize: 14,
-      lineHeight: 22,
-      color: colors.text,
-      marginBottom: 8,
+      lineHeight: 20,
+      color: colors.textSecondary,
     },
   });
 
-const RecipeHistoryDetailScreen: React.FC<RecipeHistoryDetailScreenProps> = ({ entry }) => {
+const RecipeHistoryDetailScreen: React.FC = () => {
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const recipeLines = useMemo(() => entry.recipe.split('\n'), [entry.recipe]);
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <View style={styles.heroCard}>
-        <Text style={styles.heroTitle}>{entry.method}</Text>
-        <Text style={styles.heroMeta}>{formatDate(entry.created_at)}</Text>
-        {entry.brewDevice ? (
-          <Text style={styles.heroDevice}>Zariadenie: {entry.brewDevice}</Text>
-        ) : null}
+        <Text style={styles.heroTitle}>História receptov</Text>
+        <Text style={styles.heroMeta}>Podrobnosti receptu sú momentálne skryté.</Text>
       </View>
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Chuťový profil</Text>
-        <Text style={styles.sectionText}>{entry.taste || 'Neuvedené'}</Text>
+        <Text style={styles.sectionText}>
+          Obsah receptov a chuťové poznámky sa momentálne nezobrazujú.
+        </Text>
       </View>
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Recept</Text>
-        {recipeLines.map((line, index) => (
-          <Text key={`${line}-${index}`} style={styles.recipeLine}>
-            {line.trim().length > 0 ? line : '\u00A0'}
-          </Text>
-        ))}
+        <Text style={styles.messageText}>
+          Táto obrazovka zostáva dostupná, no bez výsledkov skenovania alebo uložených údajov.
+        </Text>
       </View>
     </ScrollView>
   );

--- a/src/screens/CoffeeReceipeScanner/index.tsx
+++ b/src/screens/CoffeeReceipeScanner/index.tsx
@@ -31,7 +31,6 @@ import { showToast } from '../../utils/toast';
 interface BrewScannerProps {
   onBack?: () => void;
   onRecipeGenerated?: (recipe: string) => void;
-  onRecipeHistoryPress?: (entry: unknown) => void;
   onSeeAllRecipes?: () => void;
 }
 

--- a/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
+++ b/src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx
@@ -30,7 +30,6 @@ import { COFFEE_GRADIENT, WELCOME_GRADIENT } from './constants';
 
 interface ProfessionalOCRScannerProps {
   onBack?: () => void;
-  onHistoryPress?: () => void;
   onQuestionnairePress?: () => void;
 }
 

--- a/src/screens/ScanDetailScreen/index.tsx
+++ b/src/screens/ScanDetailScreen/index.tsx
@@ -1,32 +1,26 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
-import type { OCRHistory } from '../../services/ocr/types';
+import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../../theme/ThemeProvider';
 
-interface ScanDetailScreenProps {
-  scan: OCRHistory;
-  onBack?: () => void;
-}
-
-const ScanDetailScreen: React.FC<ScanDetailScreenProps> = ({ scan }) => {
+const ScanDetailScreen: React.FC = () => {
   const { colors } = useTheme();
 
   return (
-    <ScrollView style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.header}>
-        <Text style={[styles.title, { color: colors.text }]}>{scan.coffee_name || 'Neznáma káva'}</Text>
-        {scan.created_at ? (
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-            {new Date(scan.created_at).toLocaleString('sk-SK')}
-          </Text>
-        ) : null}
+        <Text style={[styles.title, { color: colors.text }]}>Detail skenu</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Výsledky skenu sa momentálne nezobrazujú.
+        </Text>
       </View>
 
       <View style={[styles.card, { backgroundColor: colors.cardBackground }]}>
-        <Text style={[styles.sectionTitle, { color: colors.text }]}>Opis</Text>
-        <Text style={[styles.body, { color: colors.text }]}>{scan.corrected_text || scan.original_text}</Text>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Ďakujeme za pochopenie</Text>
+        <Text style={[styles.body, { color: colors.textSecondary }]}>
+          Táto obrazovka je pripravená pre budúce využitie bez zobrazenia údajov zo skenovania.
+        </Text>
       </View>
-    </ScrollView>
+    </View>
   );
 };
 

--- a/src/screens/ScanHistoryScreen/index.tsx
+++ b/src/screens/ScanHistoryScreen/index.tsx
@@ -1,77 +1,22 @@
-import React, { useState } from 'react';
-import {
-  ActivityIndicator,
-  FlatList,
-  Image,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
-import type { OCRHistory } from '../../services/ocr/types';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../../theme/ThemeProvider';
 
-interface ScanHistoryScreenProps {
-  onBack?: () => void;
-  onSelectScan?: (scan: OCRHistory) => void;
-}
-
-const ScanHistoryScreen: React.FC<ScanHistoryScreenProps> = ({ onSelectScan }) => {
+const ScanHistoryScreen: React.FC = () => {
   const { colors } = useTheme();
-  const [history] = useState<OCRHistory[]>([]);
-  const [loading] = useState(false);
-
-  const renderItem = ({ item }: { item: OCRHistory }) => (
-    <TouchableOpacity
-      style={[styles.item, { borderColor: colors.border }]}
-      onPress={() => onSelectScan?.(item)}
-    >
-      {item.thumbnail_url ? (
-        <Image source={{ uri: item.thumbnail_url }} style={styles.thumbnail} />
-      ) : (
-        <View style={[styles.thumbnailPlaceholder, { backgroundColor: colors.cardBackground  }]}>
-          <Text style={styles.thumbnailEmoji}>☕</Text>
-        </View>
-      )}
-      <View style={styles.itemContent}>
-        <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
-          {item.coffee_name || 'Neznáma káva'}
-        </Text>
-        <Text style={[styles.date, { color: colors.textSecondary  }]}>
-          {new Date(item.created_at).toLocaleString('sk-SK')}
-        </Text>
-      </View>
-    </TouchableOpacity>
-  );
-
-  if (loading) {
-    return (
-      <View style={styles.loaderContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
-      </View>
-    );
-  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.headerRow}>
         <Text style={[styles.title, { color: colors.text }]}>História skenovaní</Text>
       </View>
-      <FlatList
-        data={history}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
-        ListEmptyComponent={
-          <View style={styles.emptyState}>
-            <Text style={[styles.emptyIcon, { color: colors.primary }]}>📷</Text>
-            <Text style={[styles.emptyTitle, { color: colors.text }]}>Žiadne skeny</Text>
-            <Text style={[styles.emptySubtitle, { color: colors.textSecondary  }]}>
-              Začni skenovať a uvidíš tu svoje výsledky.
-            </Text>
-          </View>
-        }
-      />
+      <View style={styles.emptyState}>
+        <Text style={[styles.emptyIcon, { color: colors.primary }]}>📷</Text>
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>História je skrytá</Text>
+        <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
+          Výsledky skenovania sa momentálne nezobrazujú.
+        </Text>
+      </View>
     </View>
   );
 };
@@ -92,54 +37,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 22,
     fontWeight: '700',
-  },
-  listContent: {
-    paddingBottom: 32,
-  },
-  item: {
-    flexDirection: 'row',
-    padding: 12,
-    borderRadius: 12,
-    borderWidth: 1,
-    marginBottom: 12,
-  },
-  thumbnail: {
-    width: 64,
-    height: 64,
-    borderRadius: 12,
-    marginRight: 12,
-  },
-  thumbnailPlaceholder: {
-    width: 64,
-    height: 64,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 12,
-  },
-  thumbnailEmoji: {
-    fontSize: 26,
-  },
-  itemContent: {
-    flex: 1,
-  },
-  name: {
-    fontSize: 16,
-    fontWeight: '700',
-    marginBottom: 2,
-  },
-  meta: {
-    fontSize: 14,
-    marginBottom: 2,
-  },
-  date: {
-    fontSize: 13,
-    marginBottom: 8,
-  },
-  loaderContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   emptyState: {
     alignItems: 'center',


### PR DESCRIPTION
### Motivation
- Remove scan-result navigation and UI surfaces so scanning results are no longer accessible from the main app flow and stored scan contents are hidden.
- Keep screens available for future uses but strip or hide any elements that surface OCR/recipe scan data or related selection state.

### Description
- Removed scan-related imports and routes from `App.tsx`, including `scan-history`, `scan-detail` and `recipe-history-detail` navigation branches and their state handlers, and stopped prefetching `fetchScanHistory`.
- Removed `selectedScan` and `selectedRecipeHistory` state and all navigation handlers and UI branches that exposed scan or recipe-history details in `App.tsx` and removed history callbacks passed into scanner components.
- Simplified scanner component props by removing history-related callbacks from `src/screens/CoffeeTasteScanner/CoffeeTasteScanner.tsx` and `src/screens/CoffeeReceipeScanner/index.tsx`.
- Replaced detailed result UIs with neutral placeholders in `src/screens/ScanHistoryScreen/index.tsx`, `src/screens/ScanDetailScreen/index.tsx`, and `src/screens/CoffeeReceipeScanner/RecipeHistoryDetailScreen.tsx` so screens remain but do not display scan results or ingest scan data.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b834926fc832aaf3a855ba22fe2ef)