### PR TITLE
Disable local scan caching and stub OCR cache storage

### DIFF
--- a/src/services/coffeeServices.ts
+++ b/src/services/coffeeServices.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import NetInfo from '@react-native-community/netinfo';
 import auth from '@react-native-firebase/auth';
 import { API_URL } from './api';
@@ -9,17 +8,15 @@ export interface RecentScan {
   imageUrl?: string;
 }
 
-const STORAGE_KEY = 'recentScans';
 const MAX_RECENT_SCANS = 20;
 const MAX_IMAGE_URL_LENGTH = 1000;
 const MAX_IMAGE_DATA_URI_LENGTH = 8000;
-const MAX_STORAGE_BYTES = 150 * 1024;
 
 /**
  * Normalizes loose scan payloads coming from network or storage into a consistent shape.
  *
  * Converts mixed id/name/image fields while dropping oversized data URIs to prevent
- * AsyncStorage cursor errors.
+ * memory bloat from large data payloads.
  *
  * @param {RecentScan | Record<string, any>} scan - Partial scan object from API or local cache that may use varying keys.
  * @returns {RecentScan} A sanitized scan object with guaranteed `id`, `name`, and optional `imageUrl` fields.
@@ -66,109 +63,31 @@ const sanitizeRecentScan = (scan: RecentScan | Record<string, any>): RecentScan 
   };
 };
 
-const estimateStorageBytes = (value: string): number => {
-  if (typeof TextEncoder !== 'undefined') {
-    return new TextEncoder().encode(value).length;
-  }
-
-  return value.length;
-};
-
-const trimScansToStorageLimit = (scans: RecentScan[]): RecentScan[] => {
-  const trimmed = [...scans];
-  while (trimmed.length > 0) {
-    const size = estimateStorageBytes(JSON.stringify(trimmed));
-    if (size <= MAX_STORAGE_BYTES) {
-      break;
-    }
-    trimmed.pop();
-  }
-  return trimmed;
-};
-
 /**
- * Stores a new recent scan entry, deduplicating by id and trimming the list size.
+ * Stubbed out recent scan storage to avoid persisting scan cache locally.
  *
  * @param {RecentScan} scan - Scan metadata to persist including id, name, and optional image URL.
- * @returns {Promise<void>} Promise resolving when the updated list is written to AsyncStorage.
+ * @returns {Promise<void>} Promise resolving immediately without storage.
  */
-export const addRecentScan = async (scan: RecentScan): Promise<void> => {
-  try {
-    const scans = await readCachedScans();
-    const sanitized = sanitizeRecentScan(scan);
-    const updated = trimScansToStorageLimit([
-      sanitized,
-      ...scans.filter((s) => s.id !== sanitized.id),
-    ].slice(0, MAX_RECENT_SCANS));
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-  } catch (err) {
-    console.error('Failed to store recent scan', err);
-  }
-};
-
-const ROW_TOO_BIG_MESSAGE = 'Row too big to fit into CursorWindow';
+export const addRecentScan = async (_scan: RecentScan): Promise<void> => {};
 
 /**
- * Reads and normalizes cached scans from AsyncStorage, clearing corrupted entries.
- *
- * @returns {Promise<RecentScan[]>} Array of sanitized scans; empty when no cache is present.
- * @throws {Error} Re-throws unexpected storage errors except for oversized row issues which are handled gracefully.
- */
-const readCachedScans = async (): Promise<RecentScan[]> => {
-  try {
-    const cachedRaw = await AsyncStorage.getItem(STORAGE_KEY);
-    if (!cachedRaw) {
-      return [];
-    }
-
-    const parsed = JSON.parse(cachedRaw);
-    const sanitized = Array.isArray(parsed)
-      ? parsed.map((item) => sanitizeRecentScan(item))
-      : [];
-    const trimmed = trimScansToStorageLimit(sanitized);
-    if (trimmed.length !== sanitized.length) {
-      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
-    }
-    return trimmed;
-  } catch (error: any) {
-    if (
-      typeof error?.message === 'string' &&
-      error.message.includes(ROW_TOO_BIG_MESSAGE)
-    ) {
-      console.warn(
-        'Cached recent scans exceeded storage limits, clearing corrupted entry'
-      );
-      await AsyncStorage.removeItem(STORAGE_KEY);
-      return [];
-    }
-
-    throw error;
-  }
-};
-
-/**
- * Fetches the most recent coffee scans with offline and caching support.
- *
- * Attempts to return cached results immediately, then refreshes from the API when
- * online and authenticated. Falls back to cached data on network errors.
+ * Fetches the most recent coffee scans with offline-aware behavior.
  *
  * @param {number} limit - Maximum number of scans to return to the caller.
  * @returns {Promise<RecentScan[]>} Promise resolving to recent scans limited by the requested size.
  */
 export const fetchRecentScans = async (limit: number): Promise<RecentScan[]> => {
   try {
-    let cached = await readCachedScans();
-
-    // Ak je zariadenie offline, vráť len cache
     const state = await NetInfo.fetch();
     if (!state.isConnected) {
-      return cached.slice(0, limit);
+      return [];
     }
 
     const user = auth().currentUser;
     const token = await user?.getIdToken();
     if (!token) {
-      return cached.slice(0, limit);
+      return [];
     }
 
     const res = await fetch(`${API_URL}/coffees/recent?limit=${limit}`, {
@@ -184,15 +103,13 @@ export const fetchRecentScans = async (limit: number): Promise<RecentScan[]> => 
       const normalized: RecentScan[] = Array.isArray(data)
         ? data.map((item) => sanitizeRecentScan(item)).slice(0, MAX_RECENT_SCANS)
         : [];
-      const trimmed = trimScansToStorageLimit(normalized);
-      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
-      cached = trimmed;
+      return normalized.slice(0, limit);
     }
 
-    return cached.slice(0, limit);
+    return [];
   } catch (err) {
     console.error('Failed to fetch recent scans', err);
-    return (await readCachedScans()).slice(0, limit);
+    return [];
   }
 };
 

--- a/src/services/homePagesService.ts
+++ b/src/services/homePagesService.ts
@@ -99,21 +99,6 @@ interface DashboardData {
   dailyTip: string;
 }
 
-const COFFEE_CACHE_KEY = 'coffees:favorites';
-const SCAN_HISTORY_CACHE_KEY = 'scans:history';
-const CACHE_TTL_HOURS = 24;
-
-/**
- * Converts cached coffee item timestamps back into Date instances.
- *
- * @param {CoffeeData} item - Coffee item potentially containing a serialized timestamp.
- * @returns {CoffeeData} Coffee item with `timestamp` coerced to `Date` when present.
- */
-const normalizeCachedTimestamp = (item: CoffeeData): CoffeeData => ({
-  ...item,
-  timestamp: item.timestamp ? new Date(item.timestamp) : undefined,
-});
-
 /**
  * Detects network-related errors to decide when to fall back to offline behavior.
  *
@@ -338,7 +323,7 @@ export const fetchCoffeeById = async (coffeeId: string): Promise<CoffeeData | nu
 };
 
 /**
- * Retrieves recent OCR scan history entries, prioritizing cached data when offline.
+ * Retrieves recent OCR scan history entries from the backend.
  *
  * @param {number} [limit=5] - Maximum number of history items to fetch from the API.
  * @returns {Promise<CoffeeData[]>} Array of scanned coffee records ordered by recency.
@@ -358,7 +343,7 @@ export const fetchScanHistory = async (limit: number = 5): Promise<CoffeeData[]>
 
     if (!response.ok) {
       console.warn('Scan history API returned error:', response.status);
-      return ([]).map(normalizeCachedTimestamp);
+      return [];
     }
 
     const data = await response.json();

--- a/src/services/offlineCache.ts
+++ b/src/services/offlineCache.ts
@@ -1,61 +1,19 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
-const LAST_KEY = 'ocr:last';
-
-const sanitizeRecommendationFields = (payload: any): any => {
-  if (!payload || typeof payload !== 'object') {
-    return payload;
-  }
-
-  if (Array.isArray(payload)) {
-    return payload.map((item) => sanitizeRecommendationFields(item));
-  }
-
-  const { matchPercentage, isRecommended, match_percentage, is_recommended, ...rest } = payload;
-  return rest;
-};
-
 /**
- * Persists an OCR parsing result in local encrypted storage and tracks the last
- * saved identifier for easy retrieval.
+ * Stubbed out OCR cache write to avoid persisting scan results locally.
  *
  * @param {string} id - Unique identifier of the OCR run, typically derived from
  * the source image or scan session.
  * @param {any} payload - Arbitrary OCR result payload to store; it is
  * serialized to JSON before persistence.
- * @returns {Promise<void>} Resolves after the payload and last key reference
- * are written; errors are logged but not rethrown.
+ * @returns {Promise<void>} Resolves immediately without performing any storage.
  */
-export const saveOCRResult = async (id: string, payload: any) => {
-  try {
-    const sanitizedPayload = sanitizeRecommendationFields(payload);
-    await AsyncStorage.setItem(`ocr:${id}`, JSON.stringify(sanitizedPayload));
-    await AsyncStorage.setItem(LAST_KEY, id);
-  } catch (error) {
-    console.error('Error saving OCR result:', error);
-  }
-};
+export const saveOCRResult = async (_id: string, _payload: any) => {};
 
 /**
- * Loads a previously saved OCR result, defaulting to the last stored entry
- * when no explicit identifier is provided.
+ * Stubbed out OCR cache read to avoid returning locally stored scan results.
  *
  * @param {string} [id] - Optional identifier of the OCR run to load; when
  * omitted the most recent saved ID is used.
- * @returns {Promise<any|null>} Parsed OCR payload or `null` if not found or a
- * read error occurs.
+ * @returns {Promise<any|null>} Always resolves to `null` because caching is disabled.
  */
-export const loadOCRResult = async (id?: string) => {
-  try {
-    let key = id;
-    if (!key) {
-      key = (await AsyncStorage.getItem(LAST_KEY)) || undefined;
-      if (!key) return null;
-    }
-    const data = await AsyncStorage.getItem(`ocr:${key}`);
-    return data ? sanitizeRecommendationFields(JSON.parse(data)) : null;
-  } catch (error) {
-    console.error('Error loading OCR result:', error);
-    return null;
-  }
-};
+export const loadOCRResult = async (_id?: string) => null;


### PR DESCRIPTION
### Motivation
- Prevent persisting OCR and recent scan results locally to avoid storing potentially sensitive data and to eliminate storage/cursor errors.
- Simplify recent-scan behavior to rely on the backend when online and remove fragile LocalStorage trimming/serialization logic.
- Remove unused scan-cache helpers and related timestamp normalization to reduce maintenance surface.

### Description
- Stubbed out OCR cache functions in `src/services/offlineCache.ts` so `saveOCRResult` is a no-op and `loadOCRResult` always resolves to `null`.
- Removed `AsyncStorage` usage and storage trimming helpers from `src/services/coffeeServices.ts`, made `addRecentScan` a no-op, and updated `fetchRecentScans` to return API results only (or `[]`) and no longer read/write local cache.
- Deleted cache keys and the `normalizeCachedTimestamp` helper from `src/services/homePagesService.ts`, and changed `fetchScanHistory` to return backend results or an empty array on error instead of attempting to use local cache.
- Preserved public function signatures so existing imports remain valid while disabling local caching behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b848c64bc832aa21baece696b3f66)