### PR TITLE
Import evaluation helpers in OCR route

### DIFF
--- a/server/routes/ocr.js
+++ b/server/routes/ocr.js
@@ -13,6 +13,7 @@ import {
 } from './ocr/coffee-attributes.js';
 import { extractStructuredMetadataFromText } from './ocr/structured-metadata.js';
 import { formatTasteProfileSummary } from './ocr/taste-profile.js';
+import { isValidEvaluationResponse, resolveCorrectedText } from './ocr/evaluation.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
### Motivation
- The OCR route exported `isValidEvaluationResponse` and `resolveCorrectedText` but did not define them in the module, which can cause Node ESM to fail at startup, so the evaluation helper symbols need to be imported from the evaluation module.

### Description
- Add an import for `isValidEvaluationResponse` and `resolveCorrectedText` from `./ocr/evaluation.js` at the top of `server/routes/ocr.js` to ensure the exported symbols are defined.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b86477dc4832aad402fa5b81bf980)